### PR TITLE
fix(benchmark): enforce smoke results and cache Rust builds

### DIFF
--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -35,25 +35,74 @@ jobs:
       MERRY_MODEL: ${{ vars.MERRY_MODEL || 'gpt-4.1-mini' }}
       MERRY_PROTOCOL: ${{ vars.MERRY_PROTOCOL || 'responses' }}
       MERRY_HARBOR_MODEL: ${{ vars.MERRY_HARBOR_MODEL || '' }}
+      CARGO_HOME: ${{ runner.temp }}/cargo-home
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      CARGO_NET_RETRY: "10"
+      CARGO_HTTP_TIMEOUT: "120"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      UV_HTTP_RETRIES: "10"
+      UV_HTTP_TIMEOUT: "120"
+      UV_HTTP_CONNECT_TIMEOUT: "30"
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: benchmark/uv.lock
+
+      - name: Restore Cargo registry cache
+        id: cargo-registry-cache
+        continue-on-error: true
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ${{ runner.temp }}/cargo-home/registry
+            ${{ runner.temp }}/cargo-home/git
+          key: ${{ runner.os }}-merry-cargo-${{ hashFiles('Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-merry-cargo-
+
+      - name: Restore Cargo build cache
+        id: cargo-target-cache
+        continue-on-error: true
+        uses: actions/cache/restore@v6
+        with:
+          path: target
+          key: ${{ runner.os }}-merry-target-${{ hashFiles('Cargo.lock', '**/Cargo.toml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-merry-target-${{ hashFiles('Cargo.lock', '**/Cargo.toml') }}-
+            ${{ runner.os }}-merry-target-
 
       - name: Check Docker runtime
         run: docker version
 
       - name: Build Merry CLI
         run: cargo build --locked --release -p merry-cli
+
+      - name: Save Cargo registry cache
+        if: ${{ !cancelled() && steps.cargo-registry-cache.outputs.cache-primary-key != '' }}
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ${{ runner.temp }}/cargo-home/registry
+            ${{ runner.temp }}/cargo-home/git
+          key: ${{ steps.cargo-registry-cache.outputs.cache-primary-key }}
+
+      - name: Save Cargo build cache
+        if: ${{ !cancelled() && steps.cargo-target-cache.outputs.cache-primary-key != '' }}
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: target
+          key: ${{ steps.cargo-target-cache.outputs.cache-primary-key }}
 
       - name: Install benchmark dependencies
         working-directory: benchmark
@@ -131,6 +180,8 @@ jobs:
           printf 'api_key_path=%s\n' "$RUNNER_TEMP/merry-config/secrets/openai.key" >> "$GITHUB_OUTPUT"
 
       - name: Run Harbor smoke
+        id: harbor-run
+        continue-on-error: true
         working-directory: benchmark
         env:
           DATASET: ${{ inputs.dataset }}
@@ -163,6 +214,36 @@ jobs:
             --agent-env "MERRY_CONFIG_PATH=$MERRY_CONFIG_PATH" \
             --agent-env "MERRY_API_KEY_FILE_PATH=$MERRY_API_KEY_FILE_PATH" \
             --agent-env "MERRY_AGENT_VERSION=$MERRY_AGENT_VERSION"
+
+      - name: Validate Harbor result
+        if: always()
+        working-directory: benchmark
+        env:
+          HARBOR_RUN_OUTCOME: ${{ steps.harbor-run.outcome }}
+        run: |
+          set -euo pipefail
+
+          result_path="$(find "$RUNNER_TEMP/harbor-jobs" \
+            -mindepth 2 -maxdepth 2 -type f -name result.json -print -quit \
+            2>/dev/null || true)"
+          if [[ -z "$result_path" ]]; then
+            echo "::error::Harbor did not produce a job result.json"
+            exit 1
+          fi
+
+          validation_status=0
+          if uv run python -m merry_benchmark.harbor_result "$result_path"; then
+            :
+          else
+            validation_status=1
+          fi
+
+          if [[ "$HARBOR_RUN_OUTCOME" != "success" ]]; then
+            echo "::error::Harbor command finished with outcome: $HARBOR_RUN_OUTCOME"
+            validation_status=1
+          fi
+
+          exit "$validation_status"
 
       - name: Remove temporary Merry credentials
         if: always()

--- a/benchmark/src/merry_benchmark/harbor_result.py
+++ b/benchmark/src/merry_benchmark/harbor_result.py
@@ -1,0 +1,88 @@
+"""Validate the Harbor job result used by the CI smoke evaluation."""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from harbor.models.job.result import JobResult
+
+
+def load_result(path: Path) -> JobResult:
+    """Load a Harbor job result from its persisted JSON file."""
+    return JobResult.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def result_failures(result: JobResult) -> tuple[str, ...]:
+    """Return CI-failing conditions found in a Harbor job result."""
+    failures: list[str] = []
+    stats = result.stats
+
+    if result.n_total_trials <= 0:
+        failures.append("Harbor ran no trials")
+    if stats.n_completed_trials != result.n_total_trials:
+        failures.append(f"Harbor did not complete all trials: {stats.n_completed_trials}/{result.n_total_trials}")
+    if stats.n_running_trials:
+        failures.append(f"Harbor still has {stats.n_running_trials} running trial(s)")
+    if stats.n_pending_trials:
+        failures.append(f"Harbor still has {stats.n_pending_trials} pending trial(s)")
+    if stats.n_cancelled_trials:
+        failures.append(f"Harbor cancelled {stats.n_cancelled_trials} trial(s)")
+    if stats.n_errored_trials:
+        failures.append(f"Harbor recorded {stats.n_errored_trials} errored trial(s)")
+    if not stats.evals:
+        failures.append("Harbor produced no evaluation groups")
+
+    for eval_name, eval_stats in stats.evals.items():
+        reward_stats = eval_stats.reward_stats.get("reward")
+        if reward_stats is None:
+            failures.append(f"Harbor evaluation {eval_name!r} has no reward values")
+            continue
+
+        reward_count = 0
+        for reward, trial_names in reward_stats.items():
+            reward_count += len(trial_names)
+            if not math.isfinite(float(reward)):
+                failures.append(f"Harbor evaluation {eval_name!r} has a non-finite reward")
+            elif reward <= 0:
+                failures.append(f"Harbor evaluation {eval_name!r} has non-positive reward: {reward}")
+
+        if reward_count != eval_stats.n_trials:
+            failures.append(
+                f"Harbor evaluation {eval_name!r} has incomplete reward data: "
+                f"{reward_count}/{eval_stats.n_trials} trials"
+            )
+
+    return tuple(failures)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate one Harbor job result and return a process exit code."""
+    arguments = sys.argv if argv is None else argv
+    if len(arguments) != 2:
+        print(f"usage: {arguments[0]} RESULT_JSON", file=sys.stderr)
+        return 2
+
+    result_path = Path(arguments[1])
+    try:
+        result = load_result(result_path)
+    except (OSError, ValueError) as exc:
+        print(f"::error::Could not load Harbor result: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Harbor result: "
+        f"{result.stats.n_completed_trials}/{result.n_total_trials} completed, "
+        f"{result.stats.n_errored_trials} errored"
+    )
+    failures = result_failures(result)
+    for failure in failures:
+        print(f"::error::{failure}", file=sys.stderr)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/tests/test_harbor_result.py
+++ b/benchmark/tests/test_harbor_result.py
@@ -1,0 +1,70 @@
+"""Tests for the CI-facing Harbor result validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from merry_benchmark.harbor_result import load_result, result_failures
+
+
+def write_result(
+    tmp_path: Path,
+    *,
+    reward: float | None = 1.0,
+    errored_trials: int = 0,
+) -> Path:
+    """Write the smallest valid Harbor job result for a validation test."""
+    reward_stats: dict[str, dict[str, list[str]]] = {}
+    n_trials = 0
+    if reward is not None:
+        reward_stats = {"reward": {str(reward): ["trial-1"]}}
+        n_trials = 1
+
+    payload = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "started_at": "2026-08-08T00:00:00Z",
+        "finished_at": "2026-08-08T00:01:00Z",
+        "n_total_trials": 1,
+        "stats": {
+            "n_completed_trials": 1,
+            "n_errored_trials": errored_trials,
+            "n_running_trials": 0,
+            "n_pending_trials": 0,
+            "n_cancelled_trials": 0,
+            "evals": {
+                "merry__model__dataset": {
+                    "n_trials": n_trials,
+                    "n_errors": errored_trials,
+                    "reward_stats": reward_stats,
+                }
+            },
+        },
+    }
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    return result_path
+
+
+def test_successful_result_has_no_failures(tmp_path: Path) -> None:
+    result = load_result(write_result(tmp_path))
+
+    assert result_failures(result) == ()
+
+
+def test_errored_trial_fails_validation(tmp_path: Path) -> None:
+    result = load_result(write_result(tmp_path, reward=None, errored_trials=1))
+
+    assert any("errored trial" in failure for failure in result_failures(result))
+
+
+def test_non_positive_reward_fails_validation(tmp_path: Path) -> None:
+    result = load_result(write_result(tmp_path, reward=0.0))
+
+    assert any("non-positive reward" in failure for failure in result_failures(result))
+
+
+def test_missing_reward_fails_validation(tmp_path: Path) -> None:
+    result = load_result(write_result(tmp_path, reward=None))
+
+    assert any("no reward values" in failure for failure in result_failures(result))


### PR DESCRIPTION
## Summary

- fail the benchmark smoke job when Harbor reports command or trial errors, incomplete execution, missing rewards, or non-positive rewards
- upgrade checkout, cache, and setup-uv to Node 24-compatible action releases
- cache Cargo registry and git downloads plus the release target, with Cargo and uv retry and timeout settings

## Verification

- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- uv run pytest tests -q
- uv build

Refs: #8