### PR TITLE
fix(cli): harden slash stop feedback

### DIFF
--- a/crates/merry-cli/Cargo.toml
+++ b/crates/merry-cli/Cargo.toml
@@ -16,7 +16,8 @@ merry-provider-openai = { path = "../merry-provider-openai" }
 merry-runtime = { path = "../merry-runtime" }
 merry-tool-workspace = { path = "../merry-tool-workspace" }
 pulldown-cmark.workspace = true
-ratatui.workspace = true
+# Paragraph::line_count keeps wrapped timeline viewport offsets exact.
+ratatui = { workspace = true, features = ["unstable-rendered-line-info"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/merry-cli/src/tui/command.rs
+++ b/crates/merry-cli/src/tui/command.rs
@@ -233,7 +233,7 @@ pub(crate) fn slash_help_body(keymap: &Keymap) -> String {
         .into_iter()
         .filter_map(|command| {
             Some(format!(
-                "/{:<8} {}",
+                "/{}  {}",
                 command.slash_name()?,
                 command.slash_description()?
             ))

--- a/crates/merry-cli/src/tui/command_controller.rs
+++ b/crates/merry-cli/src/tui/command_controller.rs
@@ -25,6 +25,7 @@ pub(crate) fn slash_input_effect(state: &mut TuiState) -> Option<ControllerEffec
                     "/{name} is not available. Type /help, or prefix the text with a space to send it."
                 )
             };
+            prepare_timeline_feedback(state);
             state.close_completion_menu();
             state.push_timeline_item(TimelineItem::Muted {
                 title: "Unknown command".to_owned(),
@@ -34,6 +35,7 @@ pub(crate) fn slash_input_effect(state: &mut TuiState) -> Option<ControllerEffec
         }
         SlashCommandMatch::ArgumentsNotSupported(name) => {
             let detail = format!("/{name} does not accept arguments.");
+            prepare_timeline_feedback(state);
             state.close_completion_menu();
             state.push_timeline_item(TimelineItem::Muted {
                 title: "Command not run".to_owned(),
@@ -63,18 +65,18 @@ pub(crate) fn run_palette_command(
             ControllerEffect::None
         }
         PaletteCommand::ShowHelp => {
+            prepare_timeline_feedback(state);
             let body = command::slash_help_body(state.keymap());
-            state.close_overlay();
-            state.push_timeline_item(TimelineItem::Expanded {
+            state.push_timeline_item(TimelineItem::LocalCommand {
                 title: "Command help".to_owned(),
                 body,
             });
             ControllerEffect::None
         }
         PaletteCommand::ShowStatus => {
+            prepare_timeline_feedback(state);
             let body = state.command_status_body();
-            state.close_overlay();
-            state.push_timeline_item(TimelineItem::Expanded {
+            state.push_timeline_item(TimelineItem::LocalCommand {
                 title: "Session status".to_owned(),
                 body,
             });
@@ -97,25 +99,17 @@ pub(crate) fn run_palette_command(
             handle_key_action(KeyAction::ReviewPreviousUserInput, state)
         }
         PaletteCommand::Interrupt => {
-            state.close_overlay();
+            prepare_timeline_feedback(state);
             if state.can_interrupt_run() {
-                state.set_run_state(merry_core::InteractiveRunState::Interrupting);
-                state.push_timeline_item(TimelineItem::Muted {
-                    title: "Stopping".to_owned(),
-                    detail: "Interrupt requested for the active run.".to_owned(),
-                });
+                state.begin_stop_feedback();
                 ControllerEffect::Interrupt
             } else if state.is_interrupting() {
-                state.push_timeline_item(TimelineItem::Muted {
-                    title: "Stop already requested".to_owned(),
-                    detail: "Waiting for the active run to reach a cancellation boundary."
-                        .to_owned(),
-                });
+                state.repeat_stop_feedback();
                 ControllerEffect::None
             } else {
-                state.push_timeline_item(TimelineItem::Muted {
+                state.push_timeline_item(TimelineItem::LocalCommand {
                     title: "Nothing to stop".to_owned(),
-                    detail: "No model or tool run is active.".to_owned(),
+                    body: "No model or tool run is active.".to_owned(),
                 });
                 ControllerEffect::None
             }
@@ -129,11 +123,11 @@ pub(crate) fn run_palette_command(
             handle_key_action(KeyAction::DiscardSuspended, state)
         }
         PaletteCommand::SaveSession => {
-            state.close_overlay();
+            prepare_timeline_feedback(state);
             if state.is_active_run() {
-                state.push_timeline_item(TimelineItem::Muted {
+                state.push_timeline_item(TimelineItem::LocalCommand {
                     title: "Save unavailable".to_owned(),
-                    detail: "Stop the active run before saving the session.".to_owned(),
+                    body: "Stop the active run before saving the session.".to_owned(),
                 });
                 ControllerEffect::None
             } else {
@@ -153,4 +147,10 @@ pub(crate) fn run_palette_command(
             ControllerEffect::Quit
         }
     }
+}
+
+fn prepare_timeline_feedback(state: &mut TuiState) {
+    state.close_overlay();
+    state.follow_latest();
+    state.plan_mut().leave_focus();
 }

--- a/crates/merry-cli/src/tui/controller.rs
+++ b/crates/merry-cli/src/tui/controller.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use crossterm::event::{KeyCode, KeyEvent};
 use futures_util::StreamExt;
-use merry_core::{InteractiveRunState, QueuedInputLane};
+use merry_core::QueuedInputLane;
 use merry_runtime::InterruptReason;
 use ratatui::layout::{Position, Rect, Size};
 use std::{collections::BTreeSet, time::Duration};
@@ -103,18 +103,8 @@ pub(crate) enum ControllerEffect {
 
 pub(crate) fn handle_key_action(action: KeyAction, state: &mut TuiState) -> ControllerEffect {
     match action {
-        KeyAction::SubmitNext => {
-            if exit_review_if_active(state) {
-                return ControllerEffect::None;
-            }
-            submit_input(state, ControllerEffect::SubmitNext)
-        }
-        KeyAction::SubmitBacklog => {
-            if exit_review_if_active(state) {
-                return ControllerEffect::None;
-            }
-            submit_input(state, ControllerEffect::SubmitBacklog)
-        }
+        KeyAction::SubmitNext => submit_input(state, ControllerEffect::SubmitNext),
+        KeyAction::SubmitBacklog => submit_input(state, ControllerEffect::SubmitBacklog),
         KeyAction::CancelInputOrQuit => {
             if state.cancel_input_or_mark_quit() {
                 ControllerEffect::Quit
@@ -136,8 +126,13 @@ pub(crate) fn handle_key_action(action: KeyAction, state: &mut TuiState) -> Cont
             ControllerEffect::None
         }
         KeyAction::Interrupt => {
-            if state.is_active_run() {
+            if state.can_interrupt_run() {
                 ControllerEffect::Interrupt
+            } else if state.is_interrupting() {
+                state.follow_latest();
+                state.plan_mut().leave_focus();
+                state.repeat_stop_feedback();
+                ControllerEffect::None
             } else if state.is_artifact_reviewing() {
                 state.exit_artifact_review();
                 ControllerEffect::None
@@ -192,7 +187,11 @@ fn submit_input(
     submit: impl FnOnce(TuiSubmission) -> ControllerEffect,
 ) -> ControllerEffect {
     if let Some(effect) = super::command_controller::slash_input_effect(state) {
+        exit_review_if_active(state);
         return effect;
+    }
+    if exit_review_if_active(state) {
+        return ControllerEffect::None;
     }
     state
         .take_input_for_submit()
@@ -716,9 +715,9 @@ async fn dispatch_effect(
         ControllerEffect::SaveSession => {
             session.set_title(state.latest_user_input_title());
             match session.save_now().await {
-                Ok(()) => state.push_timeline_item(TimelineItem::Muted {
+                Ok(()) => state.push_timeline_item(TimelineItem::LocalCommand {
                     title: "Session saved".to_owned(),
-                    detail: session.metadata.session_id.as_str().to_owned(),
+                    body: session.metadata.session_id.as_str().to_owned(),
                 }),
                 Err(error) => {
                     tracing::warn!(error = ?error, "explicit TUI session save failed");
@@ -1292,7 +1291,11 @@ pub(super) fn project_local_effect(effect: &ControllerEffect, state: &mut TuiSta
             state.push_local_user_echo(submission.text.clone(), QueuedInputLane::Backlog);
             state.project_local_run_start();
         }
-        ControllerEffect::Interrupt => state.set_run_state(InteractiveRunState::Interrupting),
+        ControllerEffect::Interrupt => {
+            state.follow_latest();
+            state.plan_mut().leave_focus();
+            state.begin_stop_feedback();
+        }
         ControllerEffect::PersistPreferences(_)
         | ControllerEffect::ApplyRuntimePreferences(_)
         | ControllerEffect::OpenProviderManager

--- a/crates/merry-cli/src/tui/mod.rs
+++ b/crates/merry-cli/src/tui/mod.rs
@@ -63,6 +63,8 @@ mod history_tests;
 #[cfg(test)]
 mod plan_tests;
 #[cfg(test)]
+mod slash_stop_tests;
+#[cfg(test)]
 mod slash_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/merry-cli/src/tui/panels.rs
+++ b/crates/merry-cli/src/tui/panels.rs
@@ -97,7 +97,9 @@ fn focus_view_for_item(item: &TimelineItem) -> FocusPanelView {
             },
             tone: FocusPanelTone::Default,
         },
-        TimelineItem::User { .. } | TimelineItem::Assistant { .. } => FocusPanelView {
+        TimelineItem::LocalCommand { .. }
+        | TimelineItem::User { .. }
+        | TimelineItem::Assistant { .. } => FocusPanelView {
             title: "FOCUS".to_owned(),
             body: FocusPanelBody::Empty,
             tone: FocusPanelTone::Default,

--- a/crates/merry-cli/src/tui/projector.rs
+++ b/crates/merry-cli/src/tui/projector.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use crate::tool_display::format_tool_call_detail;
 use merry_core::{
-    PlanAttemptOutcome, PlanDirectiveStatus, PlanPhase, RuntimeEvent, ToolCallId,
-    ToolCallResultStatus, ToolName, ToolOutput,
+    PlanAttemptOutcome, PlanDirectiveStatus, PlanPhase, RuntimeEvent, TOOL_CANCELLED_BY_USER_CODE,
+    ToolCallId, ToolCallResultStatus, ToolName, ToolOutput,
 };
 use merry_runtime::SessionTranscriptItem;
 use merry_tool_workspace::WORKSPACE_PATCH_TOOL;
@@ -141,8 +141,24 @@ impl TuiProjector {
             RuntimeEvent::ToolCallFinished { result, output, .. } => {
                 let text = tool_output_text(output);
                 let tool = self.started_tools.remove(result.call_id());
+                let cancelled_by_user = result
+                    .diagnostic()
+                    .is_some_and(|diagnostic| diagnostic.code() == TOOL_CANCELLED_BY_USER_CODE);
                 let failed = result.status() == ToolCallResultStatus::Failed;
-                if failed {
+                if cancelled_by_user {
+                    let item = TimelineItem::Muted {
+                        title: tool.as_ref().map_or_else(
+                            || "Tool -> cancelled".to_owned(),
+                            |tool| completed_tool_title(tool, "cancelled"),
+                        ),
+                        detail: "cancelled by user".to_owned(),
+                    };
+                    if let Some(tool) = tool.as_ref() {
+                        state.replace_timeline_item(tool.timeline_index, item);
+                    } else {
+                        state.push_timeline_item(item);
+                    }
+                } else if failed {
                     let body = failed_tool_body(
                         result.diagnostic(),
                         tool.as_ref().map(|tool| tool.name.as_str()),
@@ -325,21 +341,24 @@ impl TuiProjector {
             }
             RuntimeEvent::RunCancelled { diagnostic, .. } => {
                 self.streaming_assistant_index = None;
-                let item = if self.compaction_timeline_index.is_some() {
-                    TimelineItem::Muted {
-                        title: "Compaction cancelled".to_owned(),
-                        detail: diagnostic.message().to_owned(),
-                    }
+                let had_compaction = if let Some(index) = self.compaction_timeline_index.take() {
+                    state.replace_timeline_item(
+                        index,
+                        TimelineItem::Muted {
+                            title: "Compaction cancelled".to_owned(),
+                            detail: diagnostic.message().to_owned(),
+                        },
+                    );
+                    true
                 } else {
-                    TimelineItem::Diagnostic {
+                    false
+                };
+                let completed_stop = state.complete_stop_feedback();
+                if !had_compaction && !completed_stop {
+                    state.push_timeline_item(TimelineItem::Diagnostic {
                         title: diagnostic.code().to_owned(),
                         body: diagnostic.message().to_owned(),
-                    }
-                };
-                if let Some(index) = self.compaction_timeline_index.take() {
-                    state.replace_timeline_item(index, item);
-                } else {
-                    state.push_timeline_item(item);
+                    });
                 }
             }
             RuntimeEvent::Closed => {

--- a/crates/merry-cli/src/tui/render.rs
+++ b/crates/merry-cli/src/tui/render.rs
@@ -23,6 +23,8 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const QUEUE_PREVIEW_HEIGHT: u16 = 5;
 const MAX_COMPLETION_PREVIEW_HEIGHT: u16 = 6;
+// Keep prefix eviction below the viewport start when Paragraph scroll exceeds u16.
+const MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES: usize = 32_768;
 const MAX_INPUT_VISIBLE_ROWS: usize = 5;
 pub(crate) const STATUS_HEIGHT: u16 = 1;
 const HEADER_HEIGHT: u16 = 1;
@@ -173,9 +175,12 @@ fn header_background_style(state: &TuiState) -> Style {
 }
 
 fn render_timeline_pane(frame: &mut Frame<'_>, state: &TuiState, region: Rect) {
+    let timeline = timeline_lines_compact(state, region);
+    let viewport = timeline_viewport(state, timeline, region);
     frame.render_widget(
-        Paragraph::new(timeline_lines_compact(state, region))
+        Paragraph::new(viewport.lines)
             .wrap(Wrap { trim: false })
+            .scroll((viewport.scroll, 0))
             .block(
                 Block::default()
                     .borders(Borders::BOTTOM)
@@ -520,17 +525,30 @@ fn desired_input_region_height(state: &TuiState, max_rows: usize) -> u16 {
         .saturating_add(2)
 }
 
-fn timeline_lines_compact(state: &TuiState, region: Rect) -> Vec<Line<'static>> {
-    let mut user_line_indexes = Vec::new();
+struct TimelineLines {
+    lines: Vec<Line<'static>>,
+    review_logical_start: Option<usize>,
+}
+
+struct TimelineViewport {
+    lines: Vec<Line<'static>>,
+    scroll: u16,
+}
+
+fn timeline_lines_compact(state: &TuiState, region: Rect) -> TimelineLines {
     let mut lines = Vec::new();
+    let mut review_logical_start = None;
     for (index, item) in state.timeline().iter().enumerate() {
-        if matches!(item, TimelineItem::User { .. }) {
-            user_line_indexes.push((index, lines.len()));
+        if state.timeline_review_user_index() == Some(index) {
+            review_logical_start = Some(lines.len());
         }
         let item_lines = match item {
             TimelineItem::User { text, lane } => user_lines(state, text, *lane),
             TimelineItem::Assistant { text } => assistant_lines(state, text, region.width),
             TimelineItem::Muted { title, detail } => muted_lines(state, title, detail),
+            TimelineItem::LocalCommand { title, body } => {
+                local_command_lines(state, title, body, region.width)
+            }
             TimelineItem::Expanded { title, body }
             | TimelineItem::ExpandedDetail { title, body, .. } => {
                 expanded_timeline_lines(state, title, body, region.width)
@@ -540,39 +558,114 @@ fn timeline_lines_compact(state: &TuiState, region: Rect) -> Vec<Line<'static>> 
             }
             TimelineItem::Patch { changes } => compact_patch_lines(state, changes),
         };
+        let item_lines = item_lines
+            .into_iter()
+            .flat_map(split_oversized_timeline_line)
+            .collect();
         lines.extend(spaced_timeline_item(
             item_lines,
             index + 1 < state.timeline().len(),
         ));
     }
-    let visible_height = usize::from(region.height).saturating_sub(1).max(1);
-    let (start, take) = timeline_viewport(state, &lines, &user_line_indexes, visible_height);
-    lines.into_iter().skip(start).take(take).collect()
+    TimelineLines {
+        lines,
+        review_logical_start,
+    }
 }
 
-fn timeline_viewport(
-    state: &TuiState,
-    lines: &[Line<'static>],
-    user_line_indexes: &[(usize, usize)],
-    visible_height: usize,
-) -> (usize, usize) {
-    if let Some(target_index) = state.timeline_review_user_index()
-        && let Some((_, start)) = user_line_indexes
-            .iter()
-            .find(|(item_index, _)| *item_index == target_index)
-    {
-        let start = (*start).min(lines.len());
-        let end = start.saturating_add(visible_height).min(lines.len());
-        return (start, end.saturating_sub(start));
+fn timeline_viewport(state: &TuiState, timeline: TimelineLines, region: Rect) -> TimelineViewport {
+    let mut scroll = timeline_scroll_start(state, &timeline, region);
+    let mut lines = timeline.lines;
+    let max_scroll = usize::from(u16::MAX);
+    if scroll > max_scroll {
+        // Paragraph scroll is u16; remove complete prefix lines in one linear pass.
+        let rows_to_drop = scroll - max_scroll;
+        let mut dropped_lines = 0;
+        let mut dropped_rows = 0;
+        for line in &lines {
+            if dropped_rows >= rows_to_drop {
+                break;
+            }
+            dropped_rows += wrapped_line_count(std::slice::from_ref(line), region.width).max(1);
+            dropped_lines += 1;
+        }
+        if dropped_lines > 0 {
+            lines.drain(..dropped_lines);
+            scroll = scroll.saturating_sub(dropped_rows);
+        }
     }
 
-    let end = lines
-        .len()
-        .saturating_sub(state.timeline_scroll_offset())
-        .max(visible_height)
-        .min(lines.len());
-    let start = end.saturating_sub(visible_height);
-    (start, end.saturating_sub(start))
+    TimelineViewport {
+        lines,
+        scroll: u16::try_from(scroll).unwrap_or(u16::MAX),
+    }
+}
+
+fn timeline_scroll_start(state: &TuiState, timeline: &TimelineLines, region: Rect) -> usize {
+    if let Some(logical_start) = timeline.review_logical_start {
+        wrapped_line_count(&timeline.lines[..logical_start], region.width)
+    } else {
+        let total = wrapped_line_count(&timeline.lines, region.width);
+        let visible = usize::from(region.height.saturating_sub(1));
+        total
+            .saturating_sub(visible)
+            .saturating_sub(state.timeline_scroll_offset())
+    }
+}
+
+fn wrapped_line_count(lines: &[Line<'static>], width: u16) -> usize {
+    Paragraph::new(lines.to_vec())
+        .wrap(Wrap { trim: false })
+        .line_count(width)
+}
+
+fn split_oversized_timeline_line(line: Line<'static>) -> Vec<Line<'static>> {
+    let byte_len = line.spans.iter().fold(0_usize, |total, span| {
+        total.saturating_add(span.content.len())
+    });
+    if byte_len <= MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES {
+        return vec![line];
+    }
+
+    let Line {
+        style,
+        alignment,
+        spans,
+    } = line;
+    let mut lines = Vec::new();
+    let mut current_spans = Vec::new();
+    let mut current_graphemes = 0;
+
+    for span in spans {
+        let mut chunk = String::new();
+        for grapheme in span.styled_graphemes(Style::default()) {
+            if current_graphemes == MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES {
+                if !chunk.is_empty() {
+                    current_spans.push(Span::styled(std::mem::take(&mut chunk), span.style));
+                }
+                lines.push(Line {
+                    style,
+                    alignment,
+                    spans: std::mem::take(&mut current_spans),
+                });
+                current_graphemes = 0;
+            }
+            chunk.push_str(grapheme.symbol);
+            current_graphemes += 1;
+        }
+        if !chunk.is_empty() {
+            current_spans.push(Span::styled(chunk, span.style));
+        }
+    }
+
+    if !current_spans.is_empty() || lines.is_empty() {
+        lines.push(Line {
+            style,
+            alignment,
+            spans: current_spans,
+        });
+    }
+    lines
 }
 
 fn spaced_timeline_item(mut lines: Vec<Line<'static>>, has_next_item: bool) -> Vec<Line<'static>> {
@@ -656,6 +749,29 @@ fn expanded_title_line(state: &TuiState, title: &str) -> Line<'static> {
         title.to_owned(),
         semantic_style(state, SemanticColor::Focus),
     ))
+}
+
+fn local_command_lines(
+    state: &TuiState,
+    title: &str,
+    body: &str,
+    region_width: u16,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        title.to_owned(),
+        semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD),
+    ))];
+    let body_width = region_width.saturating_sub(2).max(1);
+    lines.extend(
+        markdown_lines(state, body, body_width)
+            .into_iter()
+            .map(|line| {
+                let mut spans = vec![Span::raw("  ")];
+                spans.extend(line.spans);
+                Line::from(spans)
+            }),
+    );
+    lines
 }
 
 fn expanded_timeline_lines(

--- a/crates/merry-cli/src/tui/slash_stop_tests.rs
+++ b/crates/merry-cli/src/tui/slash_stop_tests.rs
@@ -1,0 +1,417 @@
+use super::{
+    controller::{ControllerEffect, handle_key_action, project_local_effect},
+    keymap::{KeyAction, Keymap},
+    projector::TuiProjector,
+    render,
+    state::{TimelineItem, TuiState},
+    theme::TuiTheme,
+};
+use merry_core::{
+    ArtifactId, ArtifactKind, ArtifactRef, ErrorInfo, InteractiveRunState, PendingToolCall,
+    QueuedInputLane, QueuedInputView, RuntimeEvent, RuntimeEventSource, SessionId,
+    TOOL_CANCELLED_BY_USER_CODE, ToolCallArguments, ToolCallId, ToolCallResult, ToolName,
+    ToolOutput,
+};
+
+fn state() -> TuiState {
+    TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    )
+}
+
+fn runtime_source() -> RuntimeEventSource {
+    RuntimeEventSource::new(SessionId::new("slash-stop-test").expect("session id"), 1)
+}
+
+fn run_cancelled_event() -> RuntimeEvent {
+    RuntimeEvent::RunCancelled {
+        diagnostic: ErrorInfo::new("cancelled", "runtime step cancelled")
+            .expect("valid diagnostic"),
+        source: runtime_source(),
+    }
+}
+
+fn pending_tool_call(id: &str) -> PendingToolCall {
+    PendingToolCall::new(
+        ToolCallId::new(id).expect("tool call id"),
+        ToolName::new("workspace_search_text").expect("tool name"),
+        ToolCallArguments::new(Default::default()),
+    )
+}
+
+fn tool_cancelled_event(id: &str) -> RuntimeEvent {
+    let artifact_id = format!("{id}-cancelled");
+    let diagnostic_message = format!("tool call {id} was cancelled by user interrupt");
+    RuntimeEvent::ToolCallFinished {
+        result: ToolCallResult::failed(
+            ToolCallId::new(id).expect("tool call id"),
+            ArtifactRef::new(
+                ArtifactId::new(&artifact_id).expect("artifact id"),
+                ArtifactKind::Text,
+            ),
+            ErrorInfo::new(TOOL_CANCELLED_BY_USER_CODE, &diagnostic_message)
+                .expect("cancellation diagnostic"),
+        ),
+        output: Some(ToolOutput::Text {
+            text: "Tool execution was cancelled by user interrupt.".to_owned(),
+        }),
+        source: runtime_source(),
+    }
+}
+
+#[test]
+fn tool_cancellation_finishes_stop_without_reporting_an_error() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    state.set_run_state(InteractiveRunState::RunningTool);
+    projector.apply(
+        RuntimeEvent::ToolCallStarted {
+            call: pending_tool_call("call-cancelled"),
+            source: runtime_source(),
+        },
+        &mut state,
+    );
+
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::Interrupt
+    );
+    projector.apply(tool_cancelled_event("call-cancelled"), &mut state);
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput,
+        },
+        &mut state,
+    );
+
+    assert!(matches!(
+        state.timeline().first(),
+        Some(TimelineItem::Muted { title, detail })
+            if title.ends_with("-> cancelled") && detail == "cancelled by user"
+    ));
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Run stopped"
+    ));
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::LocalCommand { title, .. } if title == "Run stopped"
+            ))
+            .count(),
+        1
+    );
+    assert!(
+        state
+            .timeline()
+            .iter()
+            .all(|item| !matches!(item, TimelineItem::Diagnostic { .. }))
+    );
+}
+
+#[test]
+fn batched_tool_cancellation_completes_stop_feedback_once() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    state.set_run_state(InteractiveRunState::RunningTool);
+    for id in ["call-one", "call-two"] {
+        projector.apply(
+            RuntimeEvent::ToolCallStarted {
+                call: pending_tool_call(id),
+                source: runtime_source(),
+            },
+            &mut state,
+        );
+    }
+
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::Interrupt
+    );
+    projector.apply(tool_cancelled_event("call-one"), &mut state);
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Stopping"
+    ));
+    assert!(state.timeline().iter().all(|item| !matches!(
+        item,
+        TimelineItem::LocalCommand { title, .. } if title == "Run stopped"
+    )));
+    projector.apply(tool_cancelled_event("call-two"), &mut state);
+    assert!(state.timeline().iter().all(|item| !matches!(
+        item,
+        TimelineItem::LocalCommand { title, .. } if title == "Run stopped"
+    )));
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput,
+        },
+        &mut state,
+    );
+
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::Muted { title, .. } if title.ends_with("-> cancelled")
+            ))
+            .count(),
+        2
+    );
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::LocalCommand { title, .. } if title == "Run stopped"
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn compaction_cancellation_finishes_both_progress_and_stop_feedback() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    state.set_run_state(InteractiveRunState::RunningModel);
+    projector.apply(
+        RuntimeEvent::CompactionStarted {
+            source: runtime_source(),
+        },
+        &mut state,
+    );
+
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::Interrupt
+    );
+    projector.apply(run_cancelled_event(), &mut state);
+
+    assert!(matches!(
+        state.timeline().first(),
+        Some(TimelineItem::Muted { title, .. }) if title == "Compaction cancelled"
+    ));
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Run stopped"
+    ));
+    assert!(state.timeline().iter().all(|item| !matches!(
+        item,
+        TimelineItem::LocalCommand { title, .. }
+            if matches!(title.as_str(), "Stopping" | "Stop already requested")
+    )));
+}
+
+#[test]
+fn interleaved_stop_feedback_stays_chronological_and_finishes_latest() {
+    let mut state = state();
+    state.set_run_state(InteractiveRunState::RunningModel);
+
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::Interrupt
+    );
+    state.insert_input_str("/status");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::None
+    );
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::None
+    );
+    TuiProjector::default().apply(run_cancelled_event(), &mut state);
+
+    assert!(matches!(
+        state.timeline().first(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Stop requested"
+    ));
+    assert!(matches!(
+        state.timeline().get(1),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Session status"
+    ));
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Run stopped"
+    ));
+    assert!(state.timeline().iter().all(|item| !matches!(
+        item,
+        TimelineItem::LocalCommand { title, .. }
+            if matches!(title.as_str(), "Stopping" | "Stop already requested")
+    )));
+}
+
+#[test]
+fn waiting_state_is_a_stop_completion_fallback_without_duplicates() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    state.set_run_state(InteractiveRunState::RunningModel);
+    state.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::Interrupt
+    );
+
+    for _ in 0..2 {
+        projector.apply(
+            RuntimeEvent::InteractiveRunStateChanged {
+                state: InteractiveRunState::WaitingForInput,
+            },
+            &mut state,
+        );
+    }
+
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Run stopped"
+    ));
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::LocalCommand { title, .. } if title == "Run stopped"
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn slash_stop_feedback_is_idempotent_when_the_effect_is_locally_projected() {
+    let mut state = state();
+    state.set_run_state(InteractiveRunState::RunningModel);
+    state.insert_input_str("/stop");
+
+    let stop = handle_key_action(KeyAction::SubmitNext, &mut state);
+    assert_eq!(stop, ControllerEffect::Interrupt);
+    assert!(matches!(
+        state.timeline(),
+        [TimelineItem::LocalCommand { title, .. }] if title == "Stopping"
+    ));
+
+    project_local_effect(&stop, &mut state);
+
+    assert!(matches!(
+        state.timeline(),
+        [TimelineItem::LocalCommand { title, .. }] if title == "Stopping"
+    ));
+}
+
+#[test]
+fn stale_waiting_does_not_complete_stop_for_a_pending_local_run() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    state.insert_input_str("start work");
+    let submit = handle_key_action(KeyAction::SubmitNext, &mut state);
+    assert!(matches!(submit, ControllerEffect::SubmitNext(_)));
+    project_local_effect(&submit, &mut state);
+
+    state.insert_input_str("/stop");
+    let stop = handle_key_action(KeyAction::SubmitNext, &mut state);
+    assert_eq!(stop, ControllerEffect::Interrupt);
+    project_local_effect(&stop, &mut state);
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::WaitingForInput,
+        },
+        &mut state,
+    );
+
+    assert!(state.is_interrupting());
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Stopping"
+    ));
+
+    projector.apply(
+        RuntimeEvent::QueuedInputAccepted {
+            lane: QueuedInputLane::Next,
+            inputs: vec![QueuedInputView {
+                text: "start work".to_owned(),
+                lane: QueuedInputLane::Next,
+                position: 0,
+            }],
+        },
+        &mut state,
+    );
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::RunningModel,
+        },
+        &mut state,
+    );
+    projector.apply(
+        RuntimeEvent::InteractiveRunStateChanged {
+            state: InteractiveRunState::Interrupting,
+        },
+        &mut state,
+    );
+    projector.apply(run_cancelled_event(), &mut state);
+
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Run stopped"
+    ));
+    assert_eq!(
+        state
+            .timeline()
+            .iter()
+            .filter(|item| matches!(
+                item,
+                TimelineItem::LocalCommand { title, .. } if title == "Run stopped"
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn timeline_beyond_u16_scroll_limit_still_shows_latest_command_feedback() {
+    let mut state = state();
+    for _ in 0..33_000 {
+        state.push_timeline_item(TimelineItem::Muted {
+            title: "Earlier event".to_owned(),
+            detail: "completed".to_owned(),
+        });
+    }
+    state.insert_input_str("/help");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut state),
+        ControllerEffect::None
+    );
+
+    let rendered = render::render_to_text(&state, 80, 16);
+    assert!(rendered.contains("Command help"));
+    assert!(rendered.contains("/stop"));
+}
+
+#[test]
+fn single_wrapped_line_beyond_u16_scroll_limit_keeps_its_tail_visible() {
+    let mut state = state();
+    let mut text = "x".repeat(1_400_000);
+    text.push_str("TAIL_SENTINEL");
+    state.push_timeline_item(TimelineItem::User {
+        text,
+        lane: QueuedInputLane::Next,
+    });
+
+    let rendered = render::render_to_text(&state, 20, 12);
+    assert!(rendered.contains("TAIL_SENTINEL"), "{rendered}");
+}

--- a/crates/merry-cli/src/tui/slash_tests.rs
+++ b/crates/merry-cli/src/tui/slash_tests.rs
@@ -1,5 +1,6 @@
 use super::{
     command::PaletteCommand,
+    command_controller::run_palette_command,
     completion::{CompletionKind, CompletionSources},
     controller::{ControllerEffect, handle_key_action, handle_key_event, project_local_effect},
     input::{DraftImage, TuiSubmission},
@@ -11,7 +12,10 @@ use super::{
     theme::TuiTheme,
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use merry_core::{InteractiveRunState, QueuedInputLane, QueuedInputView, RuntimeEvent};
+use merry_core::{
+    ErrorInfo, InteractiveRunState, QueuedInputLane, QueuedInputView, RuntimeEvent,
+    RuntimeEventSource, SessionId,
+};
 use ratatui::{Terminal, backend::TestBackend};
 use std::sync::Arc;
 
@@ -39,6 +43,54 @@ fn draft_image() -> DraftImage {
         3,
     )
     .expect("valid draft image")
+}
+
+fn plan_snapshot() -> merry_core::PlanSnapshot {
+    merry_core::PlanSnapshot {
+        plan_id: merry_core::PlanId::new("slash-test-plan").expect("plan id"),
+        revision: 1,
+        phase: merry_core::PlanPhase::Executing,
+        activation_source: merry_core::PlanActivationSource::User,
+        root_node_id: None,
+        coordinator_node_id: None,
+        execution_contract_fingerprint: None,
+        execution_authorization_refs: Vec::new(),
+        authorized_capability_envelope: None,
+        approval_requirements: Vec::new(),
+        nodes: Vec::new(),
+        attempts: Vec::new(),
+        leases: Vec::new(),
+        attempt_progress: Vec::new(),
+        directives: Vec::new(),
+        resource_policy_snapshot: merry_core::PlanResourcePolicySnapshot::default(),
+        max_concurrency_hint: None,
+        scheduler_status: merry_core::PlanSchedulerStatus::Active,
+        revision_summaries: Vec::new(),
+    }
+}
+
+fn assert_timeline_feedback(state: &TuiState, expected: &[&str]) {
+    for (width, height) in [(50, 20), (80, 16), (120, 24)] {
+        let rendered = render::render_to_text(state, width, height);
+        for value in expected {
+            assert!(
+                rendered.contains(value),
+                "{value:?} should render at {width}x{height}:\n{rendered}"
+            );
+        }
+    }
+}
+
+fn run_cancelled_event() -> RuntimeEvent {
+    RuntimeEvent::RunCancelled {
+        diagnostic: ErrorInfo::new("cancelled", "runtime step cancelled")
+            .expect("valid diagnostic"),
+        source: runtime_source(),
+    }
+}
+
+fn runtime_source() -> RuntimeEventSource {
+    RuntimeEventSource::new(SessionId::new("slash-stop-test").expect("session id"), 1)
 }
 
 #[test]
@@ -161,9 +213,10 @@ fn local_slash_commands_do_not_enter_user_history_or_either_runtime_lane() {
     );
     assert_eq!(help.input_text(), "");
     assert!(help.input_history_entries().is_empty());
+    assert!(help.artifact_timeline_indexes().is_empty());
     assert!(matches!(
         help.timeline().last(),
-        Some(TimelineItem::Expanded { title, body })
+        Some(TimelineItem::LocalCommand { title, body })
             if title == "Command help" && body.contains("/status")
     ));
 
@@ -175,18 +228,317 @@ fn local_slash_commands_do_not_enter_user_history_or_either_runtime_lane() {
     );
     assert!(matches!(
         status.timeline().last(),
-        Some(TimelineItem::Expanded { title, body })
+        Some(TimelineItem::LocalCommand { title, body })
             if title == "Session status"
                 && body.contains("Run: ready")
                 && body.contains("Plan: none")
                 && body.contains("Workspace: /repo")
     ));
+    assert!(status.artifact_timeline_indexes().is_empty());
     assert!(
         status
             .timeline()
             .iter()
             .all(|item| !matches!(item, TimelineItem::User { .. }))
     );
+}
+
+#[test]
+fn help_and_status_render_complete_bodies_at_supported_terminal_sizes() {
+    for (width, height) in [(50, 20), (80, 16), (80, 24), (120, 24), (120, 36)] {
+        let mut help = state();
+        help.insert_input_str("/help");
+        assert_eq!(
+            handle_key_action(KeyAction::SubmitNext, &mut help),
+            ControllerEffect::None
+        );
+        let help_text = render::render_to_text(&help, width, height);
+        for expected in [
+            "Command help",
+            "/help",
+            "/save",
+            "/status",
+            "/stop",
+            "List slash commands",
+            "Submit",
+            "Backlog",
+            "Commands",
+        ] {
+            assert!(
+                help_text.contains(expected),
+                "{expected:?} should render at {width}x{height}:\n{help_text}"
+            );
+        }
+
+        let mut status = state();
+        status.insert_input_str("/status");
+        assert_eq!(
+            handle_key_action(KeyAction::SubmitNext, &mut status),
+            ControllerEffect::None
+        );
+        let status_text = render::render_to_text(&status, width, height);
+        for expected in [
+            "Session status",
+            "Run: ready",
+            "Model: gpt-test",
+            "Usage:",
+            "Plan: none",
+            "Workspace: /repo",
+        ] {
+            assert!(
+                status_text.contains(expected),
+                "{expected:?} should render at {width}x{height}:\n{status_text}"
+            );
+        }
+    }
+}
+
+#[test]
+fn status_reports_every_runtime_state_and_the_current_plan_phase() {
+    for (run_state, expected) in [
+        (InteractiveRunState::WaitingForInput, "Run: ready"),
+        (InteractiveRunState::RunningModel, "Run: running model"),
+        (InteractiveRunState::RunningTool, "Run: running tool"),
+        (InteractiveRunState::Interrupting, "Run: interrupting"),
+        (InteractiveRunState::Closed, "Run: closed"),
+    ] {
+        let mut state = state();
+        state.plan_mut().update_snapshot(plan_snapshot());
+        state.set_run_state(run_state);
+
+        assert_eq!(
+            run_palette_command(PaletteCommand::ShowStatus, &mut state),
+            ControllerEffect::None
+        );
+        assert!(matches!(
+            state.timeline().last(),
+            Some(TimelineItem::LocalCommand { body, .. })
+                if body.contains(expected) && body.contains("Plan: executing")
+        ));
+    }
+}
+
+#[test]
+fn palette_slash_commands_reveal_feedback_from_detail_and_plan_focus() {
+    for (width, height) in [(50, 20), (80, 16), (120, 24)] {
+        for (command, run_state, effect, expected) in [
+            (
+                PaletteCommand::ShowHelp,
+                InteractiveRunState::WaitingForInput,
+                ControllerEffect::None,
+                "Commands",
+            ),
+            (
+                PaletteCommand::ShowStatus,
+                InteractiveRunState::WaitingForInput,
+                ControllerEffect::None,
+                "Workspace: /repo",
+            ),
+            (
+                PaletteCommand::Interrupt,
+                InteractiveRunState::RunningModel,
+                ControllerEffect::Interrupt,
+                "Interrupt requested",
+            ),
+            (
+                PaletteCommand::SaveSession,
+                InteractiveRunState::RunningTool,
+                ControllerEffect::None,
+                "Stop the active run",
+            ),
+        ] {
+            let mut state = state();
+            state.push_timeline_item(TimelineItem::Expanded {
+                title: "Previous artifact".to_owned(),
+                body: "old output".to_owned(),
+            });
+            state.select_previous_artifact();
+            state.plan_mut().update_snapshot(plan_snapshot());
+            assert!(state.plan_mut().open_and_focus());
+            state.set_run_state(run_state);
+
+            assert!(state.is_artifact_reviewing());
+            assert!(state.plan().is_focused());
+            assert_eq!(run_palette_command(command, &mut state), effect);
+            assert!(!state.is_artifact_reviewing());
+            assert!(state.plan().is_open());
+            assert!(!state.plan().is_focused());
+
+            let rendered = render::render_to_text(&state, width, height);
+            assert!(
+                rendered.contains(expected),
+                "{expected:?} should render for {command:?} at {width}x{height}:\n{rendered}"
+            );
+        }
+    }
+}
+
+#[test]
+fn invalid_slash_feedback_is_visible_from_plan_focus_and_remains_correctable() {
+    for (input, expected) in [
+        ("/unknown", "Unknown command"),
+        ("/help now", "Command not run"),
+    ] {
+        let mut state = state();
+        state.plan_mut().update_snapshot(plan_snapshot());
+        assert!(state.plan_mut().open_and_focus());
+        state.insert_input_str(input);
+
+        assert_eq!(
+            handle_key_action(KeyAction::SubmitNext, &mut state),
+            ControllerEffect::None
+        );
+        assert!(state.plan().is_open());
+        assert!(!state.plan().is_focused());
+        assert_eq!(state.input_text(), input);
+        assert!(render::render_to_text(&state, 80, 16).contains(expected));
+    }
+}
+
+#[test]
+fn help_remains_complete_with_the_plan_open_at_80_by_16() {
+    let mut state = state();
+    state.plan_mut().update_snapshot(plan_snapshot());
+    assert!(state.plan_mut().open_and_focus());
+
+    assert_eq!(
+        run_palette_command(PaletteCommand::ShowHelp, &mut state),
+        ControllerEffect::None
+    );
+
+    let rendered = render::render_to_text(&state, 80, 16);
+    for expected in [
+        "Command help",
+        "/help",
+        "/save",
+        "/status",
+        "/stop",
+        "Submit",
+        "Backlog",
+        "Commands",
+        "Stop",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "{expected:?} should render with Plan open at 80x16:\n{rendered}"
+        );
+    }
+    assert!(state.plan().is_open());
+    assert!(!state.plan().is_focused());
+}
+
+#[test]
+fn local_slash_input_bypasses_review_confirmation_but_provider_input_does_not() {
+    let mut timeline_review = state();
+    timeline_review.push_timeline_item(TimelineItem::User {
+        text: "earlier request".to_owned(),
+        lane: QueuedInputLane::Next,
+    });
+    timeline_review.jump_to_previous_user_input();
+    timeline_review.insert_input_str("/help");
+
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut timeline_review),
+        ControllerEffect::None
+    );
+    assert!(!timeline_review.is_timeline_reviewing());
+    assert_eq!(timeline_review.input_text(), "");
+    assert!(matches!(
+        timeline_review.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Command help"
+    ));
+
+    let mut artifact_review = state();
+    artifact_review.push_timeline_item(TimelineItem::Expanded {
+        title: "Previous artifact".to_owned(),
+        body: "old output".to_owned(),
+    });
+    artifact_review.select_previous_artifact();
+    artifact_review.insert_input_str("/sa");
+
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut artifact_review,
+        ),
+        ControllerEffect::SaveSession
+    );
+    assert!(!artifact_review.is_artifact_reviewing());
+    assert_eq!(artifact_review.input_text(), "");
+
+    let mut invalid_review = state();
+    invalid_review.push_timeline_item(TimelineItem::Expanded {
+        title: "Previous artifact".to_owned(),
+        body: "old output".to_owned(),
+    });
+    invalid_review.select_previous_artifact();
+    invalid_review.insert_input_str("/unknown");
+
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut invalid_review),
+        ControllerEffect::None
+    );
+    assert!(!invalid_review.is_artifact_reviewing());
+    assert_eq!(invalid_review.input_text(), "/unknown");
+    assert!(matches!(
+        invalid_review.timeline().last(),
+        Some(TimelineItem::Muted { title, .. }) if title == "Unknown command"
+    ));
+
+    let mut provider_review = state();
+    provider_review.push_timeline_item(TimelineItem::Expanded {
+        title: "Previous artifact".to_owned(),
+        body: "old output".to_owned(),
+    });
+    provider_review.select_previous_artifact();
+    provider_review.insert_input_str("/tmp/file");
+
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitBacklog, &mut provider_review),
+        ControllerEffect::None
+    );
+    assert!(!provider_review.is_artifact_reviewing());
+    assert_eq!(provider_review.input_text(), "/tmp/file");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitBacklog, &mut provider_review),
+        ControllerEffect::SubmitBacklog(text_submission("/tmp/file"))
+    );
+}
+
+#[test]
+fn keyboard_stop_reveals_the_same_feedback_as_slash_stop() {
+    let mut state = state();
+    state.push_timeline_item(TimelineItem::Expanded {
+        title: "Previous artifact".to_owned(),
+        body: "old output".to_owned(),
+    });
+    state.select_previous_artifact();
+    state.plan_mut().update_snapshot(plan_snapshot());
+    assert!(state.plan_mut().open_and_focus());
+    state.set_run_state(InteractiveRunState::RunningModel);
+
+    let effect = handle_key_action(KeyAction::Interrupt, &mut state);
+    assert_eq!(effect, ControllerEffect::Interrupt);
+    project_local_effect(&effect, &mut state);
+
+    assert!(!state.is_artifact_reviewing());
+    assert!(state.plan().is_open());
+    assert!(!state.plan().is_focused());
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, body })
+            if title == "Stopping" && body.contains("Interrupt requested")
+    ));
+
+    assert_eq!(
+        handle_key_action(KeyAction::Interrupt, &mut state),
+        ControllerEffect::None
+    );
+    assert!(matches!(
+        state.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, body })
+            if title == "Stop already requested" && body.contains("cancellation boundary")
+    ));
 }
 
 #[test]
@@ -199,8 +551,9 @@ fn stop_and_save_respect_the_current_run_state() {
     );
     assert!(matches!(
         idle_stop.timeline().last(),
-        Some(TimelineItem::Muted { title, .. }) if title == "Nothing to stop"
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Nothing to stop"
     ));
+    assert_timeline_feedback(&idle_stop, &["Nothing to stop", "No model or tool run"]);
 
     let mut running_stop = state();
     running_stop.set_run_state(InteractiveRunState::RunningModel);
@@ -209,6 +562,43 @@ fn stop_and_save_respect_the_current_run_state() {
         handle_key_action(KeyAction::SubmitNext, &mut running_stop),
         ControllerEffect::Interrupt
     );
+    assert_timeline_feedback(
+        &running_stop,
+        &["Stopping", "Interrupt requested for the active run"],
+    );
+
+    let mut cancelled_stop = state();
+    cancelled_stop.set_run_state(InteractiveRunState::RunningModel);
+    cancelled_stop.insert_input_str("/stop");
+    assert_eq!(
+        handle_key_action(KeyAction::SubmitNext, &mut cancelled_stop),
+        ControllerEffect::Interrupt
+    );
+    TuiProjector::default().apply(run_cancelled_event(), &mut cancelled_stop);
+    assert!(matches!(
+        cancelled_stop.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, body })
+            if title == "Run stopped" && body.contains("cancellation boundary")
+    ));
+    assert!(
+        cancelled_stop
+            .timeline()
+            .iter()
+            .all(|item| !matches!(item, TimelineItem::Diagnostic { .. }))
+    );
+    assert_timeline_feedback(
+        &cancelled_stop,
+        &["Run stopped", "The active run reached", "boundary."],
+    );
+
+    let mut unexpected_cancel = state();
+    TuiProjector::default().apply(run_cancelled_event(), &mut unexpected_cancel);
+    assert!(matches!(
+        unexpected_cancel.timeline().last(),
+        Some(TimelineItem::Diagnostic { title, body })
+            if title == "cancelled" && body == "runtime step cancelled"
+    ));
+
     running_stop.insert_input_str("/stop");
     assert_eq!(
         handle_key_action(KeyAction::SubmitNext, &mut running_stop),
@@ -216,7 +606,22 @@ fn stop_and_save_respect_the_current_run_state() {
     );
     assert!(matches!(
         running_stop.timeline().last(),
-        Some(TimelineItem::Muted { title, .. }) if title == "Stop already requested"
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Stop already requested"
+    ));
+    assert_eq!(running_stop.timeline().len(), 1);
+    assert_timeline_feedback(
+        &running_stop,
+        &[
+            "Stop already requested",
+            "Waiting for the active run",
+            "boundary.",
+        ],
+    );
+    TuiProjector::default().apply(run_cancelled_event(), &mut running_stop);
+    assert_eq!(running_stop.timeline().len(), 1);
+    assert!(matches!(
+        running_stop.timeline().last(),
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Run stopped"
     ));
 
     let mut interrupting = state();
@@ -236,8 +641,53 @@ fn stop_and_save_respect_the_current_run_state() {
     );
     assert!(matches!(
         running_save.timeline().last(),
-        Some(TimelineItem::Muted { title, .. }) if title == "Save unavailable"
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Save unavailable"
     ));
+    assert_timeline_feedback(
+        &running_save,
+        &["Save unavailable", "Stop the active run", "before saving"],
+    );
+}
+
+#[test]
+fn wrapped_command_feedback_stays_visible_at_the_bottom_of_a_full_timeline() {
+    for (command, run_state, expected) in [
+        (
+            "/stop",
+            InteractiveRunState::Interrupting,
+            "cancellation boundary.",
+        ),
+        (
+            "/save",
+            InteractiveRunState::RunningTool,
+            "before saving the session.",
+        ),
+    ] {
+        let mut state = state();
+        for index in 0..12 {
+            state.push_timeline_item(TimelineItem::User {
+                text: format!(
+                    "Earlier user message {index}: {}",
+                    "long history content ".repeat(14)
+                ),
+                lane: QueuedInputLane::Next,
+            });
+        }
+        state.set_run_state(run_state);
+        state.insert_input_str(command);
+        assert_eq!(
+            handle_key_action(KeyAction::SubmitNext, &mut state),
+            ControllerEffect::None
+        );
+
+        for (width, height) in [(50, 20), (80, 16), (120, 24)] {
+            let rendered = render::render_to_text(&state, width, height);
+            assert!(
+                rendered.contains(expected),
+                "{expected:?} should remain visible at {width}x{height}:\n{rendered}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -265,7 +715,7 @@ fn locally_accepted_input_closes_the_idle_save_window() {
     );
     assert!(matches!(
         state.timeline().last(),
-        Some(TimelineItem::Muted { title, .. }) if title == "Save unavailable"
+        Some(TimelineItem::LocalCommand { title, .. }) if title == "Save unavailable"
     ));
 
     projector.apply(

--- a/crates/merry-cli/src/tui/state.rs
+++ b/crates/merry-cli/src/tui/state.rs
@@ -163,6 +163,10 @@ pub(crate) enum TimelineItem {
         title: String,
         detail: String,
     },
+    LocalCommand {
+        title: String,
+        body: String,
+    },
     Expanded {
         title: String,
         body: String,
@@ -201,6 +205,7 @@ pub(crate) struct TuiState {
     artifact_review_timeline_index: Option<usize>,
     pending_local_echoes: Vec<PendingLocalEcho>,
     pending_local_run_start: bool,
+    stop_feedback: StopFeedbackState,
     run_state: InteractiveRunState,
     active_run_started_at: Option<Instant>,
     last_completed_run_elapsed: Option<Duration>,
@@ -226,6 +231,16 @@ struct PendingLocalEcho {
     text: String,
     lane: QueuedInputLane,
     timeline_index: usize,
+}
+
+/// A stop request moves from idle to pending, then completes at a cancellation boundary.
+/// A new active run resets the state only when entered from an inactive boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum StopFeedbackState {
+    #[default]
+    Idle,
+    Pending(usize),
+    Completed,
 }
 
 #[allow(dead_code)]
@@ -254,6 +269,7 @@ impl TuiState {
             artifact_review_timeline_index: None,
             pending_local_echoes: Vec::new(),
             pending_local_run_start: false,
+            stop_feedback: StopFeedbackState::Idle,
             run_state: InteractiveRunState::WaitingForInput,
             active_run_started_at: None,
             last_completed_run_elapsed: None,
@@ -834,6 +850,75 @@ impl TuiState {
         }
     }
 
+    pub(crate) fn begin_stop_feedback(&mut self) {
+        self.set_run_state(InteractiveRunState::Interrupting);
+        if self.stop_feedback == StopFeedbackState::Idle {
+            self.push_pending_stop_feedback("Stopping", "Interrupt requested for the active run.");
+        }
+    }
+
+    pub(crate) fn repeat_stop_feedback(&mut self) {
+        match self.stop_feedback {
+            StopFeedbackState::Idle => self.push_pending_stop_feedback(
+                "Stop already requested",
+                "Waiting for the active run to reach a cancellation boundary.",
+            ),
+            StopFeedbackState::Pending(index) => self.replace_or_append_stop_feedback(
+                index,
+                "Stop already requested",
+                "Waiting for the active run to reach a cancellation boundary.",
+            ),
+            StopFeedbackState::Completed => {}
+        }
+    }
+
+    pub(crate) fn complete_stop_feedback(&mut self) -> bool {
+        match self.stop_feedback {
+            StopFeedbackState::Idle if !self.is_interrupting() => false,
+            StopFeedbackState::Idle => {
+                self.push_timeline_item(run_stopped_item());
+                self.stop_feedback = StopFeedbackState::Completed;
+                true
+            }
+            StopFeedbackState::Pending(index) => {
+                if index.saturating_add(1) == self.timeline.len() {
+                    self.replace_timeline_item(index, run_stopped_item());
+                } else {
+                    self.replace_timeline_item(index, stop_requested_item());
+                    self.push_timeline_item(run_stopped_item());
+                }
+                self.stop_feedback = StopFeedbackState::Completed;
+                true
+            }
+            StopFeedbackState::Completed => true,
+        }
+    }
+
+    fn push_pending_stop_feedback(&mut self, title: &str, body: &str) {
+        let index = self.timeline.len();
+        self.push_timeline_item(TimelineItem::LocalCommand {
+            title: title.to_owned(),
+            body: body.to_owned(),
+        });
+        self.stop_feedback = StopFeedbackState::Pending(index);
+    }
+
+    fn replace_or_append_stop_feedback(&mut self, index: usize, title: &str, body: &str) {
+        if index.saturating_add(1) == self.timeline.len() {
+            self.replace_timeline_item(
+                index,
+                TimelineItem::LocalCommand {
+                    title: title.to_owned(),
+                    body: body.to_owned(),
+                },
+            );
+            return;
+        }
+
+        self.replace_timeline_item(index, stop_requested_item());
+        self.push_pending_stop_feedback(title, body);
+    }
+
     pub(crate) fn timeline_scroll_offset(&self) -> usize {
         self.timeline_scroll_offset
     }
@@ -991,6 +1076,9 @@ impl TuiState {
         if state == InteractiveRunState::WaitingForInput && self.pending_local_run_start {
             return;
         }
+        if state == InteractiveRunState::WaitingForInput && self.is_interrupting() {
+            self.complete_stop_feedback();
+        }
         self.pending_local_run_start = false;
         self.set_run_state(state);
     }
@@ -999,6 +1087,7 @@ impl TuiState {
         let was_active = is_active_run_state(self.run_state);
         let is_active = is_active_run_state(state);
         if is_active && !was_active {
+            self.stop_feedback = StopFeedbackState::Idle;
             self.active_run_started_at = Some(now);
         } else if !is_active {
             if was_active && let Some(started_at) = self.active_run_started_at.take() {
@@ -1147,6 +1236,20 @@ fn is_active_run_state(state: InteractiveRunState) -> bool {
             | InteractiveRunState::RunningTool
             | InteractiveRunState::Interrupting
     )
+}
+
+fn stop_requested_item() -> TimelineItem {
+    TimelineItem::LocalCommand {
+        title: "Stop requested".to_owned(),
+        body: "The interrupt request remains active.".to_owned(),
+    }
+}
+
+fn run_stopped_item() -> TimelineItem {
+    TimelineItem::LocalCommand {
+        title: "Run stopped".to_owned(),
+        body: "The active run reached a cancellation boundary.".to_owned(),
+    }
 }
 
 fn compact_title(text: &str) -> String {

--- a/crates/merry-core/src/lib.rs
+++ b/crates/merry-core/src/lib.rs
@@ -40,8 +40,8 @@ pub use runtime_event::{
 pub use schema::ToolInputSchema;
 pub use subagent_activity::{SubagentActivityPhase, SubagentActivitySnapshot};
 pub use tool::{
-    PendingToolCall, PendingToolCallBatch, ToolCallArguments, ToolCallResult, ToolCallResultStatus,
-    ToolSpec,
+    PendingToolCall, PendingToolCallBatch, TOOL_CANCELLED_BY_USER_CODE, ToolCallArguments,
+    ToolCallResult, ToolCallResultStatus, ToolSpec,
 };
 pub use usage::{
     CompactionUsageWindow, ContextWindowSource, ModelUsage, SessionUsage, UsageContextWindow,

--- a/crates/merry-core/src/tool.rs
+++ b/crates/merry-core/src/tool.rs
@@ -10,6 +10,9 @@ use std::collections::BTreeSet;
 
 const MAX_TOOL_DESCRIPTION_LEN: usize = 4096;
 
+/// Stable diagnostic code for a tool call cancelled by an interactive user interrupt.
+pub const TOOL_CANCELLED_BY_USER_CODE: &str = "tool_cancelled_by_user";
+
 /// JSON object arguments supplied with a pending tool call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(transparent)]

--- a/crates/merry-runtime/src/runtime/session_access.rs
+++ b/crates/merry-runtime/src/runtime/session_access.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use merry_core::{
     ArtifactId, ArtifactRef, ErrorInfo, EvidenceLocator, EvidenceRef, PendingToolCall,
-    RuntimeJournalEvent, ToolCallId, ToolCallResult, ToolCallResultStatus,
+    RuntimeJournalEvent, TOOL_CANCELLED_BY_USER_CODE, ToolCallId, ToolCallResult,
+    ToolCallResultStatus,
 };
 use std::sync::Arc;
 
@@ -137,7 +138,7 @@ impl Runtime {
         _active_permit: &ActiveStepPermit,
     ) -> Result<Vec<RuntimeJournalEvent>, RuntimeError> {
         let diagnostic = ErrorInfo::new(
-            "tool_cancelled_by_user",
+            TOOL_CANCELLED_BY_USER_CODE,
             &format!("tool call {call_id} was cancelled by user interrupt"),
         )
         .expect("static diagnostic code and runtime-owned call id are valid");


### PR DESCRIPTION
## Summary
- Make slash and palette feedback chronological and visible from plan/review focus, with an idempotent stop lifecycle across direct slash handling, local effect projection, runtime state changes, and model/tool/compaction cancellation.
- Repeated Ctrl+C while already `Interrupting` now refreshes the existing stop feedback without emitting a second runtime interrupt request; stale `WaitingForInput` events cannot complete a newer local run.
- Share the stable `tool_cancelled_by_user` diagnostic code through `merry-core` so runtime and TUI cancellation classification cannot drift.
- Keep wrapped timeline scrolling exact beyond `u16` viewport limits while preserving styled spans and alignment, and document the required ratatui unstable API dependency.
- No provider-visible prompt, tool schema, tool order, or request composition changes; prompt/KV cache behavior is unchanged.

## Tests
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p merry-cli --bin merry tui::` (287 passed)
- `cargo test --workspace --exclude merry-cli`
- `git diff --check origin/main...HEAD`

Known: `cargo test --all` is still blocked by the pre-existing `subagent_with_narrow_tools_keeps_read_only_profile` mock-stream failure (`model_unavailable: model stream ended before completion`; 470 other CLI tests passed). The two `debug_shell` integration tests remain environment-dependent on an executable `rg` in WSL.
