### PR TITLE
fix(sandbox): align bwrap paths and tool retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,14 @@ target/release/merry cmd "find the largest Rust files"
 TUI and `run` enter an outer bubblewrap sandbox automatically. `--no-sandbox`
 disables only that outer process sandbox when the user explicitly chooses host
 execution; shell/process tools still run through Merry's inner bubblewrap
-runner. Debug commands remain unsandboxed unless `--with-sandbox` is supplied.
+runner. In the normal mode, the outer `/tmp` is a session-scoped in-memory
+tmpfs reused by action sandboxes. With `--no-sandbox`, action `/tmp` maps to the
+current process's validated `TMPDIR` directly, which is an explicit host-temp
+choice. Debug commands remain unsandboxed unless `--with-sandbox` is supplied.
+
+`[permissions].environment` applies only inside Merry-managed action processes.
+Assignments are injected after the sandbox defaults and may intentionally
+override them; they do not change the outer bootstrap or provider environment.
 
 ## Multi-Tool Execution
 

--- a/crates/merry-cli/src/coding_runtime/error.rs
+++ b/crates/merry-cli/src/coding_runtime/error.rs
@@ -1,6 +1,7 @@
 use merry_core::CoreError;
 use merry_runtime::{
-    AgentLoopConfigError, ContextError, RuntimeError, RuntimeProfileError, SkillError,
+    AgentLoopConfigError, ContextError, ProcessRunnerError, RuntimeError, RuntimeProfileError,
+    SkillError,
 };
 use merry_tool_workspace::{WorkspaceCodingLoopProfileError, WorkspaceToolConfigError};
 use std::{io, path::PathBuf};
@@ -18,6 +19,12 @@ pub(crate) enum CodingRuntimeError {
     Core {
         #[from]
         source: CoreError,
+    },
+
+    #[error("invalid action process sandbox: {source}")]
+    ProcessRunner {
+        #[from]
+        source: ProcessRunnerError,
     },
 
     #[error("failed to read project rules at {path}: {source}")]

--- a/crates/merry-cli/src/coding_runtime/process.rs
+++ b/crates/merry-cli/src/coding_runtime/process.rs
@@ -1,9 +1,10 @@
 use super::CodingRuntimeError;
 use merry_runtime::{
-    BwrapPermissionedProcessRunnerFactory, BwrapProcessRunner, BwrapSessionPermissions,
-    PathAccessRule, PermissionedProcessRunnerFactory, ProcessRunner,
+    BwrapPermissionedProcessRunnerFactory, BwrapProcessEnvironment, BwrapProcessRunner,
+    BwrapSessionPermissions, PathAccessRule, PermissionedProcessRunnerFactory, ProcessRunner,
 };
 use std::{
+    ffi::OsString,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -19,6 +20,7 @@ pub(crate) struct ActionProcessBackend {
 pub(crate) struct ActionProcessBackendOptions {
     pub(crate) path_rules: Vec<PathAccessRule>,
     pub(crate) network_allowed: bool,
+    pub(crate) environment_overrides: Vec<(OsString, OsString)>,
 }
 
 impl ActionProcessBackend {
@@ -59,9 +61,13 @@ impl ActionProcessBackend {
         let ActionProcessBackendOptions {
             path_rules,
             network_allowed,
+            environment_overrides,
         } = options.clone();
         let session_permissions = BwrapSessionPermissions::new();
+        let environment =
+            BwrapProcessEnvironment::from_current_process().with_overrides(environment_overrides);
         let mut runner = BwrapProcessRunner::new_at_workspace_root(&workspace_root)
+            .with_environment(environment.clone())
             .with_path_rules(path_rules.clone())
             .with_session_permissions(session_permissions.clone());
         if network_allowed {
@@ -69,6 +75,7 @@ impl ActionProcessBackend {
         }
         let mut permissioned_factory =
             BwrapPermissionedProcessRunnerFactory::new_at_workspace_root(&workspace_root)
+                .with_environment(environment)
                 .with_path_rules(path_rules)
                 .with_session_permissions(session_permissions);
         if network_allowed {

--- a/crates/merry-cli/src/coding_runtime/process.rs
+++ b/crates/merry-cli/src/coding_runtime/process.rs
@@ -57,15 +57,28 @@ impl ActionProcessBackend {
     pub(crate) fn from_bwrap_options(
         workspace_root: PathBuf,
         options: ActionProcessBackendOptions,
+    ) -> Result<Self, CodingRuntimeError> {
+        let environment = BwrapProcessEnvironment::from_current_process()
+            .with_overrides(options.environment_overrides.clone())?
+            .validate_for_workspace(&workspace_root)?;
+        Ok(Self::from_bwrap_options_with_environment(
+            workspace_root,
+            options,
+            environment,
+        ))
+    }
+
+    fn from_bwrap_options_with_environment(
+        workspace_root: PathBuf,
+        options: ActionProcessBackendOptions,
+        environment: BwrapProcessEnvironment,
     ) -> Self {
         let ActionProcessBackendOptions {
             path_rules,
             network_allowed,
-            environment_overrides,
+            ..
         } = options.clone();
         let session_permissions = BwrapSessionPermissions::new();
-        let environment =
-            BwrapProcessEnvironment::from_current_process().with_overrides(environment_overrides);
         let mut runner = BwrapProcessRunner::new_at_workspace_root(&workspace_root)
             .with_environment(environment.clone())
             .with_path_rules(path_rules.clone())
@@ -75,7 +88,7 @@ impl ActionProcessBackend {
         }
         let mut permissioned_factory =
             BwrapPermissionedProcessRunnerFactory::new_at_workspace_root(&workspace_root)
-                .with_environment(environment)
+                .with_environment(environment.clone())
                 .with_path_rules(path_rules)
                 .with_session_permissions(session_permissions);
         if network_allowed {
@@ -84,11 +97,16 @@ impl ActionProcessBackend {
 
         let child_workspace_root = workspace_root.clone();
         let child_options = options;
+        let child_environment = environment;
         Self {
             runner: Arc::new(runner),
             permissioned_factory: Arc::new(permissioned_factory),
             new_session: Arc::new(move || {
-                Self::from_bwrap_options(child_workspace_root.clone(), child_options.clone())
+                Self::from_bwrap_options_with_environment(
+                    child_workspace_root.clone(),
+                    child_options.clone(),
+                    child_environment.clone(),
+                )
             }),
         }
     }
@@ -98,8 +116,5 @@ pub(crate) fn action_process_runner(
     workspace_root: &Path,
     options: ActionProcessBackendOptions,
 ) -> Result<ActionProcessBackend, CodingRuntimeError> {
-    Ok(ActionProcessBackend::from_bwrap_options(
-        workspace_root.to_path_buf(),
-        options,
-    ))
+    ActionProcessBackend::from_bwrap_options(workspace_root.to_path_buf(), options)
 }

--- a/crates/merry-cli/src/config/mod.rs
+++ b/crates/merry-cli/src/config/mod.rs
@@ -1047,6 +1047,30 @@ environment = [
                 "{invalid:?} should be rejected"
             );
         }
+
+        let duplicate = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[permissions]
+environment = [
+  { name = "DUPLICATE", value = "one" },
+  { name = "DUPLICATE", value = "two" },
+]
+"#,
+            ),
+            &paths,
+        )
+        .expect("duplicate environment config should parse")
+        .expect("duplicate environment config should be present");
+        assert!(duplicate.process_environment_overrides().is_err());
+
+        let nul_value = MerryConfig::load_optional_from_text(
+            Some("[permissions]\nenvironment = [{ name = \"NUL_VALUE\", value = \"\\u0000\" } ]"),
+            &paths,
+        )
+        .expect("NUL environment config should parse")
+        .expect("NUL environment config should be present");
+        assert!(nul_value.process_environment_overrides().is_err());
     }
 
     #[test]

--- a/crates/merry-cli/src/config/mod.rs
+++ b/crates/merry-cli/src/config/mod.rs
@@ -48,8 +48,10 @@ pub enum ConfigError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XdgPaths {
     home: PathBuf,
+    config_base: PathBuf,
     config_dir: PathBuf,
     config_file: PathBuf,
+    state_base: PathBuf,
     state_dir: PathBuf,
     default_log_file: PathBuf,
 }
@@ -80,11 +82,21 @@ impl XdgPaths {
         let default_log_file = state_dir.join("logs/merry.jsonl");
         Self {
             home,
+            config_base,
             config_dir,
             config_file,
+            state_base,
             state_dir,
             default_log_file,
         }
+    }
+
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    pub fn config_base_dir(&self) -> &Path {
+        &self.config_base
     }
 
     pub fn config_dir(&self) -> &Path {
@@ -93,6 +105,10 @@ impl XdgPaths {
 
     pub fn config_file(&self) -> &Path {
         &self.config_file
+    }
+
+    pub fn state_base_dir(&self) -> &Path {
+        &self.state_base
     }
 
     pub fn state_dir(&self) -> &Path {
@@ -121,10 +137,6 @@ impl XdgPaths {
 
     pub fn model_catalog_cache_dir(&self) -> PathBuf {
         self.state_dir.join("model-catalogs")
-    }
-
-    fn home(&self) -> &Path {
-        &self.home
     }
 }
 
@@ -275,6 +287,31 @@ impl MerryConfig {
             .unwrap_or(false)
     }
 
+    pub fn process_environment_overrides(&self) -> Result<Vec<(String, String)>, ConfigError> {
+        let Some(permissions) = self.raw.permissions.as_ref() else {
+            return Ok(Vec::new());
+        };
+        let mut names = BTreeSet::new();
+        let mut overrides = Vec::with_capacity(permissions.environment.len());
+        for entry in &permissions.environment {
+            validate_environment_name(&entry.name)?;
+            if entry.value.contains('\0') {
+                return Err(ConfigError::Invalid(format!(
+                    "permissions.environment value for {:?} must not contain NUL",
+                    entry.name
+                )));
+            }
+            if !names.insert(entry.name.clone()) {
+                return Err(ConfigError::Invalid(format!(
+                    "permissions.environment contains duplicate variable {:?}",
+                    entry.name
+                )));
+            }
+            overrides.push((entry.name.clone(), entry.value.clone()));
+        }
+        Ok(overrides)
+    }
+
     pub fn skill_roots(&self) -> Result<Vec<PathBuf>, ConfigError> {
         let Some(skills) = self.raw.skills.as_ref() else {
             return Ok(vec![self.config_dir.join("skills")]);
@@ -367,6 +404,22 @@ fn resolve_path_access_rule_path(
     Ok(normalize_path_lexically(&path))
 }
 
+fn validate_environment_name(name: &str) -> Result<(), ConfigError> {
+    if name.is_empty()
+        || name.contains('=')
+        || name.contains('\0')
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        || name.as_bytes()[0].is_ascii_digit()
+    {
+        return Err(ConfigError::Invalid(format!(
+            "permissions.environment name {name:?} is not a valid environment variable"
+        )));
+    }
+    Ok(())
+}
+
 fn normalize_path_lexically(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
     let is_absolute = path.is_absolute();
@@ -455,6 +508,15 @@ struct PermissionsToml {
     deny_paths: Vec<String>,
     #[serde(default)]
     paths: Vec<PathRuleToml>,
+    #[serde(default)]
+    environment: Vec<EnvironmentVariableToml>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct EnvironmentVariableToml {
+    name: String,
+    value: String,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
@@ -944,6 +1006,47 @@ access = "ro"
                 .iter()
                 .all(|rule| rule.source() == PathAccessRuleSource::TrustedGlobalConfig)
         );
+    }
+
+    #[test]
+    fn parses_and_validates_process_environment_overrides() {
+        let paths = XdgPaths::from_parts(home(), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[permissions]
+environment = [
+  { name = "RUSTUP_TOOLCHAIN", value = "stable" },
+  { name = "CARGO_TERM_COLOR", value = "always" },
+]
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        assert_eq!(
+            config
+                .process_environment_overrides()
+                .expect("environment overrides should validate"),
+            vec![
+                ("RUSTUP_TOOLCHAIN".to_owned(), "stable".to_owned()),
+                ("CARGO_TERM_COLOR".to_owned(), "always".to_owned()),
+            ]
+        );
+
+        for invalid in ["", "1INVALID", "INVALID-NAME", "INVALID=NAME"] {
+            let text =
+                format!("[permissions]\nenvironment = [{{ name = {invalid:?}, value = \"x\" }}]");
+            let config = MerryConfig::load_optional_from_text(Some(&text), &paths)
+                .expect("config should parse");
+            let config = config.expect("config should be present");
+            assert!(
+                config.process_environment_overrides().is_err(),
+                "{invalid:?} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/merry-cli/src/debug/coding_loop/permission.rs
+++ b/crates/merry-cli/src/debug/coding_loop/permission.rs
@@ -15,10 +15,8 @@ pub(crate) fn permission_network_smoke_process_runner(
     // This smoke must prove that the first attempt is denied by the default
     // inner profile even when the user enables network access globally.
     options.network_allowed = false;
-    Ok(ActionProcessBackend::from_bwrap_options(
-        workspace_root.to_path_buf(),
-        options,
-    ))
+    ActionProcessBackend::from_bwrap_options(workspace_root.to_path_buf(), options)
+        .map_err(Into::into)
 }
 
 pub(crate) fn permission_network_live_smoke_task() -> String {

--- a/crates/merry-cli/src/debug/coding_loop/permission.rs
+++ b/crates/merry-cli/src/debug/coding_loop/permission.rs
@@ -1,6 +1,7 @@
 use crate::cli_error::{CliError, unexpected};
-use crate::coding_runtime::{ActionProcessBackend, ActionProcessBackendOptions};
+use crate::coding_runtime::ActionProcessBackend;
 use crate::config::MerryConfig;
+use crate::runtime_config::action_process_backend_options;
 use merry_tool_workspace::CODING_LOOP_PROCESS_TOOL;
 use std::path::Path;
 
@@ -10,17 +11,13 @@ pub(crate) fn permission_network_smoke_process_runner(
     workspace_root: &Path,
     merry_config: Option<&MerryConfig>,
 ) -> Result<ActionProcessBackend, CliError> {
-    let path_rules = merry_config
-        .map(MerryConfig::trusted_global_path_rules)
-        .transpose()
-        .map_err(unexpected)?
-        .unwrap_or_default();
+    let mut options = action_process_backend_options(merry_config).map_err(unexpected)?;
+    // This smoke must prove that the first attempt is denied by the default
+    // inner profile even when the user enables network access globally.
+    options.network_allowed = false;
     Ok(ActionProcessBackend::from_bwrap_options(
         workspace_root.to_path_buf(),
-        ActionProcessBackendOptions {
-            path_rules,
-            network_allowed: false,
-        },
+        options,
     ))
 }
 

--- a/crates/merry-cli/src/runtime_config.rs
+++ b/crates/merry-cli/src/runtime_config.rs
@@ -4,6 +4,7 @@ use crate::config::{self, EffectiveLogSettings, MerryConfig, XdgPaths};
 use merry_core::SessionId;
 use merry_llm::{GenerationConfig, ReasoningEffort};
 use merry_runtime::{AutomaticCompactionConfig, Runtime, RuntimeBuilder};
+use std::ffi::OsString;
 
 pub(crate) fn validate_loaded_config(
     config: Option<&MerryConfig>,
@@ -17,6 +18,7 @@ pub(crate) fn validate_loaded_config(
     let _ = automatic_compaction_config(Some(config))?;
     let _ = subagents_config(Some(config))?;
     let _ = config.trusted_global_path_rules()?;
+    let _ = config.process_environment_overrides()?;
     let _ = config.skill_roots()?;
     let _ = config.runtime_models()?;
     let _ = config.profile();
@@ -81,9 +83,17 @@ pub(crate) fn action_process_backend_options(
     let network_allowed = config
         .map(MerryConfig::permissions_network_allowed)
         .unwrap_or(false);
+    let environment_overrides = config
+        .map(MerryConfig::process_environment_overrides)
+        .transpose()?
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(name, value)| (OsString::from(name), OsString::from(value)))
+        .collect();
     Ok(ActionProcessBackendOptions {
         path_rules,
         network_allowed,
+        environment_overrides,
     })
 }
 

--- a/crates/merry-cli/src/sandbox.rs
+++ b/crates/merry-cli/src/sandbox.rs
@@ -285,6 +285,8 @@ pub(crate) fn plan_bootstrap_with_probe(
         return Ok(Bootstrap::AlreadyInside);
     }
 
+    validate_outer_mount_layout(host)?;
+
     let path = sandbox_path(host);
     let bwrap = find_bwrap_in_path(&path, |candidate| probe.file_exists(candidate))
         .ok_or(Error::MissingBubblewrap)?;
@@ -480,6 +482,27 @@ fn is_clean_absolute_path(path: &Path) -> bool {
             .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
 }
 
+fn validate_outer_mount_layout(host: &Host) -> Result<(), Error> {
+    if !is_clean_absolute_path(&host.cwd) || host.cwd == Path::new("/") {
+        return Err(Error::InvalidMountLayout(
+            "workspace root must be a clean absolute path other than /",
+        ));
+    }
+
+    let home = host.xdg_paths.home();
+    if !is_valid_runtime_home_path(home) {
+        return Err(Error::InvalidMountLayout(
+            "HOME must be a clean user path outside /tmp",
+        ));
+    }
+    if home == host.cwd || home.starts_with(&host.cwd) {
+        return Err(Error::InvalidMountLayout(
+            "workspace root must not be HOME or contain HOME",
+        ));
+    }
+    Ok(())
+}
+
 fn build_plan(
     host: &Host,
     path: OsString,
@@ -518,13 +541,12 @@ fn build_plan(
         os(SANDBOX_TMPDIR),
         os("--tmpfs"),
         os(SANDBOX_HOME_ROOT),
-        os("--perms"),
-        os("0700"),
     ];
     if !Path::new(&home).starts_with(Path::new(SANDBOX_HOME_ROOT)) {
         append_mount_parent_args(&mut args, home.as_os_str());
+        args.extend([os("--tmpfs"), home.clone()]);
     }
-    args.extend([os("--dir"), home.clone()]);
+    args.extend([os("--perms"), os("0700"), os("--dir"), home.clone()]);
     append_bind_dir_try_args(&mut args, &config_dir, &config_dir);
     append_bind_dir_rw_args(&mut args, &managed_config_dir, &managed_config_dir);
     args.extend([
@@ -799,9 +821,18 @@ pub(crate) fn runtime_profile_from_evidence(
     tmpdir: Option<&OsStr>,
     mountinfo: Option<&str>,
 ) -> Option<RuntimeProfile> {
-    if home.is_some_and(|path| is_clean_absolute_path(Path::new(path)))
-        && tmpdir == Some(OsStr::new(SANDBOX_TMPDIR))
-        && mountinfo_has_tmpfs_mounts(mountinfo?, [SANDBOX_HOME_ROOT, SANDBOX_TMPDIR])
+    let home = home.map(Path::new)?;
+    if !is_valid_runtime_home_path(home) || tmpdir != Some(OsStr::new(SANDBOX_TMPDIR)) {
+        return None;
+    }
+    let home_mount = if home.starts_with(Path::new(SANDBOX_HOME_ROOT)) {
+        SANDBOX_HOME_ROOT.to_owned()
+    } else {
+        home.to_str()?.to_owned()
+    };
+    let mountinfo = mountinfo?;
+    if mountinfo_has_tmpfs_mount(mountinfo, &home_mount)
+        && mountinfo_has_tmpfs_mount(mountinfo, SANDBOX_TMPDIR)
     {
         Some(RuntimeProfile::CliBwrapV1)
     } else {
@@ -809,10 +840,11 @@ pub(crate) fn runtime_profile_from_evidence(
     }
 }
 
-fn mountinfo_has_tmpfs_mounts(mountinfo: &str, mount_points: [&str; 2]) -> bool {
-    mount_points
-        .into_iter()
-        .all(|mount_point| mountinfo_has_tmpfs_mount(mountinfo, mount_point))
+fn is_valid_runtime_home_path(path: &Path) -> bool {
+    is_clean_absolute_path(path)
+        && path != Path::new("/")
+        && path != Path::new(SANDBOX_HOME_ROOT)
+        && !path.starts_with(Path::new(SANDBOX_TMPDIR))
 }
 
 fn mountinfo_has_tmpfs_mount(mountinfo: &str, mount_point: &str) -> bool {
@@ -893,6 +925,7 @@ pub(crate) enum Error {
     #[cfg(not(target_os = "linux"))]
     UnsupportedPlatform,
     MissingBubblewrap,
+    InvalidMountLayout(&'static str),
     Exec(io::Error),
 }
 
@@ -939,6 +972,9 @@ impl fmt::Display for Error {
                 formatter,
                 "bubblewrap executable `bwrap` was not found in PATH; install bubblewrap to use TUI/run, or omit --with-sandbox for debug commands"
             ),
+            Error::InvalidMountLayout(reason) => {
+                write!(formatter, "sandbox mount layout is invalid: {reason}")
+            }
             Error::Exec(error) => {
                 write!(
                     formatter,

--- a/crates/merry-cli/src/sandbox.rs
+++ b/crates/merry-cli/src/sandbox.rs
@@ -285,7 +285,7 @@ pub(crate) fn plan_bootstrap_with_probe(
         return Ok(Bootstrap::AlreadyInside);
     }
 
-    validate_outer_mount_layout(host)?;
+    validate_outer_paths(host)?;
 
     let path = sandbox_path(host);
     let bwrap = find_bwrap_in_path(&path, |candidate| probe.file_exists(candidate))
@@ -482,22 +482,17 @@ fn is_clean_absolute_path(path: &Path) -> bool {
             .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
 }
 
-fn validate_outer_mount_layout(host: &Host) -> Result<(), Error> {
-    if !is_clean_absolute_path(&host.cwd) || host.cwd == Path::new("/") {
-        return Err(Error::InvalidMountLayout(
-            "workspace root must be a clean absolute path other than /",
+fn validate_outer_paths(host: &Host) -> Result<(), Error> {
+    if !is_clean_absolute_path(&host.cwd) {
+        return Err(Error::InvalidWorkspacePath(
+            "workspace root must be a clean absolute path",
         ));
     }
 
     let home = host.xdg_paths.home();
     if !is_valid_runtime_home_path(home) {
-        return Err(Error::InvalidMountLayout(
+        return Err(Error::InvalidHomeLayout(
             "HOME must be a clean user path outside /tmp",
-        ));
-    }
-    if home == host.cwd || home.starts_with(&host.cwd) {
-        return Err(Error::InvalidMountLayout(
-            "workspace root must not be HOME or contain HOME",
         ));
     }
     Ok(())
@@ -925,7 +920,8 @@ pub(crate) enum Error {
     #[cfg(not(target_os = "linux"))]
     UnsupportedPlatform,
     MissingBubblewrap,
-    InvalidMountLayout(&'static str),
+    InvalidWorkspacePath(&'static str),
+    InvalidHomeLayout(&'static str),
     Exec(io::Error),
 }
 
@@ -972,8 +968,11 @@ impl fmt::Display for Error {
                 formatter,
                 "bubblewrap executable `bwrap` was not found in PATH; install bubblewrap to use TUI/run, or omit --with-sandbox for debug commands"
             ),
-            Error::InvalidMountLayout(reason) => {
-                write!(formatter, "sandbox mount layout is invalid: {reason}")
+            Error::InvalidWorkspacePath(reason) => {
+                write!(formatter, "sandbox workspace path is invalid: {reason}")
+            }
+            Error::InvalidHomeLayout(reason) => {
+                write!(formatter, "sandbox HOME layout is invalid: {reason}")
             }
             Error::Exec(error) => {
                 write!(

--- a/crates/merry-cli/src/sandbox.rs
+++ b/crates/merry-cli/src/sandbox.rs
@@ -35,20 +35,27 @@ pub(crate) const MERRY_SANDBOX_VERSION_ENV: &str = "MERRY_SANDBOX_VERSION";
 pub(crate) const MERRY_SANDBOX_VERSION: &str = "1";
 pub(crate) const SANDBOX_CHILD_HANDOFF_ARG: &str = "--merry-sandbox-child-handoff";
 pub(crate) const SANDBOX_CHILD_HANDOFF_CLI_BWRAP_V1: &str = "cli-bwrap-v1";
-pub(crate) const SANDBOX_HOME: &str = "/home/merry";
+pub(crate) const SANDBOX_HOME_ROOT: &str = "/home";
 pub(crate) const SANDBOX_TMPDIR: &str = "/tmp";
-// These are sandbox-child paths. Host paths are resolved separately before
-// re-exec; inside bwrap, HOME is intentionally set to SANDBOX_HOME.
-pub(crate) const SANDBOX_XDG_CONFIG_HOME: &str = "/home/merry/.config";
-pub(crate) const SANDBOX_XDG_STATE_HOME: &str = "/home/merry/.local/state";
-pub(crate) const SANDBOX_MERRY_CONFIG_DIR: &str = "/home/merry/.config/merry";
-pub(crate) const SANDBOX_MERRY_MANAGED_CONFIG_DIR: &str = "/home/merry/.config/merry/managed";
-pub(crate) const SANDBOX_MERRY_STATE_DIR: &str = "/home/merry/.local/state/merry";
-pub(crate) const SANDBOX_MERRY_LOG_DIR: &str = "/home/merry/.local/state/merry/logs";
 pub(crate) const SANDBOX_WAYLAND_RUNTIME_DIR: &str = "/run/merry-wayland";
 pub(crate) const SANDBOX_WAYLAND_DISPLAY: &str = "wayland-0";
 pub(crate) const SANDBOX_WAYLAND_SOCKET: &str = "/run/merry-wayland/wayland-0";
 pub(crate) const SANDBOX_X11_AUTHORITY: &str = "/run/merry-x11/Xauthority";
+
+#[cfg(test)]
+pub(crate) const SANDBOX_HOME: &str = "/home/alice";
+#[cfg(test)]
+pub(crate) const SANDBOX_XDG_CONFIG_HOME: &str = "/host/config";
+#[cfg(test)]
+pub(crate) const SANDBOX_XDG_STATE_HOME: &str = "/host/state";
+#[cfg(test)]
+pub(crate) const SANDBOX_MERRY_CONFIG_DIR: &str = "/host/config/merry";
+#[cfg(test)]
+pub(crate) const SANDBOX_MERRY_MANAGED_CONFIG_DIR: &str = "/host/config/merry/managed";
+#[cfg(test)]
+pub(crate) const SANDBOX_MERRY_STATE_DIR: &str = "/host/state/merry";
+#[cfg(test)]
+pub(crate) const SANDBOX_MERRY_LOG_DIR: &str = "/host/state/merry/logs";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ClipboardAccess {
@@ -482,6 +489,12 @@ fn build_plan(
 ) -> Plan {
     let cwd = host.cwd.as_os_str().to_owned();
     let current_exe = host.current_exe.as_os_str().to_owned();
+    let home = host.xdg_paths.home().as_os_str().to_owned();
+    let config_base = host.xdg_paths.config_base_dir().as_os_str().to_owned();
+    let state_base = host.xdg_paths.state_base_dir().as_os_str().to_owned();
+    let config_dir = host.xdg_paths.config_dir().to_path_buf();
+    let managed_config_dir = host.xdg_paths.managed_config_dir();
+    let state_dir = host.xdg_paths.state_dir().to_path_buf();
     let graphical_plan = match clipboard_access {
         ClipboardAccess::Disabled => GraphicalAccessPlan::default(),
         ClipboardAccess::Tui => graphical_access_plan(host, probe),
@@ -504,17 +517,17 @@ fn build_plan(
         os("--tmpfs"),
         os(SANDBOX_TMPDIR),
         os("--tmpfs"),
-        os("/home"),
+        os(SANDBOX_HOME_ROOT),
         os("--perms"),
         os("0700"),
-        os("--dir"),
-        os(SANDBOX_HOME),
-        os("--ro-bind-try"),
-        host.xdg_paths.config_dir().as_os_str().to_owned(),
-        os(SANDBOX_MERRY_CONFIG_DIR),
-        os("--bind"),
-        host.xdg_paths.managed_config_dir().as_os_str().to_owned(),
-        os(SANDBOX_MERRY_MANAGED_CONFIG_DIR),
+    ];
+    if !Path::new(&home).starts_with(Path::new(SANDBOX_HOME_ROOT)) {
+        append_mount_parent_args(&mut args, home.as_os_str());
+    }
+    args.extend([os("--dir"), home.clone()]);
+    append_bind_dir_try_args(&mut args, &config_dir, &config_dir);
+    append_bind_dir_rw_args(&mut args, &managed_config_dir, &managed_config_dir);
+    args.extend([
         os("--ro-bind"),
         os("/usr"),
         os("/usr"),
@@ -530,7 +543,7 @@ fn build_plan(
         os("--ro-bind-try"),
         os("/opt"),
         os("/opt"),
-    ];
+    ]);
     for path in SANDBOX_ETC_READ_ONLY_FILE_PATHS {
         if Path::new(path).exists() {
             append_bind_file_args(&mut args, OsStr::new(path), OsStr::new(path));
@@ -548,18 +561,14 @@ fn build_plan(
         os("--chdir"),
         cwd.clone(),
     ]);
-    args.extend([
-        os("--bind"),
-        host.xdg_paths.state_dir().as_os_str().to_owned(),
-        os(SANDBOX_MERRY_STATE_DIR),
-    ]);
+    append_bind_dir_rw_args(&mut args, &state_dir, &state_dir);
     if let Some(log_settings) = host.log_settings.as_ref()
         && let Some(host_log_dir) = log_settings.path.parent()
     {
         args.extend([
             os("--bind"),
             host_log_dir.as_os_str().to_owned(),
-            os(SANDBOX_MERRY_LOG_DIR),
+            host_log_dir.as_os_str().to_owned(),
         ]);
     }
     for rule in &host.trusted_path_rules {
@@ -579,16 +588,16 @@ fn build_plan(
         path.clone(),
         os("--setenv"),
         os("HOME"),
-        os(SANDBOX_HOME),
+        home,
         os("--setenv"),
         os("TMPDIR"),
         os(SANDBOX_TMPDIR),
         os("--setenv"),
         os("XDG_CONFIG_HOME"),
-        os(SANDBOX_XDG_CONFIG_HOME),
+        config_base,
         os("--setenv"),
         os("XDG_STATE_HOME"),
-        os(SANDBOX_XDG_STATE_HOME),
+        state_base,
         os("--setenv"),
         os("PWD"),
         cwd,
@@ -636,6 +645,24 @@ fn append_bind_file_args(args: &mut Vec<OsString>, source: &OsStr, destination: 
 fn append_bind_dir_args(args: &mut Vec<OsString>, source: &OsStr, destination: &OsStr) {
     append_mount_parent_args(args, destination);
     args.extend([os("--ro-bind"), source.to_owned(), destination.to_owned()]);
+}
+
+fn append_bind_dir_try_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
+    append_mount_parent_args(args, destination.as_os_str());
+    args.extend([
+        os("--ro-bind-try"),
+        source.as_os_str().to_owned(),
+        destination.as_os_str().to_owned(),
+    ]);
+}
+
+fn append_bind_dir_rw_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
+    append_mount_parent_args(args, destination.as_os_str());
+    args.extend([
+        os("--bind"),
+        source.as_os_str().to_owned(),
+        destination.as_os_str().to_owned(),
+    ]);
 }
 
 fn append_path_rule_args(args: &mut Vec<OsString>, rule: &PathAccessRule) {
@@ -772,9 +799,9 @@ pub(crate) fn runtime_profile_from_evidence(
     tmpdir: Option<&OsStr>,
     mountinfo: Option<&str>,
 ) -> Option<RuntimeProfile> {
-    if home == Some(OsStr::new(SANDBOX_HOME))
+    if home.is_some_and(|path| is_clean_absolute_path(Path::new(path)))
         && tmpdir == Some(OsStr::new(SANDBOX_TMPDIR))
-        && mountinfo_has_tmpfs_mounts(mountinfo?, ["/home", SANDBOX_TMPDIR])
+        && mountinfo_has_tmpfs_mounts(mountinfo?, [SANDBOX_HOME_ROOT, SANDBOX_TMPDIR])
     {
         Some(RuntimeProfile::CliBwrapV1)
     } else {

--- a/crates/merry-cli/src/sandbox/tests.rs
+++ b/crates/merry-cli/src/sandbox/tests.rs
@@ -115,11 +115,6 @@ fn runtime_profile_requires_tmpfs_home_tmp_and_expected_env() {
 
     for (home, tmpdir, mountinfo) in [
         (
-            Some(OsStr::new("/home/locez")),
-            Some(OsStr::new(SANDBOX_TMPDIR)),
-            Some(mountinfo),
-        ),
-        (
             Some(OsStr::new(SANDBOX_HOME)),
             Some(OsStr::new("/var/tmp")),
             Some(mountinfo),
@@ -472,7 +467,7 @@ fn plan_mounts_log_dir_read_write_when_file_logging_is_enabled() {
 
     assert!(contains_sequence(
         &args,
-        &["--bind", &host_log_dir_string, SANDBOX_MERRY_LOG_DIR]
+        &["--bind", &host_log_dir_string, &host_log_dir_string]
     ));
     assert!(contains_sequence(
         &args,

--- a/crates/merry-cli/src/sandbox/tests.rs
+++ b/crates/merry-cli/src/sandbox/tests.rs
@@ -395,12 +395,31 @@ fn plan_isolates_custom_home_before_applying_home_permissions() {
 }
 
 #[test]
-fn planning_rejects_workspace_that_contains_home() {
-    let mut host = sandbox_host();
-    host.cwd = PathBuf::from("/home");
+fn planning_binds_explicit_workspace_path_without_home_relationship_rules() {
+    for workspace in ["/home", "/etc", "/"] {
+        let mut host = sandbox_host();
+        host.cwd = PathBuf::from(workspace);
+        let Bootstrap::Reexec(plan) =
+            plan_sandbox(true, &host).expect("explicit workspace path should be accepted")
+        else {
+            panic!("expected sandbox reexec plan");
+        };
+        let args = plan_args(&plan);
+        assert!(contains_sequence(&args, &["--bind", workspace, workspace]));
+    }
+}
 
-    let error = plan_sandbox(true, &host).expect_err("HOME overlap must fail closed");
-    assert!(matches!(error, Error::InvalidMountLayout(reason) if reason.contains("HOME")));
+#[test]
+fn planning_rejects_unclean_workspace_path() {
+    for workspace in ["relative", "/home/../etc"] {
+        let mut host = sandbox_host();
+        host.cwd = PathBuf::from(workspace);
+
+        let error = plan_sandbox(true, &host).expect_err("unclean workspace path must fail");
+        assert!(
+            matches!(error, Error::InvalidWorkspacePath(reason) if reason.contains("clean absolute"))
+        );
+    }
 }
 
 #[test]

--- a/crates/merry-cli/src/sandbox/tests.rs
+++ b/crates/merry-cli/src/sandbox/tests.rs
@@ -112,6 +112,28 @@ fn runtime_profile_requires_tmpfs_home_tmp_and_expected_env() {
         ),
         Some(RuntimeProfile::CliBwrapV1)
     );
+    assert_eq!(
+        runtime_profile_from_evidence(
+            Some(OsStr::new("/home/locez")),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(mountinfo),
+        ),
+        Some(RuntimeProfile::CliBwrapV1)
+    );
+
+    let custom_home_mountinfo = "\
+26 24 0:22 / / rw,relatime - overlay overlay rw
+27 26 0:33 / /root rw,nosuid,nodev - tmpfs tmpfs rw,size=65536k
+28 26 0:34 / /tmp rw,nosuid,nodev - tmpfs tmpfs rw,size=65536k
+";
+    assert_eq!(
+        runtime_profile_from_evidence(
+            Some(OsStr::new("/root")),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(custom_home_mountinfo),
+        ),
+        Some(RuntimeProfile::CliBwrapV1)
+    );
 
     for (home, tmpdir, mountinfo) in [
         (
@@ -154,6 +176,31 @@ fn runtime_profile_requires_tmpfs_home_tmp_and_expected_env() {
             Some(OsStr::new(SANDBOX_HOME)),
             Some(OsStr::new(SANDBOX_TMPDIR)),
             None,
+        ),
+        (
+            Some(OsStr::new("/")),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(mountinfo),
+        ),
+        (
+            Some(OsStr::new(SANDBOX_HOME_ROOT)),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(mountinfo),
+        ),
+        (
+            Some(OsStr::new("/tmp/merry-home")),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(mountinfo),
+        ),
+        (
+            Some(OsStr::new("/home/../root")),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(mountinfo),
+        ),
+        (
+            Some(OsStr::new("home/alice")),
+            Some(OsStr::new(SANDBOX_TMPDIR)),
+            Some(mountinfo),
         ),
     ] {
         assert_eq!(runtime_profile_from_evidence(home, tmpdir, mountinfo), None);
@@ -311,6 +358,49 @@ fn plan_mounts_runtime_paths_and_workspace() {
         &["--bind", "/workspace/merry", "/workspace/merry"]
     ));
     assert!(contains_sequence(&args, &["--chdir", "/workspace/merry"]));
+}
+
+#[test]
+fn plan_isolates_custom_home_before_applying_home_permissions() {
+    let mut host = sandbox_host();
+    host.xdg_paths = XdgPaths::from_parts(
+        PathBuf::from("/srv/alice"),
+        Some(PathBuf::from("/host/config")),
+        Some(PathBuf::from("/host/state")),
+    );
+    let Bootstrap::Reexec(plan) =
+        plan_sandbox(true, &host).expect("sandbox planning should succeed")
+    else {
+        panic!("expected sandbox reexec plan");
+    };
+    let args = plan_args(&plan);
+
+    assert!(contains_sequence(
+        &args,
+        &[
+            "--dir",
+            "/srv",
+            "--tmpfs",
+            "/srv/alice",
+            "--perms",
+            "0700",
+            "--dir",
+            "/srv/alice"
+        ]
+    ));
+    assert!(contains_sequence(
+        &args,
+        &["--setenv", "HOME", "/srv/alice"]
+    ));
+}
+
+#[test]
+fn planning_rejects_workspace_that_contains_home() {
+    let mut host = sandbox_host();
+    host.cwd = PathBuf::from("/home");
+
+    let error = plan_sandbox(true, &host).expect_err("HOME overlap must fail closed");
+    assert!(matches!(error, Error::InvalidMountLayout(reason) if reason.contains("HOME")));
 }
 
 #[test]

--- a/crates/merry-llm/src/error.rs
+++ b/crates/merry-llm/src/error.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 pub enum ProviderErrorKind {
     /// Request validation failed before provider work could start.
     InvalidRequest,
+    /// The provider returned a tool call whose arguments cannot be decoded.
+    InvalidToolCall,
     /// Provider work was cancelled cooperatively.
     Cancelled,
     /// Provider authentication or authorization failed.

--- a/crates/merry-llm/src/retry.rs
+++ b/crates/merry-llm/src/retry.rs
@@ -134,7 +134,9 @@ impl ModelRetryPolicy {
         }
         matches!(
             error.kind(),
-            ProviderErrorKind::RateLimited | ProviderErrorKind::Unavailable
+            ProviderErrorKind::InvalidToolCall
+                | ProviderErrorKind::RateLimited
+                | ProviderErrorKind::Unavailable
         )
     }
 

--- a/crates/merry-llm/src/retry/tests.rs
+++ b/crates/merry-llm/src/retry/tests.rs
@@ -222,6 +222,48 @@ async fn retrying_provider_retries_before_visible_output_with_one_started_event(
     assert_eq!(inner.attempts_remaining(), 0);
 }
 
+#[tokio::test]
+async fn retrying_provider_retries_invalid_tool_call_before_visible_output() {
+    let inner = AttemptScriptProvider::new(vec![
+        vec![Err(ModelError::provider(
+            ProviderErrorKind::InvalidToolCall,
+            "tool arguments were not valid JSON",
+        ))],
+        vec![
+            Ok(ModelEvent::Started),
+            Ok(ModelEvent::OutputTextDelta {
+                delta: "recovered".to_owned(),
+            }),
+            Ok(completed("recovered")),
+        ],
+    ]);
+    let retrying = RetryingModelProvider::new(
+        Arc::new(inner.clone()),
+        ModelRetryPolicy::new(
+            true,
+            3,
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+            Duration::from_millis(100),
+            false,
+        )
+        .expect("valid policy"),
+    );
+
+    let events = retrying
+        .stream_model(request(), ModelStreamContext::default())
+        .await
+        .expect("retry stream setup should succeed")
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("invalid tool call retry should recover");
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(inner.attempts_remaining(), 0);
+}
+
 #[derive(Clone)]
 struct GatedProvider {
     name: ProviderName,

--- a/crates/merry-provider-anthropic/src/error.rs
+++ b/crates/merry-provider-anthropic/src/error.rs
@@ -9,6 +9,8 @@ pub enum AnthropicProviderError {
     InvalidConfig { reason: String },
     #[error("invalid Anthropic provider request: {reason}")]
     InvalidRequest { reason: String },
+    #[error("invalid Anthropic tool call: {reason}")]
+    InvalidToolCall { reason: String },
     #[error("Anthropic provider protocol error: {reason}")]
     Protocol { reason: String },
     #[error("Anthropic provider request failed ({kind:?}): {message}")]
@@ -38,6 +40,12 @@ impl AnthropicProviderError {
         }
     }
 
+    pub(crate) fn invalid_tool_call(reason: impl Into<String>) -> Self {
+        Self::InvalidToolCall {
+            reason: reason.into(),
+        }
+    }
+
     pub(crate) fn provider_with_retry_after(
         kind: ProviderErrorKind,
         message: impl Into<String>,
@@ -56,6 +64,9 @@ impl From<AnthropicProviderError> for ModelError {
         match error {
             AnthropicProviderError::InvalidConfig { reason }
             | AnthropicProviderError::InvalidRequest { reason } => Self::invalid_request(reason),
+            AnthropicProviderError::InvalidToolCall { reason } => {
+                Self::provider_with_retry_after(ProviderErrorKind::InvalidToolCall, reason, None)
+            }
             AnthropicProviderError::Protocol { reason } => {
                 Self::provider(ProviderErrorKind::Protocol, reason)
             }

--- a/crates/merry-provider-anthropic/src/parse.rs
+++ b/crates/merry-provider-anthropic/src/parse.rs
@@ -232,7 +232,7 @@ impl AnthropicToolBuffer {
             &self.input
         };
         let input = serde_json::from_str::<serde_json::Value>(raw_input).map_err(|error| {
-            AnthropicProviderError::protocol(format!(
+            AnthropicProviderError::invalid_tool_call(format!(
                 "Anthropic tool input is not valid JSON: {error}"
             ))
         })?;
@@ -246,7 +246,7 @@ impl AnthropicToolBuffer {
                 AnthropicProviderError::protocol(format!("Anthropic tool name is invalid: {error}"))
             })?,
             ToolArguments::try_from(input).map_err(|error| {
-                AnthropicProviderError::protocol(format!(
+                AnthropicProviderError::invalid_tool_call(format!(
                     "Anthropic tool input must be an object: {error}"
                 ))
             })?,
@@ -324,6 +324,7 @@ fn unexpected_sse_line(line: &str) -> AnthropicProviderError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use merry_llm::{ModelError, ProviderErrorKind};
 
     #[test]
     fn parses_text_tool_use_partial_json_usage_and_completion() {
@@ -375,5 +376,21 @@ mod tests {
         let call = call.expect("tool call should be emitted");
         assert!(call.arguments().as_object().is_empty());
         parser.finish().expect("stream should complete");
+    }
+
+    #[test]
+    fn malformed_tool_input_is_classified_as_invalid_tool_call() {
+        let error = AnthropicToolBuffer {
+            id: "toolu_bad".to_owned(),
+            name: "search".to_owned(),
+            input: "[".to_owned(),
+        }
+        .into_model_tool_call()
+        .expect_err("malformed tool input should fail");
+
+        assert_eq!(
+            ModelError::from(error).kind(),
+            ProviderErrorKind::InvalidToolCall
+        );
     }
 }

--- a/crates/merry-provider-openai/src/chat_completions/parse.rs
+++ b/crates/merry-provider-openai/src/chat_completions/parse.rs
@@ -210,7 +210,7 @@ impl ChatToolBuffer {
         };
         let arguments =
             serde_json::from_str::<serde_json::Value>(raw_arguments).map_err(|error| {
-                OpenAiProviderError::protocol(format!(
+                OpenAiProviderError::invalid_tool_call(format!(
                     "Chat Completions tool arguments are not valid JSON: {error}"
                 ))
             })?;
@@ -226,7 +226,7 @@ impl ChatToolBuffer {
                 ))
             })?,
             ToolArguments::try_from(arguments).map_err(|error| {
-                OpenAiProviderError::protocol(format!(
+                OpenAiProviderError::invalid_tool_call(format!(
                     "Chat Completions tool arguments are invalid: {error}"
                 ))
             })?,

--- a/crates/merry-provider-openai/src/error.rs
+++ b/crates/merry-provider-openai/src/error.rs
@@ -13,6 +13,9 @@ pub enum OpenAiProviderError {
     /// Provider payload could not be rendered from Merry-owned model types.
     #[error("invalid OpenAI provider request: {reason}")]
     InvalidRequest { reason: String },
+    /// The provider returned malformed or non-object tool arguments.
+    #[error("invalid OpenAI tool call: {reason}")]
+    InvalidToolCall { reason: String },
     /// Provider response did not match the expected Responses protocol.
     #[error("OpenAI provider protocol error: {reason}")]
     Protocol { reason: String },
@@ -49,6 +52,12 @@ impl OpenAiProviderError {
         }
     }
 
+    pub(crate) fn invalid_tool_call(reason: impl Into<String>) -> Self {
+        Self::InvalidToolCall {
+            reason: reason.into(),
+        }
+    }
+
     pub(crate) fn provider(kind: ProviderErrorKind, message: impl Into<String>) -> Self {
         Self::Provider {
             kind,
@@ -75,6 +84,9 @@ impl From<OpenAiProviderError> for ModelError {
         match error {
             OpenAiProviderError::InvalidConfig { reason }
             | OpenAiProviderError::InvalidRequest { reason } => Self::invalid_request(reason),
+            OpenAiProviderError::InvalidToolCall { reason } => {
+                Self::provider(ProviderErrorKind::InvalidToolCall, reason)
+            }
             OpenAiProviderError::Protocol { reason } => {
                 Self::provider(ProviderErrorKind::Protocol, reason)
             }

--- a/crates/merry-provider-openai/src/lib.rs
+++ b/crates/merry-provider-openai/src/lib.rs
@@ -632,12 +632,12 @@ mod tests {
     }
 
     #[test]
-    fn malformed_tool_arguments_fixture_returns_protocol_error() {
+    fn malformed_tool_arguments_fixture_returns_invalid_tool_call() {
         let fixture = include_str!("../tests/fixtures/responses_bad_tool_args.json");
         let error = crate::parse::parse_responses_response(fixture)
             .expect_err("malformed tool arguments should fail");
 
-        assert_eq!(error.kind(), ProviderErrorKind::Protocol);
+        assert_eq!(error.kind(), ProviderErrorKind::InvalidToolCall);
     }
 
     #[test]
@@ -707,12 +707,12 @@ mod tests {
     }
 
     #[test]
-    fn malformed_streaming_tool_arguments_fixture_returns_protocol_error() {
+    fn malformed_streaming_tool_arguments_fixture_returns_invalid_tool_call() {
         let fixture = include_str!("../tests/fixtures/responses_stream_bad_tool_args.jsonl");
         let error = crate::parse::parse_responses_stream_events(fixture)
             .expect_err("malformed streamed tool arguments should fail");
 
-        assert_eq!(error.kind(), ProviderErrorKind::Protocol);
+        assert_eq!(error.kind(), ProviderErrorKind::InvalidToolCall);
     }
 
     #[test]

--- a/crates/merry-provider-openai/src/parse.rs
+++ b/crates/merry-provider-openai/src/parse.rs
@@ -366,12 +366,12 @@ fn parse_tool_call(
     let name = required_field(name, "function call name")?;
     let arguments = required_field(arguments, "function call arguments")?;
     let arguments: Value = serde_json::from_str(&arguments).map_err(|error| {
-        OpenAiProviderError::protocol(format!(
+        OpenAiProviderError::invalid_tool_call(format!(
             "function call arguments must be valid JSON: {error}"
         ))
     })?;
     let arguments = ToolArguments::try_from(arguments).map_err(|error| {
-        OpenAiProviderError::protocol(format!(
+        OpenAiProviderError::invalid_tool_call(format!(
             "function call arguments must be a JSON object: {error}"
         ))
     })?;

--- a/crates/merry-runtime/src/lib.rs
+++ b/crates/merry-runtime/src/lib.rs
@@ -134,8 +134,8 @@ pub use process::{
     is_read_only_shell_process_action_intent,
 };
 pub use process_runner::{
-    BwrapPermissionedProcessRunnerFactory, BwrapProcessRunner, BwrapSessionPermissions,
-    TokioProcessRunner,
+    BwrapPermissionedProcessRunnerFactory, BwrapProcessEnvironment, BwrapProcessRunner,
+    BwrapSessionPermissions, TokioProcessRunner,
 };
 pub use process_tool::{ProcessCommandToolError, process_command_tool};
 pub use profile::{

--- a/crates/merry-runtime/src/process_runner.rs
+++ b/crates/merry-runtime/src/process_runner.rs
@@ -155,24 +155,12 @@ impl BwrapProcessEnvironment {
         workspace_root: &Path,
     ) -> Result<Self, ProcessRunnerError> {
         validate_clean_absolute_path(workspace_root, "action workspace root")?;
-        if workspace_root == Path::new("/") {
-            return Err(ProcessRunnerError::infrastructure(
-                "action workspace root must not be the filesystem root",
-            ));
-        }
-
         validate_clean_absolute_path(&self.home, "sandbox process HOME")?;
         if self.home == Path::new("/") || self.home == Path::new("/home") {
             return Err(ProcessRunnerError::infrastructure(
                 "sandbox process HOME must identify a user directory",
             ));
         }
-        if self.home == workspace_root || self.home.starts_with(workspace_root) {
-            return Err(ProcessRunnerError::infrastructure(
-                "action workspace root must not be HOME or contain HOME",
-            ));
-        }
-
         validate_clean_absolute_path(&self.tmp_source, "sandbox process temporary directory")?;
         if self.tmp_source == Path::new("/") {
             return Err(ProcessRunnerError::infrastructure(
@@ -192,21 +180,6 @@ impl BwrapProcessEnvironment {
         if !is_supported_temp_path(&tmp_source) {
             return Err(ProcessRunnerError::infrastructure(
                 "sandbox process TMPDIR must resolve under /tmp, /var/tmp, /dev/shm, or a runtime temporary subdirectory",
-            ));
-        }
-
-        let canonical_workspace =
-            fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
-        if canonical_workspace == tmp_source
-            || (canonical_workspace.starts_with(&tmp_source) && !is_standard_temp_root(&tmp_source))
-        {
-            return Err(ProcessRunnerError::infrastructure(
-                "action workspace root must not be the selected temporary directory or its descendant",
-            ));
-        }
-        if self.home == tmp_source || self.home.starts_with(&tmp_source) {
-            return Err(ProcessRunnerError::infrastructure(
-                "sandbox process HOME must not be inside the selected temporary directory",
             ));
         }
 
@@ -296,16 +269,6 @@ fn is_standard_temp_path(path: &Path) -> bool {
     ]
     .into_iter()
     .any(|root| path == root || path.starts_with(root))
-}
-
-fn is_standard_temp_root(path: &Path) -> bool {
-    [
-        Path::new("/tmp"),
-        Path::new("/var/tmp"),
-        Path::new("/dev/shm"),
-    ]
-    .into_iter()
-    .any(|root| path == root)
 }
 
 fn absolute_env_path(name: &str, fallback: &str) -> PathBuf {
@@ -1304,7 +1267,7 @@ mod tests {
     }
 
     #[test]
-    fn bwrap_process_environment_validates_mount_boundaries_and_overrides() {
+    fn bwrap_process_environment_validates_temporary_boundary_and_overrides() {
         let environment =
             BwrapProcessEnvironment::new("/custom/bin:/usr/bin", "/home/alice", "/tmp")
                 .expect("environment layout should validate");
@@ -1313,15 +1276,10 @@ mod tests {
             .expect("standard temporary directory should be accepted");
         assert_eq!(validated.tmp_source, PathBuf::from("/tmp"));
 
-        for (workspace, expected) in [
-            ("/home", "must not be HOME or contain HOME"),
-            ("/home/alice", "must not be HOME or contain HOME"),
-            ("/tmp", "selected temporary directory"),
-        ] {
-            let error = environment
+        for workspace in ["/", "/home", "/home/alice", "/etc", "/tmp"] {
+            environment
                 .validate_for_workspace(Path::new(workspace))
-                .expect_err("overlapping action paths must be rejected");
-            assert!(error.to_string().contains(expected), "{error}");
+                .expect("the explicit workspace path should be accepted");
         }
 
         let error = BwrapProcessEnvironment::new("/custom/bin:/usr/bin", "/home/alice", "/etc")

--- a/crates/merry-runtime/src/process_runner.rs
+++ b/crates/merry-runtime/src/process_runner.rs
@@ -11,9 +11,9 @@ use crate::{
 };
 use std::{
     env,
-    ffi::OsString,
-    io,
-    path::{Path, PathBuf},
+    ffi::{OsStr, OsString},
+    fs, io,
+    path::{Component, Path, PathBuf},
     process::Stdio,
     sync::{Arc, RwLock},
 };
@@ -112,16 +112,9 @@ impl BwrapProcessEnvironment {
                 "sandbox process PATH must not be empty",
             ));
         }
-        if !home.is_absolute() {
-            return Err(ProcessRunnerError::infrastructure(
-                "sandbox process HOME must be absolute",
-            ));
-        }
-        if !tmp_source.is_absolute() {
-            return Err(ProcessRunnerError::infrastructure(
-                "sandbox process temporary directory must be absolute",
-            ));
-        }
+        validate_os_string(&path, "sandbox process PATH")?;
+        validate_clean_absolute_path(&home, "sandbox process HOME")?;
+        validate_clean_absolute_path(&tmp_source, "sandbox process temporary directory")?;
         Ok(Self {
             path,
             home,
@@ -130,15 +123,189 @@ impl BwrapProcessEnvironment {
         })
     }
 
-    /// Adds trusted environment assignments after the sandbox defaults.
-    #[must_use]
+    /// Validates and adds environment assignments after the sandbox defaults.
     pub fn with_overrides(
         mut self,
         overrides: impl IntoIterator<Item = (OsString, OsString)>,
-    ) -> Self {
-        self.overrides = overrides.into_iter().collect();
-        self
+    ) -> Result<Self, ProcessRunnerError> {
+        let mut names = std::collections::BTreeSet::new();
+        let mut validated = Vec::new();
+        for (name, value) in overrides {
+            validate_environment_name(&name)?;
+            validate_os_string(&value, "sandbox process environment value")?;
+            if !names.insert(name.clone()) {
+                return Err(ProcessRunnerError::infrastructure(
+                    "sandbox process environment contains a duplicate variable",
+                ));
+            }
+            validated.push((name, value));
+        }
+        self.overrides = validated;
+        Ok(self)
     }
+
+    /// Validates the host paths before constructing one action namespace.
+    ///
+    /// The temporary source remains the caller-selected host `TMPDIR` in
+    /// `--no-sandbox` mode, but it must resolve to a real temporary directory.
+    /// The returned environment uses its resolved path so a symlink cannot
+    /// change the source after validation into a non-temporary tree.
+    pub fn validate_for_workspace(
+        &self,
+        workspace_root: &Path,
+    ) -> Result<Self, ProcessRunnerError> {
+        validate_clean_absolute_path(workspace_root, "action workspace root")?;
+        if workspace_root == Path::new("/") {
+            return Err(ProcessRunnerError::infrastructure(
+                "action workspace root must not be the filesystem root",
+            ));
+        }
+
+        validate_clean_absolute_path(&self.home, "sandbox process HOME")?;
+        if self.home == Path::new("/") || self.home == Path::new("/home") {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process HOME must identify a user directory",
+            ));
+        }
+        if self.home == workspace_root || self.home.starts_with(workspace_root) {
+            return Err(ProcessRunnerError::infrastructure(
+                "action workspace root must not be HOME or contain HOME",
+            ));
+        }
+
+        validate_clean_absolute_path(&self.tmp_source, "sandbox process temporary directory")?;
+        if self.tmp_source == Path::new("/") {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process temporary directory must not be the filesystem root",
+            ));
+        }
+        let tmp_source = fs::canonicalize(&self.tmp_source).map_err(|source| {
+            ProcessRunnerError::infrastructure(format!(
+                "failed to resolve sandbox process temporary directory: {source}"
+            ))
+        })?;
+        if !tmp_source.is_dir() {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process temporary directory must be a directory",
+            ));
+        }
+        if !is_supported_temp_path(&tmp_source) {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process TMPDIR must resolve under /tmp, /var/tmp, /dev/shm, or a runtime temporary subdirectory",
+            ));
+        }
+
+        let canonical_workspace =
+            fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
+        if canonical_workspace == tmp_source
+            || (canonical_workspace.starts_with(&tmp_source) && !is_standard_temp_root(&tmp_source))
+        {
+            return Err(ProcessRunnerError::infrastructure(
+                "action workspace root must not be the selected temporary directory or its descendant",
+            ));
+        }
+        if self.home == tmp_source || self.home.starts_with(&tmp_source) {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process HOME must not be inside the selected temporary directory",
+            ));
+        }
+
+        let mut validated = self.clone();
+        validated.tmp_source = tmp_source;
+        Ok(validated)
+    }
+}
+
+fn validate_os_string(value: &OsStr, label: &str) -> Result<(), ProcessRunnerError> {
+    let Some(value) = value.to_str() else {
+        return Err(ProcessRunnerError::infrastructure(format!(
+            "{label} must be valid UTF-8"
+        )));
+    };
+    if value.contains('\0') {
+        return Err(ProcessRunnerError::infrastructure(format!(
+            "{label} must not contain NUL"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_environment_name(name: &OsStr) -> Result<(), ProcessRunnerError> {
+    validate_os_string(name, "sandbox process environment name")?;
+    let name = name.to_str().ok_or_else(|| {
+        ProcessRunnerError::infrastructure("sandbox process environment name must be valid UTF-8")
+    })?;
+    let mut characters = name.chars();
+    let Some(first) = characters.next() else {
+        return Err(ProcessRunnerError::infrastructure(
+            "sandbox process environment name must not be empty",
+        ));
+    };
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    {
+        return Err(ProcessRunnerError::infrastructure(
+            "sandbox process environment names must use ASCII letters, digits, and underscores",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_clean_absolute_path(path: &Path, label: &str) -> Result<(), ProcessRunnerError> {
+    let Some(value) = path.to_str() else {
+        return Err(ProcessRunnerError::infrastructure(format!(
+            "{label} must be valid UTF-8"
+        )));
+    };
+    if value.contains('\0') {
+        return Err(ProcessRunnerError::infrastructure(format!(
+            "{label} must not contain NUL"
+        )));
+    }
+    if !path.is_absolute()
+        || !path
+            .components()
+            .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        return Err(ProcessRunnerError::infrastructure(format!(
+            "{label} must be a clean absolute path"
+        )));
+    }
+    Ok(())
+}
+
+fn is_supported_temp_path(path: &Path) -> bool {
+    is_standard_temp_path(path)
+        || env::var_os("XDG_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .filter(|root| {
+                root != path
+                    && root.is_absolute()
+                    && root.components().all(|component| {
+                        matches!(component, Component::RootDir | Component::Normal(_))
+                    })
+            })
+            .is_some_and(|root| path.starts_with(root))
+}
+
+fn is_standard_temp_path(path: &Path) -> bool {
+    [
+        Path::new("/tmp"),
+        Path::new("/var/tmp"),
+        Path::new("/dev/shm"),
+    ]
+    .into_iter()
+    .any(|root| path == root || path.starts_with(root))
+}
+
+fn is_standard_temp_root(path: &Path) -> bool {
+    [
+        Path::new("/tmp"),
+        Path::new("/var/tmp"),
+        Path::new("/dev/shm"),
+    ]
+    .into_iter()
+    .any(|root| path == root)
 }
 
 fn absolute_env_path(name: &str, fallback: &str) -> PathBuf {
@@ -221,6 +388,7 @@ impl BwrapProcessRunner {
         if let Some(message) = self.configuration_error.clone() {
             return Err(ProcessRunnerError::infrastructure(message));
         }
+        let environment = self.environment.validate_for_workspace(&self.cwd_root)?;
         let session_snapshot = self
             .session_permissions
             .as_ref()
@@ -236,7 +404,7 @@ impl BwrapProcessRunner {
         Ok(bwrap_process_plan_with_environment(
             intent,
             &self.cwd_root,
-            &self.environment,
+            &environment,
             network_allowed,
             &path_rules,
             &self.bwrap_program,
@@ -446,6 +614,9 @@ impl BwrapPermissionedProcessRunnerFactory {
 
 impl PermissionedProcessRunnerFactory for BwrapPermissionedProcessRunnerFactory {
     fn validate_request(&self, request: &PermissionRequest) -> Result<(), ProcessRunnerError> {
+        self.environment
+            .validate_for_workspace(&self.cwd_root)
+            .map(|_| ())?;
         self.path_rules_for_request(request).map(|_| ())
     }
 
@@ -654,13 +825,14 @@ fn bwrap_process_plan_with_environment(
         os(ACTION_SANDBOX_TMPDIR),
         os("--tmpfs"),
         os("/home"),
-        os("--perms"),
-        os("0700"),
     ];
     if !environment.home.starts_with(Path::new("/home")) {
         append_bwrap_mount_parent_args(&mut args, &environment.home);
+        args.extend([os("--tmpfs"), environment.home.as_os_str().to_owned()]);
     }
     args.extend([
+        os("--perms"),
+        os("0700"),
         os("--dir"),
         environment.home.as_os_str().to_owned(),
         os("--ro-bind"),
@@ -1101,7 +1273,8 @@ mod tests {
             "/run/merry/session-tmp",
         )
         .expect("environment layout should validate")
-        .with_overrides([(OsString::from("RUSTUP_TOOLCHAIN"), OsString::from("stable"))]);
+        .with_overrides([(OsString::from("RUSTUP_TOOLCHAIN"), OsString::from("stable"))])
+        .expect("environment override should validate");
         let plan = bwrap_process_plan_with_environment(
             &intent(None),
             Path::new("/workspace/merry"),
@@ -1127,6 +1300,89 @@ mod tests {
         assert!(contains_sequence(
             &args,
             &["--setenv", "RUSTUP_TOOLCHAIN", "stable"]
+        ));
+    }
+
+    #[test]
+    fn bwrap_process_environment_validates_mount_boundaries_and_overrides() {
+        let environment =
+            BwrapProcessEnvironment::new("/custom/bin:/usr/bin", "/home/alice", "/tmp")
+                .expect("environment layout should validate");
+        let validated = environment
+            .validate_for_workspace(Path::new("/workspace/merry"))
+            .expect("standard temporary directory should be accepted");
+        assert_eq!(validated.tmp_source, PathBuf::from("/tmp"));
+
+        for (workspace, expected) in [
+            ("/home", "must not be HOME or contain HOME"),
+            ("/home/alice", "must not be HOME or contain HOME"),
+            ("/tmp", "selected temporary directory"),
+        ] {
+            let error = environment
+                .validate_for_workspace(Path::new(workspace))
+                .expect_err("overlapping action paths must be rejected");
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+
+        let error = BwrapProcessEnvironment::new("/custom/bin:/usr/bin", "/home/alice", "/etc")
+            .expect("environment path shape should validate")
+            .validate_for_workspace(Path::new("/workspace/merry"))
+            .expect_err("non-temporary TMPDIR must be rejected");
+        assert!(error.to_string().contains("TMPDIR"));
+
+        let overridden = environment
+            .clone()
+            .with_overrides([
+                (OsString::from("PATH"), OsString::from("/override/bin")),
+                (OsString::from("HOME"), OsString::from("/override/home")),
+                (OsString::from("TMPDIR"), OsString::from("/override/tmp")),
+            ])
+            .expect("supported environment names should override defaults");
+        assert_eq!(overridden.overrides.len(), 3);
+
+        for name in ["", "1INVALID", "INVALID-NAME", "INVALID=NAME"] {
+            let error = environment
+                .clone()
+                .with_overrides([(OsString::from(name), OsString::from("value"))])
+                .expect_err("invalid environment names must be rejected");
+            assert!(error.to_string().contains("environment"), "{error}");
+        }
+        let error = environment
+            .with_overrides([
+                (OsString::from("DUPLICATE"), OsString::from("one")),
+                (OsString::from("DUPLICATE"), OsString::from("two")),
+            ])
+            .expect_err("duplicate environment names must be rejected");
+        assert!(error.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn bwrap_process_plan_places_custom_home_permissions_on_home_directory() {
+        let environment =
+            BwrapProcessEnvironment::new("/custom/bin:/usr/bin", "/srv/alice", "/tmp")
+                .expect("environment layout should validate");
+        let plan = bwrap_process_plan_with_environment(
+            &intent(None),
+            Path::new("/workspace/merry"),
+            &environment,
+            true,
+            &[],
+            Path::new("/custom/bin/bwrap"),
+        );
+        let args = os_args(&plan.args);
+
+        assert!(contains_sequence(
+            &args,
+            &[
+                "--dir",
+                "/srv",
+                "--tmpfs",
+                "/srv/alice",
+                "--perms",
+                "0700",
+                "--dir",
+                "/srv/alice"
+            ]
         ));
     }
 

--- a/crates/merry-runtime/src/process_runner.rs
+++ b/crates/merry-runtime/src/process_runner.rs
@@ -10,6 +10,7 @@ use crate::{
     ProcessRunnerError, ProcessRunnerFuture, ProcessRunnerOutput,
 };
 use std::{
+    env,
     ffi::OsString,
     io,
     path::{Path, PathBuf},
@@ -19,8 +20,9 @@ use std::{
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 const BWRAP_PROGRAM: &str = "bwrap";
-const ACTION_SANDBOX_HOME: &str = "/home/merry";
+const ACTION_SANDBOX_HOME_FALLBACK: &str = "/home/merry";
 const ACTION_SANDBOX_TMPDIR: &str = "/tmp";
+const ACTION_SANDBOX_PATH_FALLBACK: &str = "/usr/local/bin:/usr/bin:/bin";
 const ACTION_SANDBOX_ETC_READ_ONLY_FILE_PATHS: &[&str] = &[
     "/etc/ld.so.cache",
     "/etc/ld.so.conf",
@@ -65,6 +67,87 @@ impl TokioProcessRunner {
     }
 }
 
+/// Host-derived paths used to construct one action sandbox.
+///
+/// The HOME and PATH values preserve the caller's path namespace. The source
+/// temporary directory is mounted at `/tmp` for every action, so an outer
+/// session tmpfs remains shared while per-action bubblewrap namespaces stay
+/// isolated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BwrapProcessEnvironment {
+    path: OsString,
+    home: PathBuf,
+    tmp_source: PathBuf,
+    overrides: Vec<(OsString, OsString)>,
+}
+
+impl BwrapProcessEnvironment {
+    /// Builds an environment layout from the current process environment.
+    #[must_use]
+    pub fn from_current_process() -> Self {
+        let path = env::var_os("PATH")
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| OsString::from(ACTION_SANDBOX_PATH_FALLBACK));
+        let home = absolute_env_path("HOME", ACTION_SANDBOX_HOME_FALLBACK);
+        let tmp_source = absolute_env_path("TMPDIR", ACTION_SANDBOX_TMPDIR);
+        Self {
+            path,
+            home,
+            tmp_source,
+            overrides: Vec::new(),
+        }
+    }
+
+    /// Creates a validated environment layout for an action sandbox.
+    pub fn new(
+        path: impl Into<OsString>,
+        home: impl Into<PathBuf>,
+        tmp_source: impl Into<PathBuf>,
+    ) -> Result<Self, ProcessRunnerError> {
+        let path = path.into();
+        let home = home.into();
+        let tmp_source = tmp_source.into();
+        if path.is_empty() {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process PATH must not be empty",
+            ));
+        }
+        if !home.is_absolute() {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process HOME must be absolute",
+            ));
+        }
+        if !tmp_source.is_absolute() {
+            return Err(ProcessRunnerError::infrastructure(
+                "sandbox process temporary directory must be absolute",
+            ));
+        }
+        Ok(Self {
+            path,
+            home,
+            tmp_source,
+            overrides: Vec::new(),
+        })
+    }
+
+    /// Adds trusted environment assignments after the sandbox defaults.
+    #[must_use]
+    pub fn with_overrides(
+        mut self,
+        overrides: impl IntoIterator<Item = (OsString, OsString)>,
+    ) -> Self {
+        self.overrides = overrides.into_iter().collect();
+        self
+    }
+}
+
+fn absolute_env_path(name: &str, fallback: &str) -> PathBuf {
+    env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .unwrap_or_else(|| PathBuf::from(fallback))
+}
+
 /// Runtime-owned process runner that executes each process inside bubblewrap.
 ///
 /// This is Merry's per-action sandbox backend for Linux. It is intentionally
@@ -74,6 +157,7 @@ impl TokioProcessRunner {
 #[derive(Debug, Clone)]
 pub struct BwrapProcessRunner {
     cwd_root: PathBuf,
+    environment: BwrapProcessEnvironment,
     network_allowed: bool,
     path_rules: Vec<PathAccessRule>,
     session_permissions: Option<BwrapSessionPermissions>,
@@ -87,12 +171,20 @@ impl BwrapProcessRunner {
     pub fn new_at_workspace_root(root: impl Into<PathBuf>) -> Self {
         Self {
             cwd_root: root.into(),
+            environment: BwrapProcessEnvironment::from_current_process(),
             network_allowed: false,
             path_rules: Vec::new(),
             session_permissions: None,
             bwrap_program: PathBuf::from(BWRAP_PROGRAM),
             configuration_error: None,
         }
+    }
+
+    /// Sets the environment layout visible to child processes.
+    #[must_use]
+    pub fn with_environment(mut self, environment: BwrapProcessEnvironment) -> Self {
+        self.environment = environment;
+        self
     }
 
     /// Allows network access for child process actions.
@@ -141,9 +233,10 @@ impl BwrapProcessRunner {
             network_allowed |= snapshot.network_allowed;
         }
         path_rules = normalize_path_rules(path_rules);
-        Ok(bwrap_process_plan(
+        Ok(bwrap_process_plan_with_environment(
             intent,
             &self.cwd_root,
+            &self.environment,
             network_allowed,
             &path_rules,
             &self.bwrap_program,
@@ -220,6 +313,7 @@ impl BwrapSessionPermissions {
 #[derive(Debug, Clone)]
 pub struct BwrapPermissionedProcessRunnerFactory {
     cwd_root: PathBuf,
+    environment: BwrapProcessEnvironment,
     base_network_allowed: bool,
     path_rules: Vec<PathAccessRule>,
     session_permissions: Option<BwrapSessionPermissions>,
@@ -232,11 +326,19 @@ impl BwrapPermissionedProcessRunnerFactory {
     pub fn new_at_workspace_root(root: impl Into<PathBuf>) -> Self {
         Self {
             cwd_root: root.into(),
+            environment: BwrapProcessEnvironment::from_current_process(),
             base_network_allowed: false,
             path_rules: Vec::new(),
             session_permissions: None,
             bwrap_program: PathBuf::from(BWRAP_PROGRAM),
         }
+    }
+
+    /// Sets the environment layout used by every materialized child runner.
+    #[must_use]
+    pub fn with_environment(mut self, environment: BwrapProcessEnvironment) -> Self {
+        self.environment = environment;
+        self
     }
 
     /// Allows network capability in the base profile before per-request grants.
@@ -323,6 +425,7 @@ impl BwrapPermissionedProcessRunnerFactory {
             Err(error) => (self.path_rules.clone(), Some(error.to_string())),
         };
         let mut runner = BwrapProcessRunner::new_at_workspace_root(self.cwd_root.clone())
+            .with_environment(self.environment.clone())
             .with_path_rules(path_rules);
         let session_network_allowed = self
             .session_permissions
@@ -501,9 +604,34 @@ struct BwrapProcessPlan {
     cwd: PathBuf,
 }
 
+#[cfg(test)]
 fn bwrap_process_plan(
     intent: &ProcessActionIntent,
     cwd_root: &Path,
+    network_allowed: bool,
+    path_rules: &[PathAccessRule],
+    bwrap_program: &Path,
+) -> BwrapProcessPlan {
+    let environment = BwrapProcessEnvironment {
+        path: OsString::from(ACTION_SANDBOX_PATH_FALLBACK),
+        home: PathBuf::from(ACTION_SANDBOX_HOME_FALLBACK),
+        tmp_source: PathBuf::from(ACTION_SANDBOX_TMPDIR),
+        overrides: Vec::new(),
+    };
+    bwrap_process_plan_with_environment(
+        intent,
+        cwd_root,
+        &environment,
+        network_allowed,
+        path_rules,
+        bwrap_program,
+    )
+}
+
+fn bwrap_process_plan_with_environment(
+    intent: &ProcessActionIntent,
+    cwd_root: &Path,
+    environment: &BwrapProcessEnvironment,
     network_allowed: bool,
     path_rules: &[PathAccessRule],
     bwrap_program: &Path,
@@ -521,16 +649,20 @@ fn bwrap_process_plan(
         os("/proc"),
         os("--dev"),
         os("/dev"),
-        os("--perms"),
-        os("01777"),
-        os("--tmpfs"),
+        os("--bind"),
+        environment.tmp_source.as_os_str().to_owned(),
         os(ACTION_SANDBOX_TMPDIR),
         os("--tmpfs"),
         os("/home"),
         os("--perms"),
         os("0700"),
+    ];
+    if !environment.home.starts_with(Path::new("/home")) {
+        append_bwrap_mount_parent_args(&mut args, &environment.home);
+    }
+    args.extend([
         os("--dir"),
-        os(ACTION_SANDBOX_HOME),
+        environment.home.as_os_str().to_owned(),
         os("--ro-bind"),
         os("/usr"),
         os("/usr"),
@@ -546,7 +678,7 @@ fn bwrap_process_plan(
         os("--ro-bind-try"),
         os("/opt"),
         os("/opt"),
-    ];
+    ]);
     for path in ACTION_SANDBOX_ETC_READ_ONLY_FILE_PATHS {
         if Path::new(path).exists() {
             append_bwrap_file_bind_args(&mut args, Path::new(path), Path::new(path));
@@ -560,7 +692,7 @@ fn bwrap_process_plan(
     if !network_allowed {
         args.push(os("--unshare-net"));
     }
-    append_bwrap_path_rule(&mut args, cwd_root, PathAccess::ReadWrite);
+    append_bwrap_required_path_rule(&mut args, cwd_root, PathAccess::ReadWrite);
     for rule in path_rules {
         append_bwrap_path_rule(&mut args, rule.path(), rule.access());
     }
@@ -570,18 +702,21 @@ fn bwrap_process_plan(
         os("--clearenv"),
         os("--setenv"),
         os("PATH"),
-        os("/usr/local/bin:/usr/bin:/bin"),
+        environment.path.clone(),
         os("--setenv"),
         os("HOME"),
-        os(ACTION_SANDBOX_HOME),
+        environment.home.as_os_str().to_owned(),
         os("--setenv"),
         os("TMPDIR"),
         os(ACTION_SANDBOX_TMPDIR),
         os("--setenv"),
         os("PWD"),
         cwd.as_os_str().to_owned(),
-        os("--"),
     ]);
+    for (name, value) in &environment.overrides {
+        args.extend([os("--setenv"), name.clone(), value.clone()]);
+    }
+    args.push(os("--"));
     args.extend(intent.argv().iter().map(OsString::from));
 
     BwrapProcessPlan {
@@ -625,6 +760,23 @@ fn append_bwrap_path_rule(args: &mut Vec<OsString>, path: &Path, access: PathAcc
         PathAccess::Deny => {
             args.extend([os("--tmpfs"), path.as_os_str().to_owned()]);
         }
+    }
+}
+
+fn append_bwrap_required_path_rule(args: &mut Vec<OsString>, path: &Path, access: PathAccess) {
+    append_bwrap_mount_parent_args(args, path);
+    match access {
+        PathAccess::ReadOnly => args.extend([
+            os("--ro-bind"),
+            path.as_os_str().to_owned(),
+            path.as_os_str().to_owned(),
+        ]),
+        PathAccess::ReadWrite => args.extend([
+            os("--bind"),
+            path.as_os_str().to_owned(),
+            path.as_os_str().to_owned(),
+        ]),
+        PathAccess::Deny => args.extend([os("--tmpfs"), path.as_os_str().to_owned()]),
     }
 }
 
@@ -841,7 +993,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{BwrapProcessRunner, TokioProcessRunner, bwrap_process_plan, process_current_dir};
+    use super::{
+        BwrapProcessEnvironment, BwrapProcessRunner, TokioProcessRunner, bwrap_process_plan,
+        bwrap_process_plan_with_environment, process_current_dir,
+    };
     use crate::{
         PathAccess, PathAccessRule, PathAccessRuleSource, PermissionRequest, PermissionedAction,
         PermissionedProcessRunnerFactory, ProcessActionIntent, ProcessEnvPolicy, ProcessExitStatus,
@@ -923,7 +1078,7 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "--unshare-net"));
         assert!(contains_sequence(
             &args,
-            &["--bind-try", "/workspace/merry", "/workspace/merry"]
+            &["--bind", "/workspace/merry", "/workspace/merry"]
         ));
         if Path::new("/etc/ld.so.cache").exists() {
             assert!(contains_sequence(
@@ -936,6 +1091,43 @@ mod tests {
             &["--chdir", "/workspace/merry/crates"]
         ));
         assert!(contains_sequence(&args, &["--", "pwd"]));
+    }
+
+    #[test]
+    fn bwrap_process_plan_applies_user_environment_overrides_after_defaults() {
+        let environment = BwrapProcessEnvironment::new(
+            "/custom/bin:/usr/bin",
+            "/home/alice",
+            "/run/merry/session-tmp",
+        )
+        .expect("environment layout should validate")
+        .with_overrides([(OsString::from("RUSTUP_TOOLCHAIN"), OsString::from("stable"))]);
+        let plan = bwrap_process_plan_with_environment(
+            &intent(None),
+            Path::new("/workspace/merry"),
+            &environment,
+            true,
+            &[],
+            Path::new("/custom/bin/bwrap"),
+        );
+        let args = os_args(&plan.args);
+
+        assert!(contains_sequence(
+            &args,
+            &["--bind", "/run/merry/session-tmp", "/tmp"]
+        ));
+        assert!(contains_sequence(
+            &args,
+            &["--setenv", "PATH", "/custom/bin:/usr/bin"]
+        ));
+        assert!(contains_sequence(
+            &args,
+            &["--setenv", "HOME", "/home/alice"]
+        ));
+        assert!(contains_sequence(
+            &args,
+            &["--setenv", "RUSTUP_TOOLCHAIN", "stable"]
+        ));
     }
 
     #[test]
@@ -1332,6 +1524,92 @@ mod tests {
 
         assert_eq!(output.status(), ProcessExitStatus::Exited(0));
         assert_eq!(output.stdout_text(), format!("{path}\n{home}"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn bwrap_process_runner_reuses_tmp_and_writes_workspace() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir should be created");
+        let marker = format!("merry-process-runner-{}", std::process::id());
+        // This container cannot create a network namespace; filesystem and
+        // temporary-directory behavior are independent of that capability.
+        let runner = BwrapProcessRunner::new_at_workspace_root(workspace.path())
+            .allow_network()
+            .with_bwrap_program("/usr/bin/bwrap");
+
+        let write_tmp = ProcessActionIntent::new(
+            vec![
+                "/bin/sh".to_owned(),
+                "-c".to_owned(),
+                format!("printf 'tmp-ok' > /tmp/{marker}"),
+            ],
+            None,
+            ProcessEnvPolicy::empty(),
+            None,
+            1024,
+            1024,
+        )
+        .expect("temporary write intent should be valid");
+        let first = runner
+            .run(
+                write_tmp,
+                ProcessRunnerContext::new(CancellationToken::new()),
+            )
+            .await
+            .expect("first bwrap action should run");
+        assert!(first.ok(), "first bwrap action failed: {first:?}");
+
+        let read_tmp = ProcessActionIntent::new(
+            vec![
+                "/bin/sh".to_owned(),
+                "-c".to_owned(),
+                format!("cat /tmp/{marker}"),
+            ],
+            None,
+            ProcessEnvPolicy::empty(),
+            None,
+            1024,
+            1024,
+        )
+        .expect("temporary read intent should be valid");
+        let second = runner
+            .run(
+                read_tmp,
+                ProcessRunnerContext::new(CancellationToken::new()),
+            )
+            .await
+            .expect("second bwrap action should run");
+        assert!(second.ok(), "second bwrap action failed: {second:?}");
+        assert_eq!(second.stdout_text(), "tmp-ok");
+
+        let write_workspace = ProcessActionIntent::new(
+            vec![
+                "/bin/sh".to_owned(),
+                "-c".to_owned(),
+                "printf 'workspace-ok' > workspace-write.txt".to_owned(),
+            ],
+            None,
+            ProcessEnvPolicy::empty(),
+            None,
+            1024,
+            1024,
+        )
+        .expect("workspace write intent should be valid");
+        let third = runner
+            .run(
+                write_workspace,
+                ProcessRunnerContext::new(CancellationToken::new()),
+            )
+            .await
+            .expect("workspace write action should run");
+        assert!(third.ok(), "workspace write action failed: {third:?}");
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("workspace-write.txt"))
+                .expect("workspace write should persist"),
+            "workspace-ok"
+        );
+
+        let _ = std::fs::remove_file(Path::new("/tmp").join(marker));
     }
 
     fn os_args(args: &[OsString]) -> Vec<String> {

--- a/crates/merry-runtime/src/runtime/journal_emission.rs
+++ b/crates/merry-runtime/src/runtime/journal_emission.rs
@@ -501,6 +501,7 @@ fn duration_millis_u64(duration: std::time::Duration) -> u64 {
 fn provider_error_kind_label(kind: ProviderErrorKind) -> &'static str {
     match kind {
         ProviderErrorKind::InvalidRequest => "invalid_request",
+        ProviderErrorKind::InvalidToolCall => "invalid_tool_call",
         ProviderErrorKind::Cancelled => "cancelled",
         ProviderErrorKind::Authentication => "authentication",
         ProviderErrorKind::RateLimited => "rate_limited",

--- a/crates/merry-runtime/src/runtime/model_output.rs
+++ b/crates/merry-runtime/src/runtime/model_output.rs
@@ -118,6 +118,7 @@ pub(super) fn is_cancelled_model_error(error: &ModelError) -> bool {
 pub(super) fn diagnostic_from_model_error(error: ModelError) -> ErrorInfo {
     let code = match error.kind() {
         ProviderErrorKind::InvalidRequest => "model_invalid_request",
+        ProviderErrorKind::InvalidToolCall => "model_invalid_tool_call",
         ProviderErrorKind::Cancelled => "cancelled",
         ProviderErrorKind::Authentication => "model_authentication",
         ProviderErrorKind::RateLimited => "model_rate_limited",

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -45,8 +45,9 @@ deny_paths = [
 ]
 
 # Optional environment assignments for Merry-managed process actions. Values
-# are injected after the sandbox defaults; filesystem access is still governed
-# by the path rules above.
+# are injected after the inner action sandbox defaults, so they may override
+# PATH, HOME, TMPDIR, or PWD. They do not change the outer bootstrap or provider
+# environment; filesystem access is still governed by the path rules above.
 # environment = [
 #   { name = "RUSTUP_TOOLCHAIN", value = "stable" },
 # ]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -44,6 +44,13 @@ deny_paths = [
   "~/.ssh",
 ]
 
+# Optional environment assignments for Merry-managed process actions. Values
+# are injected after the sandbox defaults; filesystem access is still governed
+# by the path rules above.
+# environment = [
+#   { name = "RUSTUP_TOOLCHAIN", value = "stable" },
+# ]
+
 [skills]
 # Skill metadata is projected into the cacheable stable prefix. Full SKILL.md
 # bodies remain on disk and are read through workspace_read_file only when used.


### PR DESCRIPTION
Summary:

- Use the host HOME and XDG paths in both sandbox layers so user paths keep their original namespace.
- Share a session-level in-memory /tmp, reuse the current TMPDIR/PATH for --no-sandbox, and support validated process environment overrides.
- Bind the workspace read-write and retry malformed OpenAI/Anthropic tool arguments before visible output.

Verification:

- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- Targeted bwrap, sandbox, config, provider, retry, and coding-loop tests pass.
- cargo test --all --no-fail-fast: all other tests pass; six unchanged model-catalog fixture tests are blocked by EPERM when creating a local listener in this container.

Closes #22