### PR TITLE
feat(cli): add slash commands and shared workspace input history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "syntect",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ regex = "1"
 schemars = { version = "1.0", features = ["derive"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+sha2 = "0.10"
 syntect = "5"
 thiserror = "2.0"
 tokio = { version = "1", features = ["rt", "sync", "macros", "io-util", "fs", "process", "time"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,9 @@ cargo test --all
 - Structured final-output tools and typed completed, blocked, failed, and
   cancelled outcomes.
 - Ordered non-empty tool-call batches admitted atomically.
+- Idle-boundary interactive session save through `AgentLoopControl::save_session_to`
+  with `SessionSaveRequiresIdle` rejection while a model, tool, or interrupt phase
+  is active.
 - Explicit `ParallelSafe` and `Exclusive` tool execution contracts.
 - Bounded parallel-safe waves, exclusive barriers, ordered continuation
   results, bridge-call matching, and cancellation handling.
@@ -105,7 +108,9 @@ cargo test --all
   an explicit `--no-sandbox` host-mode choice that keeps tool commands on the
   inner bubblewrap process runner.
 - One chronological TUI timeline, real streaming deltas, compact tool rows,
-  on-demand detail, responsive layouts, queues, completion, and resume picker.
+  on-demand detail, responsive layouts, queues, completion, resume picker,
+  slash commands (`/help`, `/status`, `/save`, `/stop`) shared with the command
+  palette, and workspace-scoped persisted text input history.
 - A responsive Plan cockpit with recursive navigation, node inspection,
   approval preview, steering and scheduler controls, and preserved selection
   across live updates at 50x20, 80x24, and 140x40.
@@ -122,13 +127,20 @@ cargo test --all
 Make the TUI comfortable for repeated coding sessions rather than merely
 feature-complete:
 
-- Add shared text-only input history across sessions, including resumed and
-  newly created sessions. Do not persist image attachments in this history.
-- Add slash commands with one command registry shared by slash completion and
-  the existing command palette.
-- Make common tools render meaningful summaries: operation, target, status,
+- ~~Add shared text-only input history across sessions, including resumed and
+  newly created sessions. Do not persist image attachments in this history.~~
+  Delivered: workspace-scoped JSONL history with SHA256-hashed filenames,
+  atomic temp+rename writes, in-memory normalization, and cross-session reuse.
+- ~~Add slash commands with one command registry shared by slash completion and
+  the existing command palette.~~ Delivered: unified `CommandSpec` registry
+  drives both the command palette and `/`-triggered completion; `/help`,
+  `/status`, `/save`, `/stop` execute locally without sending model messages.
+- ~~Make common tools render meaningful summaries: operation, target, status,
   result, and failure reason. Generic fallback rendering must not reduce useful
-  information to output such as `args=3`.
+  information to output such as `args=3`.~~ Delivered: failed tool rows replace
+  their pending timeline row with a `-> failed` status and bounded diagnostic
+  body; process, patch, read, list, and permission tools render dedicated
+  previews.
 - Keep plan, permission, save, interrupt, resume, retry, and discard states
   visible and actionable from the same control surface.
 
@@ -244,8 +256,9 @@ named coding workflow or acceptance test.
   outside the default deterministic suite.
 - TUI session persistence is still primarily exit-time full snapshot saving;
   incremental SQLite durability is not implemented.
-- TUI has no slash-command control plane, shared cross-session text input
-  history, or consistently useful generic tool rendering yet.
+- TUI slash-command control plane, shared cross-session text input history,
+  and consistently useful generic tool rendering have been delivered; the
+  remaining TUI Daily Coding Flow work is unified state visibility.
 - Coding-tool descriptions and initial runtime context still need a deliberate
   harness-driven audit.
 - Python sessions are ephemeral by default and Python event surfaces still need

--- a/crates/merry-cli/Cargo.toml
+++ b/crates/merry-cli/Cargo.toml
@@ -20,6 +20,7 @@ ratatui.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 syntect.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-std", "io-util", "process"] }

--- a/crates/merry-cli/src/tui/command.rs
+++ b/crates/merry-cli/src/tui/command.rs
@@ -1,0 +1,317 @@
+use super::keymap::{KeyAction, Keymap};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PaletteCommand {
+    OpenSettings,
+    OpenProviders,
+    ShowShortcuts,
+    ShowHelp,
+    ShowStatus,
+    FollowLatest,
+    ReviewPreviousArtifact,
+    ReviewNextArtifact,
+    ReviewPreviousUserInput,
+    Interrupt,
+    ResumeSuspended,
+    DiscardSuspended,
+    SaveSession,
+    Quit,
+    EnterPlanMode,
+    ApprovePlan,
+    RevisePlan,
+    OpenPlan,
+    FocusPlan,
+    ClosePlan,
+    RetryPlanNode,
+    CancelPlan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CommandSpec {
+    pub(crate) command: PaletteCommand,
+    pub(crate) category: &'static str,
+    pub(crate) label: &'static str,
+    pub(crate) key_action: Option<KeyAction>,
+    slash_name: Option<&'static str>,
+    slash_description: Option<&'static str>,
+}
+
+impl CommandSpec {
+    const fn new(
+        command: PaletteCommand,
+        category: &'static str,
+        label: &'static str,
+        key_action: Option<KeyAction>,
+    ) -> Self {
+        Self {
+            command,
+            category,
+            label,
+            key_action,
+            slash_name: None,
+            slash_description: None,
+        }
+    }
+
+    const fn with_slash(mut self, name: &'static str, description: &'static str) -> Self {
+        self.slash_name = Some(name);
+        self.slash_description = Some(description);
+        self
+    }
+
+    pub(crate) const fn slash_name(&self) -> Option<&'static str> {
+        self.slash_name
+    }
+
+    pub(crate) const fn slash_description(&self) -> Option<&'static str> {
+        self.slash_description
+    }
+}
+
+const COMMANDS: [CommandSpec; 22] = [
+    CommandSpec::new(PaletteCommand::OpenSettings, "Merry", "Settings", None),
+    CommandSpec::new(
+        PaletteCommand::OpenProviders,
+        "Merry",
+        "Providers & models",
+        None,
+    ),
+    CommandSpec::new(
+        PaletteCommand::ShowShortcuts,
+        "Merry",
+        "Keyboard shortcuts",
+        None,
+    ),
+    CommandSpec::new(PaletteCommand::ShowHelp, "Merry", "Command help", None)
+        .with_slash("help", "List slash commands and essential keys"),
+    CommandSpec::new(
+        PaletteCommand::FollowLatest,
+        "Navigation",
+        "Follow latest",
+        Some(KeyAction::FollowLatestArtifact),
+    ),
+    CommandSpec::new(
+        PaletteCommand::ReviewPreviousArtifact,
+        "Navigation",
+        "Previous artifact",
+        Some(KeyAction::ReviewPreviousArtifact),
+    ),
+    CommandSpec::new(
+        PaletteCommand::ReviewNextArtifact,
+        "Navigation",
+        "Next artifact",
+        Some(KeyAction::ReviewNextArtifact),
+    ),
+    CommandSpec::new(
+        PaletteCommand::ReviewPreviousUserInput,
+        "Navigation",
+        "Previous user input",
+        Some(KeyAction::ReviewPreviousUserInput),
+    ),
+    CommandSpec::new(
+        PaletteCommand::Interrupt,
+        "Runtime",
+        "Interrupt current run",
+        Some(KeyAction::Interrupt),
+    )
+    .with_slash("stop", "Interrupt the active model or tool run"),
+    CommandSpec::new(
+        PaletteCommand::ResumeSuspended,
+        "Runtime",
+        "Resume suspended input",
+        Some(KeyAction::ResumeSuspended),
+    ),
+    CommandSpec::new(
+        PaletteCommand::DiscardSuspended,
+        "Runtime",
+        "Discard suspended input",
+        Some(KeyAction::DiscardSuspended),
+    ),
+    CommandSpec::new(
+        PaletteCommand::ShowStatus,
+        "Session",
+        "Show session status",
+        None,
+    )
+    .with_slash(
+        "status",
+        "Show run, model, usage, plan, and workspace state",
+    ),
+    CommandSpec::new(PaletteCommand::SaveSession, "Session", "Save session", None)
+        .with_slash("save", "Save the session at a stable boundary"),
+    CommandSpec::new(
+        PaletteCommand::Quit,
+        "Session",
+        "Quit Merry",
+        Some(KeyAction::Quit),
+    ),
+    CommandSpec::new(
+        PaletteCommand::EnterPlanMode,
+        "Plan",
+        "Enter Plan Mode",
+        None,
+    ),
+    CommandSpec::new(
+        PaletteCommand::ApprovePlan,
+        "Plan",
+        "Approve plan and execute",
+        None,
+    ),
+    CommandSpec::new(PaletteCommand::RevisePlan, "Plan", "Revise plan", None),
+    CommandSpec::new(PaletteCommand::OpenPlan, "Plan", "Open plan", None),
+    CommandSpec::new(PaletteCommand::FocusPlan, "Plan", "Focus plan tree", None),
+    CommandSpec::new(PaletteCommand::ClosePlan, "Plan", "Close plan", None),
+    CommandSpec::new(
+        PaletteCommand::RetryPlanNode,
+        "Plan",
+        "Retry selected interrupted node",
+        None,
+    ),
+    CommandSpec::new(PaletteCommand::CancelPlan, "Plan", "Cancel plan", None),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlashCommandMatch<'a> {
+    NotCommand,
+    Known(&'static CommandSpec),
+    Unknown(&'a str),
+    ArgumentsNotSupported(&'a str),
+}
+
+pub(crate) fn all_commands() -> &'static [CommandSpec] {
+    &COMMANDS
+}
+
+pub(crate) fn slash_commands() -> Vec<&'static CommandSpec> {
+    find_slash_prefix("")
+}
+
+pub(crate) fn find_slash_exact(name: &str) -> Option<&'static CommandSpec> {
+    COMMANDS
+        .iter()
+        .find(|command| command.slash_name() == Some(name))
+}
+
+pub(crate) fn find_slash_prefix(query: &str) -> Vec<&'static CommandSpec> {
+    let mut commands = COMMANDS
+        .iter()
+        .filter(|command| {
+            command
+                .slash_name()
+                .is_some_and(|name| name.starts_with(query))
+        })
+        .collect::<Vec<_>>();
+    commands.sort_by_key(|command| command.slash_name());
+    commands
+}
+
+pub(crate) fn match_slash_input(input: &str) -> SlashCommandMatch<'_> {
+    if input.contains(['\n', '\r']) {
+        return SlashCommandMatch::NotCommand;
+    }
+    let Some(rest) = input.trim_end().strip_prefix('/') else {
+        return SlashCommandMatch::NotCommand;
+    };
+    let name_end = rest.find(char::is_whitespace).unwrap_or(rest.len());
+    let name = &rest[..name_end];
+    if !name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return SlashCommandMatch::NotCommand;
+    }
+    let arguments = rest[name_end..].trim();
+    match (find_slash_exact(name), arguments.is_empty()) {
+        (Some(command), true) => SlashCommandMatch::Known(command),
+        (Some(_), false) => SlashCommandMatch::ArgumentsNotSupported(name),
+        (None, _) => SlashCommandMatch::Unknown(name),
+    }
+}
+
+pub(crate) fn slash_help_body(keymap: &Keymap) -> String {
+    let mut lines = slash_commands()
+        .into_iter()
+        .filter_map(|command| {
+            Some(format!(
+                "/{:<8} {}",
+                command.slash_name()?,
+                command.slash_description()?
+            ))
+        })
+        .collect::<Vec<_>>();
+    lines.push(String::new());
+    lines.push(format!(
+        "Submit {}  Backlog {}  Commands {}  Stop {}",
+        binding_label(keymap, KeyAction::SubmitNext),
+        binding_label(keymap, KeyAction::SubmitBacklog),
+        binding_label(keymap, KeyAction::OpenCommandPanel),
+        binding_label(keymap, KeyAction::Interrupt),
+    ));
+    lines.join("\n")
+}
+
+fn binding_label(keymap: &Keymap, action: KeyAction) -> String {
+    keymap
+        .binding_label_for(action)
+        .unwrap_or_else(|| "Unbound".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn slash_registry_is_unique_and_queryable() {
+        let commands = slash_commands();
+        assert!(!commands.is_empty());
+        let names = commands
+            .iter()
+            .map(|command| command.slash_name().expect("slash name"))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names.len(), commands.len());
+        assert!(names.iter().all(|name| !name.starts_with('/')));
+        assert_eq!(
+            find_slash_exact("save").map(|command| command.command),
+            Some(PaletteCommand::SaveSession)
+        );
+        assert_eq!(
+            find_slash_prefix("sa")
+                .into_iter()
+                .filter_map(CommandSpec::slash_name)
+                .collect::<Vec<_>>(),
+            vec!["save"]
+        );
+        assert_eq!(find_slash_prefix("").len(), 4);
+        assert!(find_slash_exact("unknown").is_none());
+    }
+
+    #[test]
+    fn slash_parser_is_strict_without_consuming_normal_paths_or_multiline_text() {
+        assert!(matches!(
+            match_slash_input("/save   "),
+            SlashCommandMatch::Known(command) if command.command == PaletteCommand::SaveSession
+        ));
+        assert_eq!(
+            match_slash_input("/unknown"),
+            SlashCommandMatch::Unknown("unknown")
+        );
+        assert_eq!(
+            match_slash_input("/save now"),
+            SlashCommandMatch::ArgumentsNotSupported("save")
+        );
+        assert_eq!(
+            match_slash_input("/unknown now"),
+            SlashCommandMatch::Unknown("unknown")
+        );
+        assert_eq!(
+            match_slash_input("/tmp/file"),
+            SlashCommandMatch::NotCommand
+        );
+        assert_eq!(match_slash_input("/tmp"), SlashCommandMatch::Unknown("tmp"));
+        assert_eq!(
+            match_slash_input("/save\nexplain why"),
+            SlashCommandMatch::NotCommand
+        );
+    }
+}

--- a/crates/merry-cli/src/tui/command_controller.rs
+++ b/crates/merry-cli/src/tui/command_controller.rs
@@ -1,0 +1,156 @@
+use super::{
+    command::{self, PaletteCommand, SlashCommandMatch},
+    controller::{ControllerEffect, handle_key_action},
+    keymap::KeyAction,
+    state::{TimelineItem, TuiState},
+};
+
+pub(crate) fn slash_input_effect(state: &mut TuiState) -> Option<ControllerEffect> {
+    let matched = state
+        .plain_input_text()
+        .map(command::match_slash_input)
+        .unwrap_or(SlashCommandMatch::NotCommand);
+    match matched {
+        SlashCommandMatch::NotCommand => None,
+        SlashCommandMatch::Known(command) => {
+            state.clear_input();
+            Some(run_palette_command(command.command, state))
+        }
+        SlashCommandMatch::Unknown(name) => {
+            let detail = if name.is_empty() {
+                "Type /help to list commands, or prefix the text with a space to send it."
+                    .to_owned()
+            } else {
+                format!(
+                    "/{name} is not available. Type /help, or prefix the text with a space to send it."
+                )
+            };
+            state.close_completion_menu();
+            state.push_timeline_item(TimelineItem::Muted {
+                title: "Unknown command".to_owned(),
+                detail,
+            });
+            Some(ControllerEffect::None)
+        }
+        SlashCommandMatch::ArgumentsNotSupported(name) => {
+            let detail = format!("/{name} does not accept arguments.");
+            state.close_completion_menu();
+            state.push_timeline_item(TimelineItem::Muted {
+                title: "Command not run".to_owned(),
+                detail,
+            });
+            Some(ControllerEffect::None)
+        }
+    }
+}
+
+pub(crate) fn run_palette_command(
+    command: PaletteCommand,
+    state: &mut TuiState,
+) -> ControllerEffect {
+    if let Some(effect) = super::plan_controller::palette_effect(command, state) {
+        return effect;
+    }
+    match command {
+        PaletteCommand::OpenSettings => {
+            state.close_overlay();
+            state.open_settings();
+            ControllerEffect::None
+        }
+        PaletteCommand::OpenProviders => ControllerEffect::OpenProviderManager,
+        PaletteCommand::ShowShortcuts => {
+            state.open_shortcuts();
+            ControllerEffect::None
+        }
+        PaletteCommand::ShowHelp => {
+            let body = command::slash_help_body(state.keymap());
+            state.close_overlay();
+            state.push_timeline_item(TimelineItem::Expanded {
+                title: "Command help".to_owned(),
+                body,
+            });
+            ControllerEffect::None
+        }
+        PaletteCommand::ShowStatus => {
+            let body = state.command_status_body();
+            state.close_overlay();
+            state.push_timeline_item(TimelineItem::Expanded {
+                title: "Session status".to_owned(),
+                body,
+            });
+            ControllerEffect::None
+        }
+        PaletteCommand::FollowLatest => {
+            state.close_overlay();
+            handle_key_action(KeyAction::FollowLatestArtifact, state)
+        }
+        PaletteCommand::ReviewPreviousArtifact => {
+            state.close_overlay();
+            handle_key_action(KeyAction::ReviewPreviousArtifact, state)
+        }
+        PaletteCommand::ReviewNextArtifact => {
+            state.close_overlay();
+            handle_key_action(KeyAction::ReviewNextArtifact, state)
+        }
+        PaletteCommand::ReviewPreviousUserInput => {
+            state.close_overlay();
+            handle_key_action(KeyAction::ReviewPreviousUserInput, state)
+        }
+        PaletteCommand::Interrupt => {
+            state.close_overlay();
+            if state.can_interrupt_run() {
+                state.set_run_state(merry_core::InteractiveRunState::Interrupting);
+                state.push_timeline_item(TimelineItem::Muted {
+                    title: "Stopping".to_owned(),
+                    detail: "Interrupt requested for the active run.".to_owned(),
+                });
+                ControllerEffect::Interrupt
+            } else if state.is_interrupting() {
+                state.push_timeline_item(TimelineItem::Muted {
+                    title: "Stop already requested".to_owned(),
+                    detail: "Waiting for the active run to reach a cancellation boundary."
+                        .to_owned(),
+                });
+                ControllerEffect::None
+            } else {
+                state.push_timeline_item(TimelineItem::Muted {
+                    title: "Nothing to stop".to_owned(),
+                    detail: "No model or tool run is active.".to_owned(),
+                });
+                ControllerEffect::None
+            }
+        }
+        PaletteCommand::ResumeSuspended => {
+            state.close_overlay();
+            handle_key_action(KeyAction::ResumeSuspended, state)
+        }
+        PaletteCommand::DiscardSuspended => {
+            state.close_overlay();
+            handle_key_action(KeyAction::DiscardSuspended, state)
+        }
+        PaletteCommand::SaveSession => {
+            state.close_overlay();
+            if state.is_active_run() {
+                state.push_timeline_item(TimelineItem::Muted {
+                    title: "Save unavailable".to_owned(),
+                    detail: "Stop the active run before saving the session.".to_owned(),
+                });
+                ControllerEffect::None
+            } else {
+                ControllerEffect::SaveSession
+            }
+        }
+        PaletteCommand::EnterPlanMode
+        | PaletteCommand::ApprovePlan
+        | PaletteCommand::RevisePlan
+        | PaletteCommand::OpenPlan
+        | PaletteCommand::FocusPlan
+        | PaletteCommand::ClosePlan
+        | PaletteCommand::RetryPlanNode
+        | PaletteCommand::CancelPlan => unreachable!("plan command handled above"),
+        PaletteCommand::Quit => {
+            state.close_overlay();
+            ControllerEffect::Quit
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/completion.rs
+++ b/crates/merry-cli/src/tui/completion.rs
@@ -1,3 +1,4 @@
+use super::command;
 use merry_runtime::SkillMetadata;
 use std::{
     fs,
@@ -12,6 +13,7 @@ const MAX_WORKSPACE_SCAN_ENTRIES: usize = 2_000;
 pub(crate) enum CompletionKind {
     Path,
     Skill,
+    Slash,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,6 +38,14 @@ impl CompletionItem {
             value,
             detail: Some(detail),
             kind: CompletionKind::Skill,
+        }
+    }
+
+    fn slash(value: String, detail: String) -> Self {
+        Self {
+            value,
+            detail: Some(detail),
+            kind: CompletionKind::Slash,
         }
     }
 
@@ -100,7 +110,12 @@ impl CompletionMenu {
         Some(match item.kind() {
             CompletionKind::Path => format!("@{} ", item.value()),
             CompletionKind::Skill => format!("${} ", item.value()),
+            CompletionKind::Slash => item.value().to_owned(),
         })
+    }
+
+    pub(crate) fn is_slash(&self) -> bool {
+        self.trigger == '/'
     }
 
     fn matches(&self, token_start: usize, token_end: usize, query: &str) -> bool {
@@ -164,19 +179,29 @@ impl CompletionSources {
         let items = match token.trigger {
             '@' => self.path_items(token.query),
             '$' => self.skill_items(token.query),
+            '/' => self.slash_items(token.query),
             _ => Vec::new(),
         };
         if items.is_empty() {
             return None;
         }
 
+        let selected = if token.trigger == '/' {
+            let full_token = &text[token.start..token.end];
+            items
+                .iter()
+                .position(|item| item.value() == full_token)
+                .unwrap_or(0)
+        } else {
+            0
+        };
         Some(CompletionMenu {
             trigger: token.trigger,
             token_start: token.start,
             token_end: token.end,
             query: token.query.to_owned(),
             items,
-            selected: 0,
+            selected,
         })
     }
 
@@ -200,6 +225,18 @@ impl CompletionSources {
             .filter(|skill| skill.name.starts_with(query))
             .take(MAX_COMPLETION_ITEMS)
             .map(|skill| CompletionItem::skill(skill.name.clone(), skill.description.clone()))
+            .collect()
+    }
+
+    fn slash_items(&self, query: &str) -> Vec<CompletionItem> {
+        command::find_slash_prefix(query)
+            .into_iter()
+            .filter_map(|command| {
+                Some(CompletionItem::slash(
+                    format!("/{}", command.slash_name()?),
+                    command.slash_description()?.to_owned(),
+                ))
+            })
             .collect()
     }
 }
@@ -231,15 +268,26 @@ fn active_completion_token(text: &str, cursor: usize) -> Option<CompletionToken<
         start = index;
     }
 
-    let token = &text[start..cursor];
+    let end = text[cursor..]
+        .find(char::is_whitespace)
+        .map(|offset| cursor + offset)
+        .unwrap_or(text.len());
+    let token = &text[start..end];
     let mut chars = token.char_indices();
     let (_, trigger) = chars.next()?;
-    if !matches!(trigger, '@' | '$') {
+    if !matches!(trigger, '@' | '$' | '/') {
+        return None;
+    }
+    let query_start = start + trigger.len_utf8();
+    if cursor < query_start {
+        return None;
+    }
+    if trigger == '/' && (start != 0 || text.contains(['\n', '\r'])) {
         return None;
     }
     if token[trigger.len_utf8()..]
         .chars()
-        .any(|value| matches!(value, '@' | '$'))
+        .any(|value| matches!(value, '@' | '$' | '/'))
     {
         return None;
     }
@@ -247,8 +295,8 @@ fn active_completion_token(text: &str, cursor: usize) -> Option<CompletionToken<
     Some(CompletionToken {
         trigger,
         start,
-        end: cursor,
-        query: &token[trigger.len_utf8()..],
+        end,
+        query: &text[query_start..cursor],
     })
 }
 

--- a/crates/merry-cli/src/tui/controller.rs
+++ b/crates/merry-cli/src/tui/controller.rs
@@ -1,8 +1,9 @@
 use super::{
     input::{DraftImage, TuiSubmission},
+    input_history_store::InputHistoryStore,
     keymap::KeyAction,
     layout::{BottomPaneHeights, cockpit_layout},
-    overlay::{OverlayKeyResult, PaletteCommand},
+    overlay::OverlayKeyResult,
     preferences::{TuiPreferences, TuiPreferencesStore, TuiSettingsDefaults},
     projector::TuiProjector,
     provider_overlay::{
@@ -11,7 +12,7 @@ use super::{
     },
     render,
     runtime::TuiRuntimeSession,
-    state::TuiState,
+    state::{TimelineItem, TuiState},
     terminal::{TerminalEvent, TerminalSession},
 };
 use crate::{
@@ -23,7 +24,7 @@ use crate::{
 };
 use crossterm::event::{KeyCode, KeyEvent};
 use futures_util::StreamExt;
-use merry_core::QueuedInputLane;
+use merry_core::{InteractiveRunState, QueuedInputLane};
 use merry_runtime::InterruptReason;
 use ratatui::layout::{Position, Rect, Size};
 use std::{collections::BTreeSet, time::Duration};
@@ -49,6 +50,11 @@ struct ProviderController<'a> {
     discovery_tx: &'a mpsc::Sender<ModelDiscoveryCompletion>,
     discovery_generation: &'a mut u64,
     discovery_token: &'a mut Option<CancellationToken>,
+}
+
+struct InputHistoryController<'a> {
+    store: &'a InputHistoryStore,
+    warning_shown: &'a mut bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,6 +97,7 @@ pub(crate) enum ControllerEffect {
     RevisePlan,
     RetryPlanNode(merry_core::PlanNodeId),
     CancelPlan,
+    SaveSession,
     Quit,
 }
 
@@ -100,17 +107,13 @@ pub(crate) fn handle_key_action(action: KeyAction, state: &mut TuiState) -> Cont
             if exit_review_if_active(state) {
                 return ControllerEffect::None;
             }
-            state
-                .take_input_for_submit()
-                .map_or(ControllerEffect::None, ControllerEffect::SubmitNext)
+            submit_input(state, ControllerEffect::SubmitNext)
         }
         KeyAction::SubmitBacklog => {
             if exit_review_if_active(state) {
                 return ControllerEffect::None;
             }
-            state
-                .take_input_for_submit()
-                .map_or(ControllerEffect::None, ControllerEffect::SubmitBacklog)
+            submit_input(state, ControllerEffect::SubmitBacklog)
         }
         KeyAction::CancelInputOrQuit => {
             if state.cancel_input_or_mark_quit() {
@@ -184,6 +187,18 @@ pub(crate) fn handle_key_action(action: KeyAction, state: &mut TuiState) -> Cont
     }
 }
 
+fn submit_input(
+    state: &mut TuiState,
+    submit: impl FnOnce(TuiSubmission) -> ControllerEffect,
+) -> ControllerEffect {
+    if let Some(effect) = super::command_controller::slash_input_effect(state) {
+        return effect;
+    }
+    state
+        .take_input_for_submit()
+        .map_or(ControllerEffect::None, submit)
+}
+
 fn exit_review_if_active(state: &mut TuiState) -> bool {
     let was_reviewing = state.is_timeline_reviewing() || state.is_artifact_reviewing();
     if state.is_timeline_reviewing() {
@@ -211,7 +226,9 @@ pub(crate) fn handle_key_event(key: KeyEvent, state: &mut TuiState) -> Controlle
                 state.back_overlay();
                 ControllerEffect::None
             }
-            OverlayKeyResult::Run(command) => run_palette_command(command, state),
+            OverlayKeyResult::Run(command) => {
+                super::command_controller::run_palette_command(command, state)
+            }
             OverlayKeyResult::AdjustSetting(item, direction) => {
                 if state.adjust_setting(item, direction) {
                     preferences_effect(item, state.preferences().clone())
@@ -273,7 +290,17 @@ pub(crate) fn handle_key_event(key: KeyEvent, state: &mut TuiState) -> Controlle
     }
 
     if state.completion_menu().is_some() {
+        let slash_completion = state
+            .completion_menu()
+            .is_some_and(super::completion::CompletionMenu::is_slash);
         match key.code {
+            KeyCode::Enter if slash_completion => {
+                state.accept_completion();
+                if input_is_known_slash(state) {
+                    return handle_key_action(KeyAction::SubmitNext, state);
+                }
+                return ControllerEffect::None;
+            }
             KeyCode::Enter | KeyCode::Tab => {
                 state.accept_completion();
                 return ControllerEffect::None;
@@ -371,67 +398,18 @@ fn preferences_effect(
     }
 }
 
+fn input_is_known_slash(state: &TuiState) -> bool {
+    state.plain_input_text().is_some_and(|text| {
+        matches!(
+            super::command::match_slash_input(text),
+            super::command::SlashCommandMatch::Known(_)
+        )
+    })
+}
+
 pub(crate) fn handle_paste_event(text: &str, state: &mut TuiState) {
     if !state.insert_overlay_paste(text) {
         state.insert_input_paste(text);
-    }
-}
-
-fn run_palette_command(command: PaletteCommand, state: &mut TuiState) -> ControllerEffect {
-    if let Some(effect) = super::plan_controller::palette_effect(command, state) {
-        return effect;
-    }
-    match command {
-        PaletteCommand::OpenSettings => {
-            state.close_overlay();
-            state.open_settings();
-            ControllerEffect::None
-        }
-        PaletteCommand::OpenProviders => ControllerEffect::OpenProviderManager,
-        PaletteCommand::ShowShortcuts => {
-            state.open_shortcuts();
-            ControllerEffect::None
-        }
-        PaletteCommand::FollowLatest => {
-            state.close_overlay();
-            handle_key_action(KeyAction::FollowLatestArtifact, state)
-        }
-        PaletteCommand::ReviewPreviousArtifact => {
-            state.close_overlay();
-            handle_key_action(KeyAction::ReviewPreviousArtifact, state)
-        }
-        PaletteCommand::ReviewNextArtifact => {
-            state.close_overlay();
-            handle_key_action(KeyAction::ReviewNextArtifact, state)
-        }
-        PaletteCommand::ReviewPreviousUserInput => {
-            state.close_overlay();
-            handle_key_action(KeyAction::ReviewPreviousUserInput, state)
-        }
-        PaletteCommand::Interrupt => {
-            state.close_overlay();
-            handle_key_action(KeyAction::Interrupt, state)
-        }
-        PaletteCommand::ResumeSuspended => {
-            state.close_overlay();
-            handle_key_action(KeyAction::ResumeSuspended, state)
-        }
-        PaletteCommand::DiscardSuspended => {
-            state.close_overlay();
-            handle_key_action(KeyAction::DiscardSuspended, state)
-        }
-        PaletteCommand::EnterPlanMode
-        | PaletteCommand::ApprovePlan
-        | PaletteCommand::RevisePlan
-        | PaletteCommand::OpenPlan
-        | PaletteCommand::FocusPlan
-        | PaletteCommand::ClosePlan
-        | PaletteCommand::RetryPlanNode
-        | PaletteCommand::CancelPlan => unreachable!("plan command handled above"),
-        PaletteCommand::Quit => {
-            state.close_overlay();
-            ControllerEffect::Quit
-        }
     }
 }
 
@@ -511,6 +489,7 @@ pub(crate) async fn run_controller(
     mut session: TuiRuntimeSession,
     mut state: TuiState,
     preferences_store: TuiPreferencesStore,
+    input_history_store: InputHistoryStore,
     mut provider_management: ProviderManagementService,
 ) -> Result<(), CliError> {
     let mut projector = TuiProjector::default();
@@ -519,6 +498,7 @@ pub(crate) async fn run_controller(
     let mut model_discovery_generation = 0_u64;
     let mut model_discovery_token: Option<CancellationToken> = None;
     let mut subagent_activity_open = true;
+    let mut input_history_warning_shown = false;
     state
         .plan_mut()
         .update_subagent_activity(session.subagent_activity.borrow().clone());
@@ -551,11 +531,16 @@ pub(crate) async fn run_controller(
                             discovery_generation: &mut model_discovery_generation,
                             discovery_token: &mut model_discovery_token,
                         };
+                        let mut input_history = InputHistoryController {
+                            store: &input_history_store,
+                            warning_shown: &mut input_history_warning_shown,
+                        };
                         let should_quit = dispatch_effect(
                             effect,
                             &mut session,
                             &mut state,
                             &preferences_store,
+                            &mut input_history,
                             &mut providers,
                             &clipboard_image_tx,
                         )
@@ -640,6 +625,7 @@ async fn dispatch_effect(
     session: &mut TuiRuntimeSession,
     state: &mut TuiState,
     preferences_store: &TuiPreferencesStore,
+    input_history: &mut InputHistoryController<'_>,
     providers: &mut ProviderController<'_>,
     clipboard_image_tx: &mpsc::Sender<ClipboardImageCompletion>,
 ) -> Result<bool, CliError> {
@@ -651,21 +637,39 @@ async fn dispatch_effect(
     match effect {
         ControllerEffect::None => Ok(false),
         ControllerEffect::SubmitNext(submission) => {
-            let message = submission.into_user_message().map_err(unexpected)?;
+            let (message, history_text) = submission
+                .into_user_message_and_history()
+                .map_err(unexpected)?;
             session
                 .input
                 .submit_next_message(message)
                 .await
                 .map_err(unexpected)?;
+            persist_submitted_input_history(
+                input_history.store,
+                state,
+                &history_text,
+                input_history.warning_shown,
+            )
+            .await;
             Ok(false)
         }
         ControllerEffect::SubmitBacklog(submission) => {
-            let message = submission.into_user_message().map_err(unexpected)?;
+            let (message, history_text) = submission
+                .into_user_message_and_history()
+                .map_err(unexpected)?;
             session
                 .input
                 .enqueue_message(message)
                 .await
                 .map_err(unexpected)?;
+            persist_submitted_input_history(
+                input_history.store,
+                state,
+                &history_text,
+                input_history.warning_shown,
+            )
+            .await;
             Ok(false)
         }
         ControllerEffect::PasteImage => {
@@ -685,11 +689,12 @@ async fn dispatch_effect(
             Ok(false)
         }
         ControllerEffect::Interrupt => {
-            session
-                .control
-                .interrupt(InterruptReason::User)
-                .await
-                .map_err(unexpected)?;
+            let control = session.control.clone();
+            let _interrupt_task = tokio::spawn(async move {
+                if let Err(error) = control.interrupt(InterruptReason::User).await {
+                    tracing::warn!(error = %error, "interactive interrupt request failed");
+                }
+            });
             Ok(false)
         }
         ControllerEffect::ResumeSuspended => {
@@ -706,6 +711,24 @@ async fn dispatch_effect(
                 .discard_suspended()
                 .await
                 .map_err(unexpected)?;
+            Ok(false)
+        }
+        ControllerEffect::SaveSession => {
+            session.set_title(state.latest_user_input_title());
+            match session.save_now().await {
+                Ok(()) => state.push_timeline_item(TimelineItem::Muted {
+                    title: "Session saved".to_owned(),
+                    detail: session.metadata.session_id.as_str().to_owned(),
+                }),
+                Err(error) => {
+                    tracing::warn!(error = ?error, "explicit TUI session save failed");
+                    state.push_timeline_item(TimelineItem::Diagnostic {
+                        title: "Session save failed".to_owned(),
+                        body: "Session state could not be written. The TUI is still open; check the logs and retry at an idle boundary."
+                            .to_owned(),
+                    });
+                }
+            }
             Ok(false)
         }
         ControllerEffect::PersistPreferences(preferences) => {
@@ -1084,6 +1107,32 @@ async fn dispatch_effect(
     }
 }
 
+pub(super) async fn persist_submitted_input_history(
+    store: &InputHistoryStore,
+    state: &mut TuiState,
+    text: &str,
+    warning_shown: &mut bool,
+) {
+    if text.trim().is_empty() {
+        return;
+    }
+    state.record_input_history(text);
+    match store.record(text).await {
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(error = %error, "could not persist accepted TUI input history");
+            if !*warning_shown {
+                state.push_timeline_item(TimelineItem::Diagnostic {
+                    title: "Input history not saved".to_owned(),
+                    body: "The message was accepted, but shared input history could not be written. In-memory history remains available for this session."
+                        .to_owned(),
+                });
+                *warning_shown = true;
+            }
+        }
+    }
+}
+
 fn provider_list_items(
     provider_management: &ProviderManagementService,
     state: &TuiState,
@@ -1233,14 +1282,17 @@ fn model_list_items(catalog: merry_llm::ModelCatalog) -> Vec<ModelListItem> {
         .collect()
 }
 
-fn project_local_effect(effect: &ControllerEffect, state: &mut TuiState) {
+pub(super) fn project_local_effect(effect: &ControllerEffect, state: &mut TuiState) {
     match effect {
         ControllerEffect::SubmitNext(submission) => {
             state.push_local_user_echo(submission.text.clone(), QueuedInputLane::Next);
+            state.project_local_run_start();
         }
         ControllerEffect::SubmitBacklog(submission) => {
             state.push_local_user_echo(submission.text.clone(), QueuedInputLane::Backlog);
+            state.project_local_run_start();
         }
+        ControllerEffect::Interrupt => state.set_run_state(InteractiveRunState::Interrupting),
         ControllerEffect::PersistPreferences(_)
         | ControllerEffect::ApplyRuntimePreferences(_)
         | ControllerEffect::OpenProviderManager

--- a/crates/merry-cli/src/tui/history_tests.rs
+++ b/crates/merry-cli/src/tui/history_tests.rs
@@ -1,0 +1,76 @@
+use super::{
+    controller::persist_submitted_input_history,
+    input_history_store::InputHistoryStore,
+    keymap::Keymap,
+    state::{TimelineItem, TuiState},
+    theme::TuiTheme,
+};
+use std::path::Path;
+
+fn state() -> TuiState {
+    TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    )
+}
+
+#[tokio::test]
+async fn accepted_text_updates_memory_and_workspace_history_together() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = InputHistoryStore::for_workspace(temp.path(), Path::new("/repo"));
+    let mut state = state();
+    let mut warning_shown = false;
+
+    persist_submitted_input_history(&store, &mut state, "first\nline", &mut warning_shown).await;
+    persist_submitted_input_history(&store, &mut state, "second", &mut warning_shown).await;
+
+    assert_eq!(state.input_history_entries(), ["first\nline", "second"]);
+    assert_eq!(store.load().await, ["first\nline", "second"]);
+    assert!(!warning_shown);
+}
+
+#[tokio::test]
+async fn blank_or_image_only_history_text_is_not_persisted() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = InputHistoryStore::for_workspace(temp.path(), Path::new("/repo"));
+    let mut state = state();
+    let mut warning_shown = false;
+
+    persist_submitted_input_history(&store, &mut state, "  ", &mut warning_shown).await;
+
+    assert!(state.input_history_entries().is_empty());
+    assert!(!store.path().exists());
+    assert!(!warning_shown);
+}
+
+#[tokio::test]
+async fn persistence_failure_and_recovery_keep_memory_history_and_warn_once() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let blocked_state_dir = temp.path().join("not-a-directory");
+    std::fs::write(&blocked_state_dir, "blocked").expect("blocking file");
+    let store = InputHistoryStore::for_workspace(&blocked_state_dir, Path::new("/repo"));
+    let mut state = state();
+    let mut warning_shown = false;
+
+    persist_submitted_input_history(&store, &mut state, "first", &mut warning_shown).await;
+    persist_submitted_input_history(&store, &mut state, "second", &mut warning_shown).await;
+    std::fs::remove_file(&blocked_state_dir).expect("remove blocking file");
+    persist_submitted_input_history(&store, &mut state, "third", &mut warning_shown).await;
+
+    assert_eq!(state.input_history_entries(), ["first", "second", "third"]);
+    assert_eq!(store.load().await, ["third"]);
+    assert!(warning_shown);
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::Diagnostic { title, .. } if title == "Input history not saved"
+            ))
+            .count(),
+        1
+    );
+}

--- a/crates/merry-cli/src/tui/input.rs
+++ b/crates/merry-cli/src/tui/input.rs
@@ -5,7 +5,7 @@ use merry_runtime::{
 use std::{ops::Range, sync::Arc};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-const MAX_INPUT_HISTORY: usize = 200;
+pub(crate) const MAX_INPUT_HISTORY: usize = 200;
 const PASTE_PLACEHOLDER_THRESHOLD_CHARS: usize = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,8 +84,16 @@ pub(crate) struct TuiSubmission {
 }
 
 impl TuiSubmission {
-    pub(crate) fn into_user_message(self) -> Result<UserMessageInput, RuntimeError> {
-        UserMessageInput::new(&self.text, self.images)
+    pub(crate) fn into_user_message_and_history(
+        self,
+    ) -> Result<(UserMessageInput, String), RuntimeError> {
+        let Self {
+            text,
+            history_text,
+            images,
+        } = self;
+        let message = UserMessageInput::new(&text, images)?;
+        Ok((message, history_text))
     }
 }
 
@@ -93,6 +101,10 @@ impl TuiSubmission {
 impl TextInput {
     pub(crate) fn text(&self) -> &str {
         &self.text
+    }
+
+    pub(crate) fn plain_text(&self) -> Option<&str> {
+        self.elements.is_empty().then_some(&self.text)
     }
 
     pub(crate) fn cursor_byte_index(&self) -> usize {
@@ -566,16 +578,19 @@ pub(crate) struct InputHistory {
 #[allow(dead_code)]
 impl InputHistory {
     pub(crate) fn record(&mut self, text: &str) {
-        if text.trim().is_empty() {
-            return;
-        }
-
-        self.entries.push(text.to_owned());
-        if self.entries.len() > MAX_INPUT_HISTORY {
-            self.entries.remove(0);
-        }
+        push_input_history_entry(&mut self.entries, text);
         self.navigation = None;
         self.draft.clear();
+    }
+
+    pub(crate) fn replace_entries(&mut self, entries: Vec<String>) {
+        self.entries = normalize_input_history(entries);
+        self.navigation = None;
+        self.draft.clear();
+    }
+
+    pub(crate) fn entries(&self) -> &[String] {
+        &self.entries
     }
 
     pub(crate) fn previous(&mut self, input: &mut TextInput) {
@@ -608,6 +623,25 @@ impl InputHistory {
 
         self.navigation = None;
         *input = std::mem::take(&mut self.draft);
+    }
+}
+
+pub(crate) fn normalize_input_history(entries: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(entries.len().min(MAX_INPUT_HISTORY));
+    for entry in entries {
+        push_input_history_entry(&mut normalized, &entry);
+    }
+    normalized
+}
+
+pub(crate) fn push_input_history_entry(entries: &mut Vec<String>, text: &str) {
+    if text.trim().is_empty() || entries.last().is_some_and(|entry| entry == text) {
+        return;
+    }
+    entries.push(text.to_owned());
+    let excess = entries.len().saturating_sub(MAX_INPUT_HISTORY);
+    if excess > 0 {
+        entries.drain(..excess);
     }
 }
 

--- a/crates/merry-cli/src/tui/input_history_store.rs
+++ b/crates/merry-cli/src/tui/input_history_store.rs
@@ -1,0 +1,403 @@
+use super::input::{normalize_input_history, push_input_history_entry};
+use sha2::{Digest, Sha256};
+use std::{
+    fmt::Write as _,
+    fs::{self, File, OpenOptions},
+    io::{self, BufRead, BufReader, Write as _},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+use thiserror::Error;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+const HISTORY_HASH_DOMAIN: &[u8] = b"merry-input-history-v1\0";
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InputHistoryStore {
+    path: PathBuf,
+    lock_path: PathBuf,
+}
+
+impl InputHistoryStore {
+    pub(crate) fn for_workspace(state_dir: &Path, workspace_root: &Path) -> Self {
+        let hash = workspace_hash(workspace_root);
+        let directory = state_dir.join("input-history");
+        Self {
+            path: directory.join(format!("{hash}.jsonl")),
+            lock_path: directory.join(format!("{hash}.lock")),
+        }
+    }
+
+    pub(crate) async fn load(&self) -> Vec<String> {
+        let path = self.path.clone();
+        match tokio::task::spawn_blocking(move || load_history(&path)).await {
+            Ok(Ok(entries)) => entries,
+            Ok(Err(error)) => {
+                tracing::warn!(error = %error, "could not load TUI input history");
+                Vec::new()
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "TUI input history load task failed");
+                Vec::new()
+            }
+        }
+    }
+
+    pub(crate) async fn record(&self, text: &str) -> Result<Vec<String>, InputHistoryError> {
+        if text.trim().is_empty() {
+            return Ok(self.load().await);
+        }
+        let path = self.path.clone();
+        let lock_path = self.lock_path.clone();
+        let text = text.to_owned();
+        tokio::task::spawn_blocking(move || record_history(&path, &lock_path, &text))
+            .await
+            .map_err(InputHistoryError::TaskJoin)?
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+}
+
+fn workspace_hash(workspace_root: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(HISTORY_HASH_DOMAIN);
+    hasher.update(workspace_root.as_os_str().as_encoded_bytes());
+    let digest = hasher.finalize();
+    let mut hash = String::with_capacity(32);
+    for byte in &digest[..16] {
+        write!(&mut hash, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    hash
+}
+
+fn record_history(
+    path: &Path,
+    lock_path: &Path,
+    text: &str,
+) -> Result<Vec<String>, InputHistoryError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| InputHistoryError::InvalidPath {
+            path: path.to_path_buf(),
+        })?;
+    ensure_private_directory(parent)?;
+    let lock_file = open_private_lock_file(lock_path)?;
+    lock_file
+        .lock()
+        .map_err(|source| io_error("lock", lock_path, source))?;
+
+    let mut entries = load_history(path)?;
+    push_input_history_entry(&mut entries, text);
+    write_history_atomically(path, &entries)?;
+    Ok(entries)
+}
+
+fn load_history(path: &Path) -> Result<Vec<String>, InputHistoryError> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => return Err(io_error("read", path, source)),
+    };
+    let mut entries = Vec::new();
+    let mut skipped_lines = 0_usize;
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        if reader
+            .read_until(b'\n', &mut line)
+            .map_err(|source| io_error("read", path, source))?
+            == 0
+        {
+            break;
+        }
+        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+            continue;
+        }
+        match serde_json::from_slice::<String>(&line) {
+            Ok(entry) if !entry.trim().is_empty() => entries.push(entry),
+            Ok(_) | Err(_) => skipped_lines += 1,
+        }
+    }
+    if skipped_lines > 0 {
+        tracing::warn!(
+            path = %path.display(),
+            skipped_lines,
+            "skipped invalid TUI input history lines"
+        );
+    }
+    Ok(normalize_input_history(entries))
+}
+
+fn ensure_private_directory(path: &Path) -> Result<(), InputHistoryError> {
+    fs::create_dir_all(path).map_err(|source| io_error("create directory", path, source))?;
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|source| io_error("set directory permissions", path, source))?;
+    Ok(())
+}
+
+fn open_private_lock_file(path: &Path) -> Result<File, InputHistoryError> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let file = options
+        .open(path)
+        .map_err(|source| io_error("open lock file", path, source))?;
+    #[cfg(unix)]
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .map_err(|source| io_error("set lock file permissions", path, source))?;
+    Ok(file)
+}
+
+fn write_history_atomically(path: &Path, entries: &[String]) -> Result<(), InputHistoryError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| InputHistoryError::InvalidPath {
+            path: path.to_path_buf(),
+        })?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| InputHistoryError::InvalidPath {
+            path: path.to_path_buf(),
+        })?;
+    let temp_path = parent.join(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options
+            .open(&temp_path)
+            .map_err(|source| io_error("create temporary file", &temp_path, source))?;
+        for entry in entries {
+            serde_json::to_writer(&mut file, entry).map_err(InputHistoryError::Serialize)?;
+            file.write_all(b"\n")
+                .map_err(|source| io_error("write temporary file", &temp_path, source))?;
+        }
+        file.sync_all()
+            .map_err(|source| io_error("sync temporary file", &temp_path, source))?;
+        drop(file);
+        fs::rename(&temp_path, path).map_err(|source| io_error("replace", path, source))?;
+        #[cfg(unix)]
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|source| io_error("sync directory", parent, source))?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn io_error(operation: &'static str, path: &Path, source: io::Error) -> InputHistoryError {
+    InputHistoryError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum InputHistoryError {
+    #[error("could not {operation} input history path {}: {source}", path.display())]
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("input history path {} is invalid", path.display())]
+    InvalidPath { path: PathBuf },
+    #[error("could not serialize input history: {0}")]
+    Serialize(#[source] serde_json::Error),
+    #[error("input history persistence task failed: {0}")]
+    TaskJoin(#[source] tokio::task::JoinError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn history_store(temp: &tempfile::TempDir, workspace: &str) -> InputHistoryStore {
+        InputHistoryStore::for_workspace(&temp.path().join("merry"), Path::new(workspace))
+    }
+
+    fn write_fixture(path: &Path, text: &str) {
+        fs::create_dir_all(path.parent().expect("history parent")).expect("create parent");
+        fs::write(path, text).expect("write history fixture");
+    }
+
+    #[tokio::test]
+    async fn round_trips_multiline_unicode_entries_and_loads_empty_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = history_store(&temp, "/workspace/merry");
+        for entry in ["first", "second\nline", "第三条"] {
+            store.record(entry).await.expect("record history");
+        }
+        assert_eq!(store.load().await, vec!["first", "second\nline", "第三条"]);
+
+        let empty = history_store(&temp, "/workspace/empty");
+        write_fixture(empty.path(), "");
+        assert!(empty.load().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn salvages_valid_lines_from_partially_or_fully_corrupt_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let partial = history_store(&temp, "/workspace/partial");
+        write_fixture(partial.path(), "\"first\"\nnot-json\n42\n\"second\"\n");
+        assert_eq!(partial.load().await, vec!["first", "second"]);
+
+        let invalid_utf8 = history_store(&temp, "/workspace/invalid-utf8");
+        fs::create_dir_all(invalid_utf8.path().parent().expect("history parent"))
+            .expect("create parent");
+        fs::write(invalid_utf8.path(), b"\"first\"\n\xff\n\"second\"\n")
+            .expect("write invalid UTF-8 fixture");
+        assert_eq!(invalid_utf8.load().await, vec!["first", "second"]);
+
+        let corrupt = history_store(&temp, "/workspace/corrupt");
+        write_fixture(corrupt.path(), "not-json\n{}\n");
+        assert!(corrupt.load().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scopes_paths_by_workspace_without_leaking_the_raw_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first = history_store(&temp, "/private/workspace/first");
+        let second = history_store(&temp, "/private/workspace/second");
+        assert_ne!(first.path(), second.path());
+        assert_eq!(
+            first.path().parent(),
+            Some(temp.path().join("merry/input-history").as_path())
+        );
+        let file_name = first
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("UTF-8 hash file name");
+        assert_eq!(file_name.len(), 32 + ".jsonl".len());
+        assert!(file_name.ends_with(".jsonl"));
+        assert!(!first.path().display().to_string().contains("private"));
+        assert_eq!(
+            history_store(&temp, "/workspace/merry")
+                .path()
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("d4d8319782c356e98a4473aa3c7cc170.jsonl")
+        );
+
+        first.record("first only").await.expect("first record");
+        second.record("second only").await.expect("second record");
+        assert_eq!(first.load().await, vec!["first only"]);
+        assert_eq!(second.load().await, vec!["second only"]);
+    }
+
+    #[tokio::test]
+    async fn normalizes_duplicates_blanks_and_capacity_on_load_and_record() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = history_store(&temp, "/workspace/merry");
+        let fixture = (0..=200)
+            .map(|index| serde_json::to_string(&format!("entry-{index}")))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("serialize fixture")
+            .join("\n");
+        write_fixture(store.path(), &fixture);
+        let loaded = store.load().await;
+        assert_eq!(loaded.len(), 200);
+        assert_eq!(loaded.first().map(String::as_str), Some("entry-1"));
+
+        store
+            .record("entry-200")
+            .await
+            .expect("deduplicated record");
+        store.record("   ").await.expect("blank record");
+        assert_eq!(store.load().await, loaded);
+        store
+            .record("entry-1")
+            .await
+            .expect("non-adjacent duplicate");
+        let loaded = store.load().await;
+        assert_eq!(loaded.last().map(String::as_str), Some("entry-1"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_stores_merge_records_under_the_workspace_lock() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let first = history_store(&temp, "/workspace/merry");
+        let second = first.clone();
+        let (first_result, second_result) =
+            tokio::join!(first.record("from first"), second.record("from second"));
+        first_result.expect("first record");
+        second_result.expect("second record");
+        assert_eq!(
+            first.load().await.into_iter().collect::<BTreeSet<_>>(),
+            BTreeSet::from(["from first".to_owned(), "from second".to_owned()])
+        );
+    }
+
+    #[tokio::test]
+    async fn atomic_replace_leaves_no_temporary_file_and_uses_private_permissions() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = history_store(&temp, "/workspace/merry");
+        store.record("secret-ish input").await.expect("record");
+        let parent = store.path().parent().expect("history parent");
+        assert!(store.path().is_file());
+        assert!(store.lock_path().is_file());
+        assert!(
+            fs::read_dir(parent)
+                .expect("read history directory")
+                .filter_map(Result::ok)
+                .all(|entry| !entry.file_name().to_string_lossy().contains(".tmp-"))
+        );
+
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                fs::metadata(parent)
+                    .expect("directory metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(store.path())
+                    .expect("history metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+            assert_eq!(
+                fs::metadata(store.lock_path())
+                    .expect("lock metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/mod.rs
+++ b/crates/merry-cli/src/tui/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     provider_management::ProviderDraft,
 };
 use crossterm::event::KeyCode;
+use input_history_store::InputHistoryStore;
 use keymap::Keymap;
 use preferences::{TuiPreferences, TuiPreferencesStore, TuiSettingsDefaults};
 use projector::TuiProjector;
@@ -26,10 +27,13 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(target_os = "linux")]
 mod clipboard_image;
+mod command;
+mod command_controller;
 mod completion;
 mod controller;
 mod highlight;
 mod input;
+mod input_history_store;
 pub(crate) mod keymap;
 mod layout;
 mod markdown;
@@ -55,7 +59,11 @@ pub(crate) mod theme;
 mod tool_error;
 
 #[cfg(test)]
+mod history_tests;
+#[cfg(test)]
 mod plan_tests;
+#[cfg(test)]
+mod slash_tests;
 #[cfg(test)]
 mod tests;
 
@@ -146,6 +154,9 @@ pub(crate) async fn run(
         keymap,
         theme,
     );
+    let input_history_store =
+        InputHistoryStore::for_workspace(paths.state_dir(), &session.workspace_root);
+    state.set_input_history(input_history_store.load().await);
     state.set_reasoning_effort_label(session.reasoning_effort_label.clone());
     state.set_completion_skills(session.skills.clone());
     state.configure_preferences(preferences, settings_defaults);
@@ -171,6 +182,7 @@ pub(crate) async fn run(
         session,
         state,
         preferences_store,
+        input_history_store,
         provider_management,
     )
     .await

--- a/crates/merry-cli/src/tui/overlay.rs
+++ b/crates/merry-cli/src/tui/overlay.rs
@@ -1,6 +1,6 @@
 use super::{
+    command::all_commands,
     input::{TextInput, TextInputViewport},
-    keymap::KeyAction,
     provider_overlay::{
         ModelPickerOverlay, ProviderFormOverlay, ProviderManagerOverlay, ProviderOverlayAction,
     },
@@ -8,153 +8,7 @@ use super::{
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use merry_core::{PlanAttemptOutcome, PlanNodeId, PlanPhase, PlanSnapshot};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PaletteCommand {
-    OpenSettings,
-    OpenProviders,
-    ShowShortcuts,
-    FollowLatest,
-    ReviewPreviousArtifact,
-    ReviewNextArtifact,
-    ReviewPreviousUserInput,
-    Interrupt,
-    ResumeSuspended,
-    DiscardSuspended,
-    Quit,
-    EnterPlanMode,
-    ApprovePlan,
-    RevisePlan,
-    OpenPlan,
-    FocusPlan,
-    ClosePlan,
-    RetryPlanNode,
-    CancelPlan,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CommandSpec {
-    pub(crate) command: PaletteCommand,
-    pub(crate) category: &'static str,
-    pub(crate) label: &'static str,
-    pub(crate) key_action: Option<KeyAction>,
-}
-
-const COMMANDS: [CommandSpec; 19] = [
-    CommandSpec {
-        command: PaletteCommand::OpenSettings,
-        category: "Merry",
-        label: "Settings",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::OpenProviders,
-        category: "Merry",
-        label: "Providers & models",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::ShowShortcuts,
-        category: "Merry",
-        label: "Keyboard shortcuts",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::FollowLatest,
-        category: "Navigation",
-        label: "Follow latest",
-        key_action: Some(KeyAction::FollowLatestArtifact),
-    },
-    CommandSpec {
-        command: PaletteCommand::ReviewPreviousArtifact,
-        category: "Navigation",
-        label: "Previous artifact",
-        key_action: Some(KeyAction::ReviewPreviousArtifact),
-    },
-    CommandSpec {
-        command: PaletteCommand::ReviewNextArtifact,
-        category: "Navigation",
-        label: "Next artifact",
-        key_action: Some(KeyAction::ReviewNextArtifact),
-    },
-    CommandSpec {
-        command: PaletteCommand::ReviewPreviousUserInput,
-        category: "Navigation",
-        label: "Previous user input",
-        key_action: Some(KeyAction::ReviewPreviousUserInput),
-    },
-    CommandSpec {
-        command: PaletteCommand::Interrupt,
-        category: "Runtime",
-        label: "Interrupt current run",
-        key_action: Some(KeyAction::Interrupt),
-    },
-    CommandSpec {
-        command: PaletteCommand::ResumeSuspended,
-        category: "Runtime",
-        label: "Resume suspended input",
-        key_action: Some(KeyAction::ResumeSuspended),
-    },
-    CommandSpec {
-        command: PaletteCommand::DiscardSuspended,
-        category: "Runtime",
-        label: "Discard suspended input",
-        key_action: Some(KeyAction::DiscardSuspended),
-    },
-    CommandSpec {
-        command: PaletteCommand::Quit,
-        category: "Session",
-        label: "Quit Merry",
-        key_action: Some(KeyAction::Quit),
-    },
-    CommandSpec {
-        command: PaletteCommand::EnterPlanMode,
-        category: "Plan",
-        label: "Enter Plan Mode",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::ApprovePlan,
-        category: "Plan",
-        label: "Approve plan and execute",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::RevisePlan,
-        category: "Plan",
-        label: "Revise plan",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::OpenPlan,
-        category: "Plan",
-        label: "Open plan",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::FocusPlan,
-        category: "Plan",
-        label: "Focus plan tree",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::ClosePlan,
-        category: "Plan",
-        label: "Close plan",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::RetryPlanNode,
-        category: "Plan",
-        label: "Retry selected interrupted node",
-        key_action: None,
-    },
-    CommandSpec {
-        command: PaletteCommand::CancelPlan,
-        category: "Plan",
-        label: "Cancel plan",
-        key_action: None,
-    },
-];
+pub(crate) use super::command::{CommandSpec, PaletteCommand};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct PlanPaletteContext {
@@ -378,13 +232,17 @@ impl CommandPalette {
 
     pub(crate) fn visible_commands(&self) -> Vec<&'static CommandSpec> {
         let query = self.query.text().trim().to_ascii_lowercase();
-        COMMANDS
+        let slash_query = query.strip_prefix('/').unwrap_or(&query);
+        all_commands()
             .iter()
             .filter(|command| plan_command_is_available(command.command, self.plan))
             .filter(|command| {
                 query.is_empty()
                     || fuzzy_matches(command.label, &query)
                     || fuzzy_matches(command.category, &query)
+                    || command
+                        .slash_name()
+                        .is_some_and(|name| fuzzy_matches(name, slash_query))
             })
             .collect()
     }

--- a/crates/merry-cli/src/tui/overlay_render.rs
+++ b/crates/merry-cli/src/tui/overlay_render.rs
@@ -74,10 +74,20 @@ pub(crate) fn render_overlay(frame: &mut Frame<'_>, state: &TuiState) {
                 .map(|row| match row {
                     CommandPaletteRow::Category(category) => command_category_line(state, category),
                     CommandPaletteRow::Command { index, spec } => {
-                        let shortcut = spec
+                        let key_binding = spec
                             .key_action
                             .and_then(|action| state.keymap().binding_label_for(action))
                             .unwrap_or_default();
+                        let slash_alias = spec
+                            .slash_name()
+                            .map(|name| format!("/{name}"))
+                            .unwrap_or_default();
+                        let shortcut = match (key_binding.is_empty(), slash_alias.is_empty()) {
+                            (false, false) => format!("{key_binding}  {slash_alias}"),
+                            (false, true) => key_binding,
+                            (true, false) => slash_alias,
+                            (true, true) => String::new(),
+                        };
                         command_line(
                             state,
                             spec.label,

--- a/crates/merry-cli/src/tui/projector.rs
+++ b/crates/merry-cli/src/tui/projector.rs
@@ -90,7 +90,7 @@ impl TuiProjector {
             }
             RuntimeEvent::AssistantMessageDelta { .. } => {}
             RuntimeEvent::InteractiveRunStateChanged { state: run_state } => {
-                state.set_run_state(run_state);
+                state.apply_runtime_run_state(run_state);
             }
             RuntimeEvent::QueuedInputsChanged { inputs } => {
                 state.update_queue_preview(QueuePreview {
@@ -100,6 +100,7 @@ impl TuiProjector {
                 });
             }
             RuntimeEvent::QueuedInputAccepted { lane, inputs } => {
+                state.confirm_local_run_start();
                 for input in inputs {
                     state.confirm_or_push_user_input(input.text, lane);
                 }

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -315,9 +315,17 @@ impl TuiRuntimeSession {
             .save_session_to(self.session_store.session_state_store())
             .await
             .map_err(unexpected)?;
-        self.session_store
-            .write_metadata(&self.metadata)
+        write_session_metadata(&self.session_store, &self.metadata).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn save_now(&mut self) -> Result<(), CliError> {
+        self.metadata.mark_active(now_unix_ms());
+        self.control
+            .save_session_to(self.session_store.session_state_store())
+            .await
             .map_err(unexpected)?;
+        write_session_metadata(&self.session_store, &self.metadata).await?;
         Ok(())
     }
 
@@ -328,6 +336,18 @@ impl TuiRuntimeSession {
     pub(crate) async fn plan_snapshot(&self) -> Result<Option<merry_core::PlanSnapshot>, CliError> {
         self.runtime.plan_snapshot().await.map_err(unexpected)
     }
+}
+
+async fn write_session_metadata(
+    store: &TuiSessionStore,
+    metadata: &TuiSessionMetadata,
+) -> Result<(), CliError> {
+    let store = store.clone();
+    let metadata = metadata.clone();
+    tokio::task::spawn_blocking(move || store.write_metadata(&metadata))
+        .await
+        .map_err(unexpected)?
+        .map_err(unexpected)
 }
 
 fn permission_review_view(request: &PermissionReviewRequest) -> (String, String) {

--- a/crates/merry-cli/src/tui/session_list.rs
+++ b/crates/merry-cli/src/tui/session_list.rs
@@ -1,15 +1,22 @@
 use merry_core::SessionId;
 use serde::{Deserialize, Serialize};
 use std::{
-    fs, io,
+    fs::{self, OpenOptions},
+    io::{self, Write as _},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
 
+#[cfg(unix)]
+use std::{fs::File, os::unix::fs::OpenOptionsExt};
+
 const META_FILE: &str = "meta.json";
 const SESSION_STATE_FILE: &str = "state.json";
 const PLAN_STATE_FILE: &str = "plan-state.json";
+const METADATA_TEMP_PREFIX: &str = ".meta.json.tmp-";
+static METADATA_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Error)]
 pub(crate) enum TuiSessionListError {
@@ -84,10 +91,39 @@ impl TuiSessionStore {
             .parent()
             .expect("metadata path should always have a parent")
             .to_path_buf();
-        fs::create_dir_all(&dir).map_err(|source| io_error(dir, source))?;
-        let bytes =
+        fs::create_dir_all(&dir).map_err(|source| io_error(dir.clone(), source))?;
+        let mut bytes =
             serde_json::to_vec_pretty(metadata).map_err(|source| json_error(&path, source))?;
-        fs::write(&path, bytes).map_err(|source| io_error(path, source))
+        bytes.push(b'\n');
+        let temp_path = path.with_file_name(format!(
+            "{METADATA_TEMP_PREFIX}{}-{}",
+            std::process::id(),
+            METADATA_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let result = (|| {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            let mut file = options
+                .open(&temp_path)
+                .map_err(|source| io_error(temp_path.clone(), source))?;
+            file.write_all(&bytes)
+                .map_err(|source| io_error(temp_path.clone(), source))?;
+            file.sync_all()
+                .map_err(|source| io_error(temp_path.clone(), source))?;
+            drop(file);
+            fs::rename(&temp_path, &path).map_err(|source| io_error(path.clone(), source))?;
+            #[cfg(unix)]
+            File::open(&dir)
+                .and_then(|directory| directory.sync_all())
+                .map_err(|source| io_error(dir.clone(), source))?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(temp_path);
+        }
+        result
     }
 
     pub(crate) fn sessions_for_workspace(
@@ -255,5 +291,38 @@ mod tests {
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_id, session_id);
+    }
+
+    #[test]
+    fn session_store_atomically_replaces_metadata_without_temp_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = TuiSessionStore::new(temp.path().to_path_buf());
+        let session_id = session_id("replace-metadata");
+        write_state_placeholder(&store, &session_id);
+        let mut metadata = TuiSessionMetadata::new(session_id.clone(), "/repo".into(), 10);
+        store
+            .write_metadata(&metadata)
+            .expect("initial metadata writes");
+        metadata.title = Some("updated title".to_owned());
+        metadata.mark_active(20);
+        store
+            .write_metadata(&metadata)
+            .expect("metadata replacement writes");
+
+        let path = store.metadata_path(&session_id);
+        let loaded = serde_json::from_slice::<TuiSessionMetadata>(
+            &fs::read(&path).expect("metadata reads after replacement"),
+        )
+        .expect("replacement remains valid JSON");
+        assert_eq!(loaded, metadata);
+        assert!(
+            fs::read_dir(path.parent().expect("metadata parent"))
+                .expect("metadata directory reads")
+                .filter_map(Result::ok)
+                .all(|entry| !entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(METADATA_TEMP_PREFIX))
+        );
     }
 }

--- a/crates/merry-cli/src/tui/slash_tests.rs
+++ b/crates/merry-cli/src/tui/slash_tests.rs
@@ -1,0 +1,415 @@
+use super::{
+    command::PaletteCommand,
+    completion::{CompletionKind, CompletionSources},
+    controller::{ControllerEffect, handle_key_action, handle_key_event, project_local_effect},
+    input::{DraftImage, TuiSubmission},
+    keymap::{KeyAction, Keymap},
+    overlay::Overlay,
+    projector::TuiProjector,
+    render,
+    state::{TimelineItem, TuiState},
+    theme::TuiTheme,
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use merry_core::{InteractiveRunState, QueuedInputLane, QueuedInputView, RuntimeEvent};
+use ratatui::{Terminal, backend::TestBackend};
+use std::sync::Arc;
+
+fn state() -> TuiState {
+    TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    )
+}
+
+fn text_submission(text: &str) -> TuiSubmission {
+    TuiSubmission {
+        text: text.to_owned(),
+        history_text: text.to_owned(),
+        images: Vec::new(),
+    }
+}
+
+fn draft_image() -> DraftImage {
+    DraftImage::new(
+        Arc::<[u8]>::from([137, 80, 78, 71, 13, 10, 26, 10, 7]),
+        2,
+        3,
+    )
+    .expect("valid draft image")
+}
+
+#[test]
+fn slash_completion_uses_the_shared_registry_only_at_the_input_start() {
+    let sources = CompletionSources::from_skill_names("/repo".into(), &[]);
+    let all = sources
+        .menu_for_input("/", 1, None)
+        .expect("slash completion");
+    assert_eq!(all.items().len(), 4);
+    assert!(
+        all.items()
+            .iter()
+            .all(|item| item.kind() == &CompletionKind::Slash)
+    );
+    assert_eq!(
+        all.items()
+            .iter()
+            .map(|item| item.value())
+            .collect::<Vec<_>>(),
+        vec!["/help", "/save", "/status", "/stop"]
+    );
+
+    let save = sources
+        .menu_for_input("/sa", 3, None)
+        .expect("save completion");
+    assert_eq!(save.items()[0].value(), "/save");
+    assert!(save.items()[0].detail().is_some());
+    assert!(sources.menu_for_input("hello", 5, None).is_none());
+    assert!(sources.menu_for_input("hello /sa", 9, None).is_none());
+    assert!(sources.menu_for_input("/xyz", 4, None).is_none());
+
+    let middle = sources
+        .menu_for_input("/save", 3, None)
+        .expect("mid-token slash completion");
+    assert_eq!(middle.replacement_range(), 0..5);
+    assert_eq!(middle.replacement_text(), Some("/save".to_owned()));
+}
+
+#[test]
+fn slash_completion_does_not_auto_submit_multiline_or_attached_input() {
+    let mut multiline = state();
+    multiline.insert_input_str("/sa\nexplain");
+    multiline.handle_input_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+    for _ in 0..3 {
+        multiline.handle_input_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+    }
+    assert!(multiline.completion_menu().is_none());
+
+    let mut attached = state();
+    attached.insert_input_str("/sa ");
+    attached
+        .insert_input_image(draft_image())
+        .expect("image attaches");
+    attached.handle_input_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+    for _ in 0..3 {
+        attached.handle_input_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+    }
+    assert!(attached.completion_menu().is_none());
+}
+
+#[test]
+fn enter_executes_a_slash_completion_once_while_tab_only_completes() {
+    let mut enter_state = state();
+    enter_state.insert_input_str("/sa");
+    let effect = handle_key_event(
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        &mut enter_state,
+    );
+    assert_eq!(effect, ControllerEffect::SaveSession);
+    assert_eq!(enter_state.input_text(), "");
+    assert!(enter_state.input_history_entries().is_empty());
+
+    let mut tab_state = state();
+    tab_state.insert_input_str("/sa");
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+            &mut tab_state,
+        ),
+        ControllerEffect::None
+    );
+    assert_eq!(tab_state.input_text(), "/save");
+    assert!(tab_state.completion_menu().is_none());
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut tab_state,
+        ),
+        ControllerEffect::SaveSession
+    );
+
+    let mut mid_token = state();
+    mid_token.set_run_state(InteractiveRunState::RunningModel);
+    mid_token.insert_input_str("/stop");
+    for _ in 0..3 {
+        mid_token.handle_input_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+    }
+    assert_eq!(
+        mid_token
+            .completion_menu()
+            .and_then(|menu| menu.replacement_text()),
+        Some("/stop".to_owned())
+    );
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut mid_token,
+        ),
+        ControllerEffect::Interrupt
+    );
+}
+
+#[test]
+fn local_slash_commands_do_not_enter_user_history_or_either_runtime_lane() {
+    let mut help = state();
+    help.insert_input_str("/help");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitBacklog, &mut help),
+        ControllerEffect::None
+    );
+    assert_eq!(help.input_text(), "");
+    assert!(help.input_history_entries().is_empty());
+    assert!(matches!(
+        help.timeline().last(),
+        Some(TimelineItem::Expanded { title, body })
+            if title == "Command help" && body.contains("/status")
+    ));
+
+    let mut status = state();
+    status.insert_input_str("/status");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut status),
+        ControllerEffect::None
+    );
+    assert!(matches!(
+        status.timeline().last(),
+        Some(TimelineItem::Expanded { title, body })
+            if title == "Session status"
+                && body.contains("Run: ready")
+                && body.contains("Plan: none")
+                && body.contains("Workspace: /repo")
+    ));
+    assert!(
+        status
+            .timeline()
+            .iter()
+            .all(|item| !matches!(item, TimelineItem::User { .. }))
+    );
+}
+
+#[test]
+fn stop_and_save_respect_the_current_run_state() {
+    let mut idle_stop = state();
+    idle_stop.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut idle_stop),
+        ControllerEffect::None
+    );
+    assert!(matches!(
+        idle_stop.timeline().last(),
+        Some(TimelineItem::Muted { title, .. }) if title == "Nothing to stop"
+    ));
+
+    let mut running_stop = state();
+    running_stop.set_run_state(InteractiveRunState::RunningModel);
+    running_stop.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut running_stop),
+        ControllerEffect::Interrupt
+    );
+    running_stop.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut running_stop),
+        ControllerEffect::None
+    );
+    assert!(matches!(
+        running_stop.timeline().last(),
+        Some(TimelineItem::Muted { title, .. }) if title == "Stop already requested"
+    ));
+
+    let mut interrupting = state();
+    interrupting.set_run_state(InteractiveRunState::Interrupting);
+    interrupting.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut interrupting),
+        ControllerEffect::None
+    );
+
+    let mut running_save = state();
+    running_save.set_run_state(InteractiveRunState::RunningTool);
+    running_save.insert_input_str("/save");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut running_save),
+        ControllerEffect::None
+    );
+    assert!(matches!(
+        running_save.timeline().last(),
+        Some(TimelineItem::Muted { title, .. }) if title == "Save unavailable"
+    ));
+}
+
+#[test]
+fn locally_accepted_input_closes_the_idle_save_window() {
+    let mut state = state();
+    state.insert_input_str("start work");
+    let submit = handle_key_action(KeyAction::SubmitNext, &mut state);
+    assert!(matches!(submit, ControllerEffect::SubmitNext(_)));
+    project_local_effect(&submit, &mut state);
+    assert!(state.is_active_run());
+
+    let mut projector = TuiProjector::default();
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput,
+        },
+        &mut state,
+    );
+    assert!(state.is_active_run());
+
+    state.insert_input_str("/save");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::None
+    );
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::Muted { title, .. }) if title == "Save unavailable"
+    ));
+
+    projector.apply(
+        RuntimeEvent::QueuedInputAccepted {
+            lane: QueuedInputLane::Next,
+            inputs: vec![QueuedInputView {
+                text: "start work".to_owned(),
+                lane: QueuedInputLane::Next,
+                position: 0,
+            }],
+        },
+        &mut state,
+    );
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::RunningModel,
+        },
+        &mut state,
+    );
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput,
+        },
+        &mut state,
+    );
+    assert!(!state.is_active_run());
+}
+
+#[test]
+fn interrupting_queued_next_input_accepts_real_waiting_and_relabels_the_echo() {
+    let mut state = state();
+    state.set_run_state(InteractiveRunState::RunningModel);
+    state.insert_input_str("queued next");
+    let submit = handle_key_action(KeyAction::SubmitNext, &mut state);
+    project_local_effect(&submit, &mut state);
+
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::Interrupt
+    );
+    let mut projector = TuiProjector::default();
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput,
+        },
+        &mut state,
+    );
+    assert!(!state.is_active_run());
+
+    projector.apply(
+        RuntimeEvent::QueuedInputAccepted {
+            lane: QueuedInputLane::Suspended,
+            inputs: vec![QueuedInputView {
+                text: "queued next".to_owned(),
+                lane: QueuedInputLane::Suspended,
+                position: 0,
+            }],
+        },
+        &mut state,
+    );
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::User { text, .. } if text == "queued next"
+            ))
+            .count(),
+        1
+    );
+    assert!(matches!(
+        state.timeline().first(),
+        Some(TimelineItem::User {
+            text,
+            lane: QueuedInputLane::Suspended,
+        }) if text == "queued next"
+    ));
+}
+
+#[test]
+fn unknown_commands_are_correctable_while_nested_paths_and_plain_text_still_submit() {
+    let mut unknown = state();
+    unknown.insert_input_str("/unknown");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut unknown),
+        ControllerEffect::None
+    );
+    assert_eq!(unknown.input_text(), "/unknown");
+    assert!(unknown.input_history_entries().is_empty());
+
+    let mut path = state();
+    path.insert_input_str("/tmp/file");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut path),
+        ControllerEffect::SubmitNext(text_submission("/tmp/file"))
+    );
+
+    let mut plain = state();
+    plain.insert_input_str("save");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut plain),
+        ControllerEffect::SubmitNext(text_submission("save"))
+    );
+}
+
+#[test]
+fn command_palette_searches_the_same_slash_aliases() {
+    for query in ["save", "/save"] {
+        let mut state = state();
+        state.open_command_palette();
+        assert!(state.insert_overlay_paste(query));
+        let Overlay::CommandPalette(palette) = state.overlay().expect("command palette") else {
+            panic!("expected command palette");
+        };
+        let commands = palette.visible_commands();
+        assert!(commands.iter().any(|command| {
+            command.command == PaletteCommand::SaveSession && command.slash_name() == Some("save")
+        }));
+    }
+}
+
+#[test]
+fn slash_completion_renders_all_commands_at_compact_and_standard_sizes() {
+    for (width, height) in [(80, 16), (120, 24)] {
+        let mut state = state();
+        state.insert_input_str("/");
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| render::render(frame, &state))
+            .expect("render slash completion");
+        let buffer = terminal.backend().buffer();
+        let text = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        for command in ["/help", "/save", "/status", "/stop"] {
+            assert!(
+                text.contains(command),
+                "{command} should render at {width}x{height}"
+            );
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/state.rs
+++ b/crates/merry-cli/src/tui/state.rs
@@ -200,6 +200,7 @@ pub(crate) struct TuiState {
     timeline_review_user_index: Option<usize>,
     artifact_review_timeline_index: Option<usize>,
     pending_local_echoes: Vec<PendingLocalEcho>,
+    pending_local_run_start: bool,
     run_state: InteractiveRunState,
     active_run_started_at: Option<Instant>,
     last_completed_run_elapsed: Option<Duration>,
@@ -224,6 +225,7 @@ enum ProviderOverlayBack {
 struct PendingLocalEcho {
     text: String,
     lane: QueuedInputLane,
+    timeline_index: usize,
 }
 
 #[allow(dead_code)]
@@ -251,6 +253,7 @@ impl TuiState {
             timeline_review_user_index: None,
             artifact_review_timeline_index: None,
             pending_local_echoes: Vec::new(),
+            pending_local_run_start: false,
             run_state: InteractiveRunState::WaitingForInput,
             active_run_started_at: None,
             last_completed_run_elapsed: None,
@@ -287,6 +290,16 @@ impl TuiState {
         self.input.text()
     }
 
+    pub(crate) fn plain_input_text(&self) -> Option<&str> {
+        self.input.plain_text()
+    }
+
+    pub(crate) fn clear_input(&mut self) {
+        self.input.clear();
+        self.completion_menu = None;
+        self.pending_empty_input_quit = false;
+    }
+
     pub(crate) fn input_viewport(&self, max_width: usize) -> super::input::TextInputViewport {
         self.input.viewport(max_width)
     }
@@ -311,18 +324,16 @@ impl TuiState {
     pub(crate) fn take_input_for_submit(&mut self) -> Option<TuiSubmission> {
         self.completion_menu = None;
         self.pending_empty_input_quit = false;
-        let submission = match self.input.take_submission() {
-            Ok(submission) => submission?,
+        match self.input.take_submission() {
+            Ok(submission) => submission,
             Err(error) => {
                 self.push_timeline_item(TimelineItem::Diagnostic {
                     title: "user_input".to_owned(),
                     body: error.to_string(),
                 });
-                return None;
+                None
             }
-        };
-        self.input_history.record(&submission.history_text);
-        Some(submission)
+        }
     }
 
     pub(crate) fn previous_input_history(&mut self) {
@@ -335,6 +346,18 @@ impl TuiState {
         self.pending_empty_input_quit = false;
         self.input_history.next(&mut self.input);
         self.refresh_completion_menu();
+    }
+
+    pub(crate) fn set_input_history(&mut self, entries: Vec<String>) {
+        self.input_history.replace_entries(entries);
+    }
+
+    pub(crate) fn record_input_history(&mut self, text: &str) {
+        self.input_history.record(text);
+    }
+
+    pub(crate) fn input_history_entries(&self) -> &[String] {
+        self.input_history.entries()
     }
 
     pub(crate) fn handle_input_key(&mut self, key: crossterm::event::KeyEvent) {
@@ -405,16 +428,20 @@ impl TuiState {
         self.pending_empty_input_quit = false;
         self.input
             .replace_range(menu.replacement_range(), &replacement);
-        self.refresh_completion_menu();
+        if !menu.is_slash() {
+            self.refresh_completion_menu();
+        }
         true
     }
 
     fn refresh_completion_menu(&mut self) {
-        self.completion_menu = self.completion_sources.menu_for_input(
+        let menu = self.completion_sources.menu_for_input(
             self.input.text(),
             self.input.cursor_byte_index(),
             self.completion_menu.as_ref(),
         );
+        self.completion_menu =
+            menu.filter(|menu| !menu.is_slash() || self.input.plain_text().is_some());
     }
 
     pub(crate) fn keymap(&self) -> &Keymap {
@@ -763,20 +790,35 @@ impl TuiState {
     }
 
     pub(crate) fn push_local_user_echo(&mut self, text: String, lane: QueuedInputLane) {
+        let timeline_index = self.timeline.len();
         self.pending_local_echoes.push(PendingLocalEcho {
             text: text.clone(),
             lane,
+            timeline_index,
         });
         self.push_user_timeline_item(text, lane);
     }
 
     pub(crate) fn confirm_or_push_user_input(&mut self, text: String, lane: QueuedInputLane) {
-        if let Some(index) = self
+        let exact = self
             .pending_local_echoes
             .iter()
-            .position(|echo| echo.text == text && echo.lane == lane)
-        {
-            self.pending_local_echoes.remove(index);
+            .position(|echo| echo.text == text && echo.lane == lane);
+        let moved_to_suspended = (lane == QueuedInputLane::Suspended).then(|| {
+            self.pending_local_echoes
+                .iter()
+                .position(|echo| echo.text == text && echo.lane == QueuedInputLane::Next)
+        });
+        if let Some(index) = exact.or_else(|| moved_to_suspended.flatten()) {
+            let echo = self.pending_local_echoes.remove(index);
+            if echo.lane != lane
+                && let Some(TimelineItem::User {
+                    lane: timeline_lane,
+                    ..
+                }) = self.timeline.get_mut(echo.timeline_index)
+            {
+                *timeline_lane = lane;
+            }
             return;
         }
 
@@ -933,6 +975,26 @@ impl TuiState {
         self.set_run_state_at(state, Instant::now());
     }
 
+    pub(crate) fn project_local_run_start(&mut self) {
+        if self.run_state == InteractiveRunState::WaitingForInput {
+            self.pending_local_run_start = true;
+            self.set_run_state(InteractiveRunState::RunningModel);
+        }
+    }
+
+    pub(crate) fn confirm_local_run_start(&mut self) {
+        self.pending_local_run_start = false;
+    }
+
+    pub(crate) fn apply_runtime_run_state(&mut self, state: InteractiveRunState) {
+        // The producer's initial or previous Waiting event can race a locally submitted input.
+        if state == InteractiveRunState::WaitingForInput && self.pending_local_run_start {
+            return;
+        }
+        self.pending_local_run_start = false;
+        self.set_run_state(state);
+    }
+
     pub(crate) fn set_run_state_at(&mut self, state: InteractiveRunState, now: Instant) {
         let was_active = is_active_run_state(self.run_state);
         let is_active = is_active_run_state(state);
@@ -964,6 +1026,17 @@ impl TuiState {
         is_active_run_state(self.run_state)
     }
 
+    pub(crate) fn can_interrupt_run(&self) -> bool {
+        matches!(
+            self.run_state,
+            InteractiveRunState::RunningModel | InteractiveRunState::RunningTool
+        )
+    }
+
+    pub(crate) fn is_interrupting(&self) -> bool {
+        self.run_state == InteractiveRunState::Interrupting
+    }
+
     pub(crate) fn cancel_input_or_mark_quit(&mut self) -> bool {
         if !self.input.text().is_empty() {
             self.input.replace_text(String::new());
@@ -983,6 +1056,30 @@ impl TuiState {
 
     pub(crate) fn status_text(&self) -> String {
         self.status_parts().join("  ")
+    }
+
+    pub(crate) fn command_status_body(&self) -> String {
+        let [workspace, model, usage] = self.status_parts();
+        let plan = self
+            .plan
+            .snapshot()
+            .map(|snapshot| match snapshot.phase {
+                merry_core::PlanPhase::Planning => "planning",
+                merry_core::PlanPhase::AwaitingApproval => "awaiting approval",
+                merry_core::PlanPhase::Executing => "executing",
+                merry_core::PlanPhase::Completed => "completed",
+                merry_core::PlanPhase::Blocked => "blocked",
+                merry_core::PlanPhase::Cancelled => "cancelled",
+            })
+            .unwrap_or("none");
+        let run = match self.run_state {
+            InteractiveRunState::WaitingForInput => "ready",
+            InteractiveRunState::RunningModel => "running model",
+            InteractiveRunState::RunningTool => "running tool",
+            InteractiveRunState::Interrupting => "interrupting",
+            InteractiveRunState::Closed => "closed",
+        };
+        format!("Run: {run}\nModel: {model}\nUsage: {usage}\nPlan: {plan}\nWorkspace: {workspace}")
     }
 
     pub(crate) fn status_parts(&self) -> [String; 3] {

--- a/crates/merry-cli/src/tui/tests.rs
+++ b/crates/merry-cli/src/tui/tests.rs
@@ -5,7 +5,7 @@ use super::controller::{
 };
 use super::input::{DraftImage, TextInput, TuiSubmission};
 use super::keymap::{KeyAction, KeyBinding, Keymap};
-use super::overlay::Overlay;
+use super::overlay::{Overlay, PaletteCommand};
 use super::panels::{FocusPanelBody, FocusPanelTone, focus_panel_view};
 use super::preferences::CodeTheme;
 use super::projector::TuiProjector;
@@ -535,6 +535,7 @@ fn controller_submit_carries_images_and_records_text_only_history() {
     assert_eq!(submission.images[0].label(), "[Image #1]");
     assert_eq!(submission.images[0].png_bytes()[8], 7);
     assert!(state.input_text().is_empty());
+    state.record_input_history(&submission.history_text);
 
     assert_eq!(
         handle_key_action(KeyAction::HistoryPrevious, &mut state),
@@ -557,11 +558,13 @@ fn controller_submit_records_shell_like_input_history() {
         handle_key_action(KeyAction::SubmitNext, &mut state),
         ControllerEffect::SubmitNext(text_submission("first"))
     );
+    state.record_input_history("first");
     state.input_mut().insert_str("second");
     assert_eq!(
         handle_key_action(KeyAction::SubmitNext, &mut state),
         ControllerEffect::SubmitNext(text_submission("second"))
     );
+    state.record_input_history("second");
 
     assert_eq!(
         handle_key_action(KeyAction::HistoryPrevious, &mut state),
@@ -599,6 +602,7 @@ fn controller_history_restores_unsent_draft() {
         handle_key_action(KeyAction::SubmitNext, &mut state),
         ControllerEffect::SubmitNext(text_submission("sent"))
     );
+    state.record_input_history("sent");
     state.input_mut().insert_str("draft");
 
     assert_eq!(
@@ -1355,9 +1359,25 @@ fn command_palette_keeps_the_selected_command_visible_in_a_short_terminal() {
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
         &mut state,
     );
-    for _ in 0..10 {
+    let mut selected_quit = false;
+    for _ in 0..32 {
+        selected_quit = matches!(
+            state.overlay(),
+            Some(Overlay::CommandPalette(palette))
+                if palette
+                    .visible_commands()
+                    .get(palette.selected())
+                    .is_some_and(|command| command.command == PaletteCommand::Quit)
+        );
+        if selected_quit {
+            break;
+        }
         handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), &mut state);
     }
+    assert!(
+        selected_quit,
+        "Quit should remain reachable in the command palette"
+    );
 
     let palette = render_to_text(&state, 40, 12);
 

--- a/crates/merry-runtime/src/interactive.rs
+++ b/crates/merry-runtime/src/interactive.rs
@@ -891,6 +891,18 @@ impl InteractiveProducer {
                     Some(CommandDecision::Continue)
                 }
             }
+            InteractiveCommand::SaveSession { store, ack_sender } => {
+                let result = if mode == CommandHandlingMode::Waiting {
+                    self.runtime
+                        .save_session_to_with_active_permit(store, &self.loop_permit)
+                        .await
+                        .map_err(InteractiveError::from)
+                } else {
+                    Err(InteractiveError::SessionSaveRequiresIdle)
+                };
+                let _ = ack_sender.send(result);
+                Some(CommandDecision::Continue)
+            }
             InteractiveCommand::EnterPlanMode { reason, ack_sender } => {
                 let result = if mode == CommandHandlingMode::Waiting {
                     self.runtime.enter_plan_mode(&reason).await.map(|_| ())

--- a/crates/merry-runtime/src/interactive/commands.rs
+++ b/crates/merry-runtime/src/interactive/commands.rs
@@ -3,7 +3,7 @@ use super::{
     queue::AcceptedQueuedInput,
     types::{InputReceipt, InputRecords, QueuedInputId},
 };
-use crate::{PlanApprovalInput, UserMessageInput};
+use crate::{FileSessionStore, PlanApprovalInput, UserMessageInput};
 use merry_core::{PlanNodeId, QueuedInputLane};
 use tokio::sync::oneshot;
 
@@ -45,6 +45,10 @@ pub(super) enum InteractiveCommand {
     },
     Interrupt {
         reason: InterruptReason,
+        ack_sender: oneshot::Sender<Result<(), InteractiveError>>,
+    },
+    SaveSession {
+        store: FileSessionStore,
         ack_sender: oneshot::Sender<Result<(), InteractiveError>>,
     },
     EnterPlanMode {

--- a/crates/merry-runtime/src/interactive/handles.rs
+++ b/crates/merry-runtime/src/interactive/handles.rs
@@ -3,7 +3,7 @@ use super::{
     InterruptReason,
     types::{InputReceipt, InputRecord, InputRecords},
 };
-use crate::{PlanApprovalInput, UserMessageInput};
+use crate::{FileSessionStore, PlanApprovalInput, UserMessageInput};
 use futures_core::Stream;
 use merry_core::{PlanNodeId, QueuedInputLane, RuntimeEvent};
 use std::{
@@ -421,6 +421,25 @@ impl AgentLoopControl {
         let (ack_sender, ack_receiver) = oneshot::channel();
         self.command_sender
             .send(InteractiveCommand::Interrupt { reason, ack_sender })
+            .await
+            .map_err(|_| InteractiveError::CommandChannelClosed {
+                run_id: self.run_id,
+            })?;
+        ack_receiver
+            .await
+            .map_err(|_| InteractiveError::CommandChannelClosed {
+                run_id: self.run_id,
+            })?
+    }
+
+    /// Saves the session only while the interactive producer is at an idle boundary.
+    ///
+    /// Returns [`InteractiveError::SessionSaveRequiresIdle`] immediately when a model, tool, or
+    /// interrupt phase is active.
+    pub async fn save_session_to(&self, store: FileSessionStore) -> Result<(), InteractiveError> {
+        let (ack_sender, ack_receiver) = oneshot::channel();
+        self.command_sender
+            .send(InteractiveCommand::SaveSession { store, ack_sender })
             .await
             .map_err(|_| InteractiveError::CommandChannelClosed {
                 run_id: self.run_id,

--- a/crates/merry-runtime/src/interactive/types.rs
+++ b/crates/merry-runtime/src/interactive/types.rs
@@ -97,4 +97,6 @@ pub enum InteractiveError {
     },
     #[error("plan controls require an idle interactive boundary")]
     PlanControlRequiresIdle,
+    #[error("session save requires an idle interactive boundary")]
+    SessionSaveRequiresIdle,
 }

--- a/crates/merry-runtime/src/runtime.rs
+++ b/crates/merry-runtime/src/runtime.rs
@@ -215,7 +215,16 @@ impl Runtime {
 
     /// Saves the current resume-safe session state to the provided store.
     pub async fn save_session_to(&self, store: FileSessionStore) -> Result<(), RuntimeError> {
-        let _active_permit = self.acquire_active_step_permit()?;
+        let active_permit = self.acquire_active_step_permit()?;
+        self.save_session_to_with_active_permit(store, &active_permit)
+            .await
+    }
+
+    pub(crate) async fn save_session_to_with_active_permit(
+        &self,
+        store: FileSessionStore,
+        _active_permit: &ActiveStepPermit,
+    ) -> Result<(), RuntimeError> {
         let bundle = {
             let session = self.inner.session.lock().await;
             session.persistable_bundle()?

--- a/crates/merry-runtime/tests/interactive_agent_loop.rs
+++ b/crates/merry-runtime/tests/interactive_agent_loop.rs
@@ -13,12 +13,12 @@ use merry_llm::{
 };
 use merry_runtime::{
     AgentLoopConfig, AutomaticCompactionConfig, BeginPlanInput, ChildRuntimeFactory,
-    ChildRuntimeInput, CitationCompactionPolicy, InteractiveError, InteractivePrimaryModel,
-    InteractiveSettingsUpdate, InteractiveSubagentSettings, InterruptReason, PlanApprovalInput,
-    PlanChangeInput, PlanExecutionIntent, PlanNodeInput, ReportPlanAttemptInput, Runtime,
-    StepContext, SubagentConfig, SubagentManager, ToolExecutionContext, ToolExecutionError,
-    ToolExecutionOutcome, ToolExecutor, ToolExecutorFuture, UpdatePlanInput,
-    subagent_registered_tools,
+    ChildRuntimeInput, CitationCompactionPolicy, FileSessionStore, InteractiveError,
+    InteractivePrimaryModel, InteractiveSettingsUpdate, InteractiveSubagentSettings,
+    InterruptReason, PlanApprovalInput, PlanChangeInput, PlanExecutionIntent, PlanNodeInput,
+    ReportPlanAttemptInput, Runtime, SessionTranscriptItem, StepContext, SubagentConfig,
+    SubagentManager, ToolExecutionContext, ToolExecutionError, ToolExecutionOutcome, ToolExecutor,
+    ToolExecutorFuture, UpdatePlanInput, subagent_registered_tools,
 };
 use schemars::Schema;
 use serde_json::json;
@@ -568,6 +568,89 @@ async fn interactive_run_starts_waiting_for_input() {
 }
 
 #[tokio::test]
+async fn interactive_control_saves_at_a_waiting_boundary_without_closing_the_run() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = FileSessionStore::new(temp.path());
+    let id = session_id("interactive-save-waiting");
+    let runtime = Runtime::builder(id.clone())
+        .model_provider(Arc::new(RecordingProvider::new()), model_name())
+        .build()
+        .expect("runtime builds");
+    let run = runtime
+        .start_interactive_agent_run(
+            StepContext::new(CancellationToken::new()),
+            AgentLoopConfig::default(),
+        )
+        .expect("interactive run starts");
+    let (mut stream, input, control) = run.split();
+    assert!(matches!(
+        stream.next().await.expect("waiting state"),
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput
+        }
+    ));
+    input
+        .submit_next("persist this turn")
+        .await
+        .expect("input queued");
+    wait_for_interactive_waiting(&mut stream).await;
+
+    control
+        .save_session_to(store.clone())
+        .await
+        .expect("waiting save succeeds");
+    let resumed = Runtime::builder(id)
+        .resume_from_store_without_automatic_savepoints(store)
+        .await
+        .expect("saved session resumes");
+    assert_eq!(
+        resumed
+            .session_transcript()
+            .await
+            .expect("transcript reads"),
+        vec![
+            SessionTranscriptItem::UserMessage {
+                text: "persist this turn".to_owned(),
+                images: Vec::new(),
+            },
+            SessionTranscriptItem::AssistantText {
+                text: "done".to_owned(),
+            },
+        ]
+    );
+
+    control.close().await.expect("interactive run closes");
+    stream.wait_until_closed().await;
+}
+
+#[tokio::test]
+async fn interactive_control_returns_waiting_save_failures_through_the_ack() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let blocked_root = temp.path().join("not-a-directory");
+    std::fs::write(&blocked_root, "blocked").expect("blocking file");
+    let runtime = Runtime::builder(session_id("interactive-save-error"))
+        .build()
+        .expect("runtime builds");
+    let run = runtime
+        .start_interactive_agent_run(
+            StepContext::new(CancellationToken::new()),
+            AgentLoopConfig::default(),
+        )
+        .expect("interactive run starts");
+    let (mut stream, _input, control) = run.split();
+    let _ = stream.next().await.expect("waiting state");
+
+    let error = control
+        .save_session_to(FileSessionStore::new(blocked_root))
+        .await
+        .expect_err("write failure reaches the caller");
+    assert!(matches!(error, InteractiveError::Runtime { .. }));
+
+    control.close().await.expect("interactive run closes");
+    stream.wait_until_closed().await;
+}
+
+#[tokio::test]
 async fn interactive_plan_mode_control_commits_and_streams_the_plan_snapshot() {
     let runtime = Runtime::builder(session_id("interactive-enter-plan"))
         .build()
@@ -645,6 +728,12 @@ async fn interactive_plan_controls_reject_while_the_main_model_phase_is_running(
         .await
         .expect_err("running model phase rejects retry control");
     assert!(matches!(error, InteractiveError::PlanControlRequiresIdle));
+    let temp = tempfile::tempdir().expect("tempdir");
+    let error = control
+        .save_session_to(FileSessionStore::new(temp.path()))
+        .await
+        .expect_err("running model phase rejects session save");
+    assert!(matches!(error, InteractiveError::SessionSaveRequiresIdle));
     release_tx.send(()).expect("provider release succeeds");
 }
 

--- a/plans/2026-07-16-slash-commands-and-shared-input-history.md
+++ b/plans/2026-07-16-slash-commands-and-shared-input-history.md
@@ -1,0 +1,225 @@
+# Slash Commands And Shared Input History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete two sub-items of ROADMAP "TUI Daily Coding Flow #1": a slash command registry that also serves slash completion, and workspace-scoped persisted plain-text input history that survives resume and is shared across new/resumed sessions in the same workspace.
+
+**Architecture:** Slash commands are a static registry mapping each command name to an effect (`ControllerEffect` reuse or a timeline display), never a new execution subsystem. Slash completion plugs into the existing `CompletionSources` so the existing menu, navigation, and Tab-accept logic is reused. Input history stays workspace-scoped (keyed by a hash of the workspace root), persisted as JSONL under XDG state, and loaded into the existing in-memory `InputHistory` at startup. No runtime/core protocol changes; all work is in `merry-cli` TUI layer.
+
+**Tech Stack:** Rust 2024, Crossterm 0.29, Tokio, XDG state dir, serde_json (JSONL), existing `TuiPreferencesStore` atomic write pattern.
+
+---
+
+### Task 1: Slash Command Registry
+
+**Files:**
+- Create: `crates/merry-cli/src/tui/slash_command.rs`
+- Modify: `crates/merry-cli/src/tui/mod.rs`
+
+- [ ] **Step 1: Write failing registry tests**
+
+Assert `SLASH_COMMANDS` is non-empty, command names are unique, names carry no
+leading `/`, `find_exact("save")` returns the save spec, `find_prefix("sa")`
+returns only save, `find_prefix("")` returns all commands, and `find_exact`
+returns `None` for unknown names.
+
+- [ ] **Step 2: Add the registry module**
+
+Define an immutable `SlashCommandSpec { name, description, effect }` and a
+`SlashCommandEffect` enum with two variants: `ControllerEffect(&'static str)`
+(for save/stop) and `DisplayInTimeline` (for help/status). Provide
+`find_exact(name: &str) -> Option<&'static SlashCommandSpec>` and
+`find_prefix(query: &str) -> Vec<&'static SlashCommandSpec>`. Seed four commands:
+`help`, `status`, `save`, `stop`.
+
+- [ ] **Step 3: Register the module**
+
+Add `mod slash_command;` to `crates/merry-cli/src/tui/mod.rs` and re-export the
+query functions needed by completion and controller.
+
+- [ ] **Step 4: Run registry tests**
+
+```bash
+cargo test -p merry-cli --bin merry -- tui::slash_command -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 2: Slash Completion Source
+
+**Files:**
+- Modify: `crates/merry-cli/src/tui/completion.rs`
+- Test: `crates/merry-cli/src/tui/tests.rs`
+
+- [ ] **Step 1: Write failing completion tests**
+
+Cover: typing `/sa` yields a menu containing `/save`; typing `/` yields all four
+commands; typing `hello` (no leading slash) yields no slash items; typing
+`/xyz` yields an empty slash menu; existing path/skill completion still works
+for non-slash input.
+
+- [ ] **Step 2: Extend CompletionSources with a slash source**
+
+In `menu_for_input`, when the text starts with `/` and the cursor is on the
+first line, parse the command prefix after `/` and call
+`slash_command::find_prefix`. Map each result to a `CompletionItem` that renders
+with the leading `/`. Reuse the existing fuzzy/refresh path so navigation and
+Tab accept work unchanged.
+
+- [ ] **Step 3: Run completion tests**
+
+```bash
+cargo test -p merry-cli --bin merry -- tui::tests::completion -- --nocapture
+cargo test -p merry-cli --bin merry -- tui::tests::slash -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 3: Slash Command Dispatch
+
+**Files:**
+- Modify: `crates/merry-cli/src/tui/controller.rs`
+- Test: `crates/merry-cli/src/tui/tests.rs`
+
+- [ ] **Step 1: Write failing dispatch tests**
+
+Cover: submitting `/save` produces `ControllerEffect::SaveSession` and does not
+call `submit_next_message`; `/stop` produces `Interrupt`; `/help` pushes a
+timeline item without submitting; `/status` pushes a status summary; `/unknown`
+falls through to a normal `SubmitNext`; after any slash command the input box is
+cleared.
+
+- [ ] **Step 2: Intercept slash commands before submission**
+
+In the `SubmitNext(submission)` handling path, before calling
+`session.input.submit_next_message`, check whether `submission.text` exactly
+matches a registered slash command name (with leading `/`). If it matches:
+- for `ControllerEffect` variants, return the mapped effect and skip submission;
+- for `DisplayInTimeline`, push the rendered text to `TuiState.timeline` and
+  return `None`;
+- clear the input box in both cases.
+
+Only exact matches are intercepted; `save` without `/` is not intercepted.
+
+- [ ] **Step 3: Render help and status output**
+
+`/help` lists all slash commands plus a compact summary of keymap actions.
+`/status` assembles model label, usage, plan phase, run state, and workspace
+from existing `TuiState` fields; no new runtime queries.
+
+- [ ] **Step 4: Run dispatch tests**
+
+```bash
+cargo test -p merry-cli --bin merry -- tui::tests::slash_command -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 4: Workspace-Scoped Input History Store
+
+**Files:**
+- Create: `crates/merry-cli/src/tui/input_history_store.rs`
+- Modify: `crates/merry-cli/src/tui/mod.rs`
+
+- [ ] **Step 1: Write failing store tests**
+
+Cover: round-trip of three entries; empty file loads as empty Vec; a corrupted
+line is skipped while remaining lines load; a fully corrupted file loads as
+empty Vec without panic; two different workspace roots map to different paths
+and do not cross-contaminate; save is atomic (temp file plus rename).
+
+- [ ] **Step 2: Add the store module**
+
+Define `InputHistoryStore { path: PathBuf }` with:
+- `for_workspace(state_dir, workspace_root) -> Self`, where the file name is a
+  hex hash of the workspace root (sha2 first 16 bytes); never store the raw
+  path;
+- `load() -> Vec<String>` reading JSONL, skipping unparseable lines, returning
+  empty on missing/corrupt with `tracing::warn!`;
+- `save(&[String]) -> Result<(), InputHistoryError>` using the atomic temp +
+  rename pattern from `TuiPreferencesStore`.
+
+Path layout: `<state_dir>/merry/input-history/<hash>.jsonl`.
+
+- [ ] **Step 3: Register and run store tests**
+
+```bash
+cargo test -p merry-cli --bin merry -- tui::input_history_store -- --nocapture
+```
+
+Expected: PASS.
+
+### Task 5: Wire History Into TuiState And Lifecycle
+
+**Files:**
+- Modify: `crates/merry-cli/src/tui/state.rs`
+- Modify: `crates/merry-cli/src/tui/input.rs`
+- Modify: `crates/merry-cli/src/tui/controller.rs`
+- Modify: `crates/merry-cli/src/tui/mod.rs`
+
+- [ ] **Step 1: Add a save effect and store field**
+
+Add `ControllerEffect::SaveInputHistory` and an `input_history_store:
+Option<InputHistoryStore>` field on `TuiState`. Keep the existing in-memory
+`InputHistory` navigation logic unchanged.
+
+- [ ] **Step 2: Load history at startup**
+
+In `tui::run`, after constructing `TuiState`, build the store for the current
+workspace and load entries, then call `state.set_input_history(entries)`. Both
+new and resume paths load, because history is workspace-scoped.
+
+- [ ] **Step 3: Save only on successful submission**
+
+After a successful `SubmitNext` or `SubmitBacklog` in `dispatch_effect`, if the
+store is present, emit `SaveInputHistory` and persist `history.entries()`. Never
+save on keystroke or on slash command dispatch. Failures log a warning and do
+not block the user.
+
+- [ ] **Step 4: Expose entries for persistence**
+
+Add `InputHistory::entries() -> &[String]` so the controller can read the
+current history without disturbing navigation state.
+
+- [ ] **Step 5: Run lifecycle tests**
+
+```bash
+cargo test -p merry-cli --bin merry -- tui::tests::input_history -- --nocapture
+```
+
+Expected: existing `previous`/`next` tests still pass; new persistence tests
+pass.
+
+### Task 6: Full Verification
+
+**Files:**
+- Verify all touched files
+
+- [ ] **Step 1: Run targeted checks**
+
+```bash
+cargo fmt --all --check
+cargo test -p merry-cli --bin merry -- tui::slash_command tui::input_history_store -- --nocapture
+cargo test -p merry-cli --bin merry -- tui::tests -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full repository checks**
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+git diff --check
+```
+
+Expected: zero new failures beyond the three known pre-existing baseline
+failures (`subagent_with_narrow_tools_keeps_read_only_profile`, and the two
+`debug_shell` tests that require `rg`).
+
+- [ ] **Step 3: Manual interaction check**
+
+At 120x24 and 80x16: type `/`, confirm the menu lists four commands, accept a
+completion, run `/save` and `/stop`, confirm the input clears, and confirm the
+history file exists under the XDG state dir without leaking the raw workspace
+path.


### PR DESCRIPTION
## Summary
- Add a unified command registry (`command.rs` + `command_controller.rs`) that powers both the slash completion source and the existing command palette, with four first-class slash commands: `/help`, `/status`, `/save`, `/stop`.
- Add workspace-scoped persisted input history (`input_history_store.rs`) as JSONL keyed by a domain-separated SHA-256 hash of the workspace root; history survives resume and is shared across new/resumed sessions in the same workspace. Only plain text is persisted (no image attachments), with adjacent deduplication and a 200-entry cap.
- Extend the interactive runtime with an idle-boundary `save_session_to` command so `/save` cannot race an active model/tool step; session metadata writes are now atomic (temp + fsync + rename).
- Update ROADMAP to mark the slash-command and shared-input-history sub-items of TUI Daily Coding Flow as delivered.

## Tests
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p merry-cli --bin merry tui::
- cargo test -p merry-runtime --test interactive_agent_loop

Known: `cargo test --all` is still blocked by the pre-existing `subagent_with_narrow_tools_keeps_read_only_profile` mock-stream failure and the two `debug_shell` tests that require `rg` to be installed.