### PR TITLE
feat(eval): add provider-neutral TaskSpec and evaluation record protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "merry-eval"
+version = "0.1.0"
+dependencies = [
+ "jsonschema",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "toml",
+]
+
+[[package]]
 name = "merry-llm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/merry",
     "crates/merry-cli",
     "crates/merry-py",
+    "crates/merry-eval",
 ]
 default-members = [
     "crates/merry-core",
@@ -23,6 +24,7 @@ default-members = [
     "crates/merry",
     "crates/merry-cli",
     "crates/merry-py",
+    "crates/merry-eval",
 ]
 
 [workspace.package]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ issues. This file keeps only the major delivery sequence and its dependencies.
 
 - [ ] [Parent: Establish an evaluable, reusable, production-grade Rust coding agent boundary](https://github.com/locez/merry/issues/9)
 - [x] [T0: Establish delivery baseline, roadmap, and architecture guard](https://github.com/locez/merry/issues/10)
-- [x] [T1: Establish independent Harbor benchmark integration](https://github.com/locez/merry/issues/8)
+- [x] [T1: Establish evaluation protocol and TaskSpec](https://github.com/locez/merry/issues/8)
 - [ ] [T2: Establish deterministic Offline Harness](https://github.com/locez/merry/issues/11)
 - [ ] [T3: Establish the unique CodingAgentProfile](https://github.com/locez/merry/issues/12)
 - [ ] [T4: Establish the internal Coding Eval Suite](https://github.com/locez/merry/issues/13)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -47,6 +47,15 @@ config file; it is uploaded privately and exposed through
 `MERRY_API_KEY_FILE_PATH` uploads that key separately with private permissions.
 Do not put credentials in this repository.
 
+## TaskSpec adapter
+
+Set `MERRY_TASK_SPEC_PATH` to a host-side TaskSpec TOML manifest when a Harbor
+trial should consume the provider-neutral evaluation protocol. The adapter
+strictly parses the manifest and translates it into Harbor's instruction
+boundary before invoking Merry. The Rust local-suite test and this adapter
+share `crates/merry-eval/tests/fixtures/adapter-task.toml` as the canonical
+contract fixture.
+
 ## GitHub Actions smoke
 
 `.github/workflows/benchmark-smoke.yml` is a manual, small-task smoke workflow.
@@ -117,6 +126,7 @@ fails clearly instead of silently evaluating another agent.
 Harbor's benchmark adapter converts an upstream benchmark into Harbor task
 directories (`task.toml`, instruction, environment, solution, and tests). That
 work belongs in Harbor's adapter and dataset repositories when a benchmark is
-not already registered. Merry owns the agent adapter here. A future
-Merry-specific internal suite may add a Harbor benchmark adapter without
-introducing a second evaluation protocol in the runtime.
+not already registered. Merry owns the agent adapter here. For protocol-backed
+trials, `MERRY_TASK_SPEC_PATH` lets this adapter consume the same TaskSpec TOML
+that the Rust local suite parses, without introducing Harbor or provider wire
+types into the runtime.

--- a/benchmark/src/merry_benchmark/agents/merry.py
+++ b/benchmark/src/merry_benchmark/agents/merry.py
@@ -17,11 +17,14 @@ from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 from pydantic import BaseModel
 
+from merry_benchmark.task_spec import load_task_spec
+
 MERRY_BINARY_PATH_ENV: Final[str] = "MERRY_BINARY_PATH"
 MERRY_COMMAND_ENV: Final[str] = "MERRY_COMMAND"
 MERRY_CONFIG_PATH_ENV: Final[str] = "MERRY_CONFIG_PATH"
 MERRY_API_KEY_FILE_PATH_ENV: Final[str] = "MERRY_API_KEY_FILE_PATH"
 MERRY_AGENT_VERSION_ENV: Final[str] = "MERRY_AGENT_VERSION"
+MERRY_TASK_SPEC_PATH_ENV: Final[str] = "MERRY_TASK_SPEC_PATH"
 DEFAULT_MERRY_COMMAND: Final[str] = "merry"
 REMOTE_MERRY_BINARY: Final[str] = "/installed-agent/merry"
 REMOTE_CONFIG_HOME: Final[str] = "/installed-agent/config"
@@ -78,6 +81,8 @@ class MerryAgent(BaseInstalledAgent):
     into each task container, or set ``MERRY_COMMAND`` when the task image
     already contains the exact Merry executable. ``MERRY_CONFIG_PATH`` is an
     optional host-side Merry config file uploaded with private permissions.
+    Set ``MERRY_TASK_SPEC_PATH`` to consume the shared TaskSpec TOML and
+    translate it into Harbor's instruction boundary for a trial.
     When that config references ``secrets/openai.key``, set
     ``MERRY_API_KEY_FILE_PATH`` to upload the key file separately with private
     permissions.
@@ -138,6 +143,18 @@ class MerryAgent(BaseInstalledAgent):
         """Execute one task instruction and record a minimal Harbor context."""
 
         context.metadata = {"merry_status": "running"}
+        task_spec_path = self._get_env(MERRY_TASK_SPEC_PATH_ENV)
+        if task_spec_path is not None:
+            try:
+                source_path = Path(task_spec_path).expanduser()
+                if not source_path.is_file():
+                    raise FileNotFoundError(
+                        f"{MERRY_TASK_SPEC_PATH_ENV} does not point to a file: {source_path}"
+                    )
+                instruction = load_task_spec(source_path).to_harbor_instruction()
+            except (OSError, ValueError):
+                context.metadata = {"merry_status": "failed"}
+                raise
         command = build_merry_run_command(self._remote_executable(), instruction)
         result = await environment.exec(
             command=f"set -o pipefail; {command}",

--- a/benchmark/src/merry_benchmark/task_spec.py
+++ b/benchmark/src/merry_benchmark/task_spec.py
@@ -1,0 +1,451 @@
+"""Load the shared TaskSpec manifest at the external benchmark boundary."""
+
+from __future__ import annotations
+
+import tomllib
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from math import isfinite
+from pathlib import Path
+
+type TomlValue = str | int | float | bool | list[TomlValue] | dict[str, TomlValue]
+
+MAX_DESCRIPTION_CHARS = 16 * 1024
+MAX_DIFF_CHARS = 1024 * 1024
+MAX_COMMAND_ARGS = 256
+MAX_COMMAND_ARG_CHARS = 16 * 1024
+MAX_PATH_CHARS = 512
+MAX_SCOPE_CHARS = 512
+MAX_TASK_TIMEOUT_SECONDS = 7 * 24 * 60 * 60
+
+
+def _mapping(value: TomlValue | None, field: str) -> Mapping[str, TomlValue]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a TOML table")
+    return value
+
+
+def _list(value: TomlValue | None, field: str) -> list[TomlValue]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a TOML array")
+    return value
+
+
+def _strict(mapping: Mapping[str, TomlValue], allowed: set[str], field: str) -> None:
+    unknown = set(mapping) - allowed
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"{field} has unknown field(s): {names}")
+
+
+def _is_control(character: str) -> bool:
+    return unicodedata.category(character) == "Cc"
+
+
+def _text(value: TomlValue | None, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be non-blank text")
+    return value
+
+
+def _optional_text(value: TomlValue | None, field: str) -> str | None:
+    if value is None:
+        return None
+    return _text(value, field)
+
+
+def _identifier(value: TomlValue | None, field: str, max_chars: int) -> str:
+    text = _text(value, field)
+    if text.strip() != text:
+        raise ValueError(f"{field} must not have leading or trailing whitespace")
+    if len(text) > max_chars:
+        raise ValueError(f"{field} must contain at most {max_chars} characters")
+    if any(_is_control(char) for char in text):
+        raise ValueError(f"{field} must not contain control characters")
+    return text
+
+
+def _protocol_text(value: TomlValue | None, field: str, max_chars: int) -> str:
+    text = _text(value, field)
+    if len(text) > max_chars:
+        raise ValueError(f"{field} must contain at most {max_chars} characters")
+    if any(char == "\x00" or (_is_control(char) and char not in {"\n", "\r", "\t"}) for char in text):
+        raise ValueError(f"{field} must not contain unsafe control characters")
+    return text
+
+
+def _relative_path(value: TomlValue | None, field: str, max_chars: int = MAX_PATH_CHARS) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must not be empty")
+    if value.startswith(("/", "\\")) or "\\" in value:
+        raise ValueError(f"{field} must be a relative slash-separated path")
+    if len(value) > max_chars:
+        raise ValueError(f"{field} must contain at most {max_chars} characters")
+    if any(_is_control(char) for char in value):
+        raise ValueError(f"{field} must not contain control characters")
+    if any(
+        not component
+        or component in {".", ".."}
+        or (len(component) > 1 and component[1] == ":")
+        for component in value.split("/")
+    ):
+        raise ValueError(f"{field} must not escape the task workspace")
+    return value
+
+
+def _optional_relative_path(value: TomlValue | None, field: str) -> str | None:
+    if value is None:
+        return None
+    return _relative_path(value, field)
+
+
+def _integer(value: TomlValue | None, field: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and isfinite(value) and value.is_integer():
+        return int(value)
+    raise ValueError(f"{field} must be an integer")
+
+
+def _positive_integer(value: TomlValue | None, field: str) -> int:
+    result = _integer(value, field)
+    if result <= 0:
+        raise ValueError(f"{field} must be greater than zero")
+    return result
+
+
+def _optional_positive_integer(value: TomlValue | None, field: str) -> int | None:
+    if value is None:
+        return None
+    return _positive_integer(value, field)
+
+
+def _commands(value: TomlValue | None, field: str) -> tuple[CommandSpecDocument, ...]:
+    return tuple(
+        CommandSpecDocument.from_mapping(_mapping(item, f"{field}[{index}]"), f"{field}[{index}]")
+        for index, item in enumerate(_list(value, field))
+    )
+
+
+@dataclass(frozen=True)
+class CommandSpecDocument:
+    """A command declaration consumed by the benchmark adapter."""
+
+    program: str
+    args: tuple[str, ...]
+    working_dir: str | None
+    timeout_seconds: int | None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, TomlValue], field: str) -> CommandSpecDocument:
+        _strict(value, {"program", "args", "working_dir", "timeout_seconds"}, field)
+        raw_args = value.get("args", [])
+        raw_arg_items = _list(raw_args, f"{field}.args")
+        if len(raw_arg_items) > MAX_COMMAND_ARGS:
+            raise ValueError(f"{field}.args must contain at most {MAX_COMMAND_ARGS} arguments")
+        args = tuple(
+            _protocol_text(item, f"{field}.args[{index}]", MAX_COMMAND_ARG_CHARS)
+            for index, item in enumerate(raw_arg_items)
+        )
+        timeout_value = value.get("timeout_seconds")
+        timeout = None if timeout_value is None else _positive_integer(timeout_value, f"{field}.timeout_seconds")
+        return cls(
+            program=_protocol_text(value.get("program"), f"{field}.program", MAX_PATH_CHARS),
+            args=args,
+            working_dir=_optional_relative_path(value.get("working_dir"), f"{field}.working_dir"),
+            timeout_seconds=timeout,
+        )
+
+    def render(self) -> str:
+        command = " ".join((self.program, *self.args))
+        if self.working_dir is not None:
+            command = f"{command} (cwd: {self.working_dir})"
+        if self.timeout_seconds is not None:
+            command = f"{command} (timeout: {self.timeout_seconds}s)"
+        return command
+
+
+@dataclass(frozen=True)
+class CriterionDocument:
+    """A success criterion represented at the external adapter boundary."""
+
+    kind: str
+    path: str | None
+    text: str | None
+    program: str | None
+    args: tuple[str, ...]
+    working_dir: str | None
+    expected: str | None
+    timeout_seconds: int | None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, TomlValue], field: str) -> CriterionDocument:
+        kind = _text(value.get("kind"), f"{field}.kind")
+        allowed_by_kind = {
+            "file_exists": {"kind", "path"},
+            "file_contains": {"kind", "path", "text"},
+            "command_passes": {"kind", "program", "args", "working_dir", "timeout_seconds"},
+            "diff_matches": {"kind", "path", "expected"},
+        }
+        allowed = allowed_by_kind.get(kind)
+        if allowed is None:
+            raise ValueError(f"{field}.kind is unsupported: {kind}")
+        _strict(value, allowed, field)
+        command = None
+        if kind == "command_passes":
+            command_value = {key: item for key, item in value.items() if key != "kind"}
+            command = CommandSpecDocument.from_mapping(command_value, field)
+        path = (
+            _relative_path(value.get("path"), f"{field}.path")
+            if kind in {"file_exists", "file_contains", "diff_matches"}
+            else None
+        )
+        text = (
+            _protocol_text(value.get("text"), f"{field}.text", MAX_DIFF_CHARS)
+            if kind == "file_contains"
+            else None
+        )
+        expected = (
+            _protocol_text(value.get("expected"), f"{field}.expected", MAX_DIFF_CHARS)
+            if kind == "diff_matches"
+            else None
+        )
+        return cls(
+            kind=kind,
+            path=path,
+            text=text,
+            program=None if command is None else command.program,
+            args=() if command is None else command.args,
+            working_dir=None if command is None else command.working_dir,
+            expected=expected,
+            timeout_seconds=None if command is None else command.timeout_seconds,
+        )
+
+    def render(self) -> str:
+        if self.kind == "command_passes":
+            command = CommandSpecDocument(
+                self.program or "",
+                self.args,
+                self.working_dir,
+                self.timeout_seconds,
+            )
+            return f"run {command.render()}"
+        if self.kind == "file_contains":
+            return f"verify {self.path} contains the configured text"
+        if self.kind == "diff_matches":
+            return f"verify the expected diff in {self.path}"
+        return f"verify {self.path} exists"
+
+
+@dataclass(frozen=True)
+class ArtifactDocument:
+    """An expected artifact declaration consumed by the adapter."""
+
+    path: str
+    kind: str
+    sha256: str | None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, TomlValue], field: str) -> ArtifactDocument:
+        _strict(value, {"path", "kind", "sha256"}, field)
+        kind = _text(value.get("kind"), f"{field}.kind")
+        if kind not in {"file", "directory", "text", "json", "diff"}:
+            raise ValueError(f"{field}.kind is unsupported: {kind}")
+        sha256 = _optional_text(value.get("sha256"), f"{field}.sha256")
+        if sha256 is not None and (len(sha256) != 64 or any(char not in "0123456789abcdefABCDEF" for char in sha256)):
+            raise ValueError(f"{field}.sha256 must be a 64-character hexadecimal digest")
+        return cls(
+            path=_relative_path(value.get("path"), f"{field}.path"),
+            kind=kind,
+            sha256=sha256,
+        )
+
+    def render(self) -> str:
+        digest = "" if self.sha256 is None else f", sha256={self.sha256}"
+        return f"{self.path} ({self.kind}{digest})"
+
+
+@dataclass(frozen=True)
+class ResourceLimitsDocument:
+    """Resource ceilings carried through the external adapter boundary."""
+
+    max_output_bytes: int | None
+    max_file_changes: int | None
+    max_processes: int | None
+
+    def render(self) -> str:
+        values = (
+            ("max_output_bytes", self.max_output_bytes),
+            ("max_file_changes", self.max_file_changes),
+            ("max_processes", self.max_processes),
+        )
+        return ", ".join(f"{name}={value}" for name, value in values if value is not None)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, TomlValue]) -> ResourceLimitsDocument:
+        _strict(value, {"max_output_bytes", "max_file_changes", "max_processes"}, "resource_limits")
+        return cls(
+            max_output_bytes=_optional_positive_integer(
+                value.get("max_output_bytes"), "resource_limits.max_output_bytes"
+            ),
+            max_file_changes=_optional_positive_integer(
+                value.get("max_file_changes"), "resource_limits.max_file_changes"
+            ),
+            max_processes=_optional_positive_integer(
+                value.get("max_processes"), "resource_limits.max_processes"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class TaskSpecDocument:
+    """The provider-neutral TaskSpec view used by the Harbor adapter."""
+
+    schema_version: int
+    task_id: str
+    task_version: str
+    description: str
+    repository_path: str | None
+    repository_image: str | None
+    repository_commit: str | None
+    write_scope: tuple[str, ...]
+    setup: tuple[CommandSpecDocument, ...]
+    tests: tuple[CommandSpecDocument, ...]
+    timeout_seconds: int
+    resource_limits: ResourceLimitsDocument
+    risk_policy: str
+    success_criteria: tuple[CriterionDocument, ...]
+    expected_artifacts: tuple[ArtifactDocument, ...]
+    expected_diff: str | None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, TomlValue]) -> TaskSpecDocument:
+        _strict(
+            value,
+            {
+                "schema_version",
+                "task_id",
+                "task_version",
+                "description",
+                "repository",
+                "write_scope",
+                "setup",
+                "tests",
+                "timeout_seconds",
+                "resource_limits",
+                "risk_policy",
+                "success_criteria",
+                "expected_artifacts",
+                "expected_diff",
+            },
+            "task",
+        )
+        repository = _mapping(value.get("repository"), "repository")
+        _strict(repository, {"path", "image", "commit"}, "repository")
+        repository_path = _optional_relative_path(repository.get("path"), "repository.path")
+        repository_image = (
+            None
+            if repository.get("image") is None
+            else _protocol_text(repository.get("image"), "repository.image", MAX_PATH_CHARS)
+        )
+        repository_commit = (
+            _identifier(repository.get("commit"), "repository.commit", 256)
+            if repository.get("commit") is not None
+            else None
+        )
+        if (repository_path is None) == (repository_image is None):
+            raise ValueError("repository must contain exactly one of path or image")
+        if _integer(value.get("schema_version"), "schema_version") != 1:
+            raise ValueError("unsupported schema_version")
+        raw_scope = _list(value.get("write_scope"), "write_scope")
+        if not raw_scope:
+            raise ValueError("write_scope must contain at least one path pattern")
+        write_scope = tuple(
+            _relative_path(item, f"write_scope[{index}]", MAX_SCOPE_CHARS)
+            for index, item in enumerate(raw_scope)
+        )
+        resource_limits = ResourceLimitsDocument.from_mapping(
+            _mapping(value.get("resource_limits", {}), "resource_limits")
+        )
+        risk_policy_value = _text(value.get("risk_policy", "workspace_write"), "risk_policy")
+        if risk_policy_value not in {"read_only", "workspace_write", "workspace_write_and_network"}:
+            raise ValueError(f"risk_policy is unsupported: {risk_policy_value}")
+        expected_diff = (
+            None
+            if value.get("expected_diff") is None
+            else _protocol_text(value.get("expected_diff"), "expected_diff", MAX_DIFF_CHARS)
+        )
+        timeout_seconds = _positive_integer(value.get("timeout_seconds"), "timeout_seconds")
+        if timeout_seconds > MAX_TASK_TIMEOUT_SECONDS:
+            raise ValueError("timeout_seconds must not exceed seven days")
+        criteria = tuple(
+            CriterionDocument.from_mapping(_mapping(item, f"success_criteria[{index}]"), f"success_criteria[{index}]")
+            for index, item in enumerate(_list(value.get("success_criteria"), "success_criteria"))
+        )
+        if not criteria:
+            raise ValueError("success_criteria must not be empty")
+        artifacts = tuple(
+            ArtifactDocument.from_mapping(
+                _mapping(item, f"expected_artifacts[{index}]"),
+                f"expected_artifacts[{index}]",
+            )
+            for index, item in enumerate(_list(value.get("expected_artifacts", []), "expected_artifacts"))
+        )
+        return cls(
+            schema_version=_integer(value.get("schema_version"), "schema_version"),
+            task_id=_identifier(value.get("task_id"), "task_id", 128),
+            task_version=_identifier(value.get("task_version"), "task_version", 128),
+            description=_protocol_text(value.get("description"), "description", MAX_DESCRIPTION_CHARS),
+            repository_path=repository_path,
+            repository_image=repository_image,
+            repository_commit=repository_commit,
+            write_scope=write_scope,
+            setup=_commands(value.get("setup", []), "setup"),
+            tests=_commands(value.get("tests", []), "tests"),
+            timeout_seconds=timeout_seconds,
+            resource_limits=resource_limits,
+            risk_policy=risk_policy_value,
+            success_criteria=criteria,
+            expected_artifacts=artifacts,
+            expected_diff=expected_diff,
+        )
+
+    def to_harbor_instruction(self) -> str:
+        """Convert the shared protocol document into Harbor's instruction text."""
+
+        repository = self.repository_path or self.repository_image or "configured repository"
+        if self.repository_commit is not None:
+            repository = f"{repository}@{self.repository_commit}"
+        lines = [
+            f"Task {self.task_id} ({self.task_version})",
+            self.description,
+            f"Repository: {repository}",
+            f"Writable scope: {', '.join(self.write_scope)}",
+            f"Task timeout: {self.timeout_seconds}s",
+            f"Risk policy: {self.risk_policy}",
+        ]
+        if self.setup:
+            lines.append("Setup: " + "; ".join(command.render() for command in self.setup))
+        if self.tests:
+            lines.append("Tests: " + "; ".join(command.render() for command in self.tests))
+        limits = self.resource_limits.render()
+        if limits:
+            lines.append(f"Resource limits: {limits}")
+        lines.append("Success criteria: " + "; ".join(criterion.render() for criterion in self.success_criteria))
+        if self.expected_artifacts:
+            artifacts = ", ".join(artifact.render() for artifact in self.expected_artifacts)
+            lines.append(f"Expected artifacts: {artifacts}")
+        if self.expected_diff is not None:
+            lines.append("Expected diff: configured")
+        return "\n".join(lines)
+
+
+def load_task_spec(path: Path) -> TaskSpecDocument:
+    """Load and normalize one TaskSpec TOML document for Harbor."""
+
+    source = path.read_bytes()
+    value: TomlValue = tomllib.loads(source.decode("utf-8"))
+    return TaskSpecDocument.from_mapping(_mapping(value, "task"))

--- a/benchmark/tests/test_merry_agent.py
+++ b/benchmark/tests/test_merry_agent.py
@@ -9,7 +9,11 @@ import pytest
 from harbor.environments.base import BaseEnvironment, ExecResult
 from harbor.models.agent.context import AgentContext
 
-from merry_benchmark.agents.merry import MerryAgent, build_merry_run_command
+from merry_benchmark.agents.merry import (
+    MERRY_TASK_SPEC_PATH_ENV,
+    MerryAgent,
+    build_merry_run_command,
+)
 
 
 class RecordingEnvironment(BaseEnvironment):
@@ -83,6 +87,36 @@ def test_run_command_quotes_instruction_and_disables_nested_sandbox() -> None:
 def test_run_command_rejects_empty_executable() -> None:
     with pytest.raises(ValueError, match="must not be empty"):
         build_merry_run_command("   ", "task")
+
+
+def test_run_consumes_shared_task_spec_fixture(tmp_path: Path) -> None:
+    fixture = Path(__file__).parents[2] / "crates/merry-eval/tests/fixtures/adapter-task.toml"
+    environment = RecordingEnvironment()
+    agent = MerryAgent(
+        logs_dir=tmp_path,
+        extra_env={MERRY_TASK_SPEC_PATH_ENV: str(fixture)},
+    )
+
+    asyncio.run(agent.run("ignored dataset instruction", environment, AgentContext()))
+
+    command = environment.commands[-1][0]
+    assert "Task adapter-fixture (v1)" in command
+    assert "Fix the adapter fixture." in command
+    assert "Writable scope: src/**" in command
+    assert "Expected artifacts: target/evaluation.json (json)" in command
+
+
+def test_task_spec_path_must_point_to_a_file(tmp_path: Path) -> None:
+    agent = MerryAgent(
+        logs_dir=tmp_path,
+        extra_env={MERRY_TASK_SPEC_PATH_ENV: str(tmp_path / "missing.toml")},
+    )
+
+    context = AgentContext()
+    with pytest.raises(FileNotFoundError, match=MERRY_TASK_SPEC_PATH_ENV):
+        asyncio.run(agent.run("ignored dataset instruction", RecordingEnvironment(), context))
+
+    assert context.metadata == {"merry_status": "failed"}
 
 
 def test_api_key_file_requires_config(tmp_path: Path) -> None:

--- a/benchmark/tests/test_task_spec.py
+++ b/benchmark/tests/test_task_spec.py
@@ -1,0 +1,53 @@
+"""Tests for the shared TaskSpec external adapter boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from merry_benchmark.task_spec import load_task_spec
+
+FIXTURE = Path(__file__).parents[2] / "crates/merry-eval/tests/fixtures/adapter-task.toml"
+
+
+def test_shared_task_spec_loads_into_harbor_instruction() -> None:
+    task = load_task_spec(FIXTURE)
+
+    assert task.task_id == "adapter-fixture"
+    assert task.timeout_seconds == 120
+    assert task.setup[0].render() == "cargo fmt --check (timeout: 30s)"
+    assert "Task adapter-fixture (v1)" in task.to_harbor_instruction()
+    instruction = task.to_harbor_instruction()
+    assert (
+        "Success criteria: verify src/lib.rs exists; run cargo test "
+        "(cwd: fixtures/adapter) (timeout: 90s)"
+    ) in instruction
+
+
+def test_task_spec_adapter_rejects_unknown_top_level_fields(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.toml"
+    invalid.write_text(FIXTURE.read_text(encoding="utf-8") + "unknown = true\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown"):
+        load_task_spec(invalid)
+
+
+def test_task_spec_adapter_matches_rust_path_and_timeout_guards(tmp_path: Path) -> None:
+    invalid_scope = tmp_path / "invalid-scope.toml"
+    invalid_scope.write_text(
+        FIXTURE.read_text(encoding="utf-8").replace(
+            "write_scope = [\"src/**\"]", "write_scope = [\"../src\"]"
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="workspace"):
+        load_task_spec(invalid_scope)
+
+    invalid_timeout = tmp_path / "invalid-timeout.toml"
+    invalid_timeout.write_text(
+        FIXTURE.read_text(encoding="utf-8").replace("timeout_seconds = 120", "timeout_seconds = 604801"),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="seven days"):
+        load_task_spec(invalid_timeout)

--- a/crates/merry-eval/Cargo.toml
+++ b/crates/merry-eval/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "merry-eval"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+schemars.workspace = true
+serde.workspace = true
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
+thiserror.workspace = true
+toml.workspace = true
+
+[dev-dependencies]
+jsonschema.workspace = true
+
+[lints]
+workspace = true

--- a/crates/merry-eval/src/error.rs
+++ b/crates/merry-eval/src/error.rs
@@ -1,0 +1,158 @@
+use schemars::{Schema, SchemaGenerator, json_schema};
+use thiserror::Error;
+
+pub(crate) const RELATIVE_PATH_PATTERN: &str = r"^(?:[^./\\\x00-\x1f\x7f-\x9f](?:[^/\\:\x00-\x1f\x7f-\x9f][^/\\\x00-\x1f\x7f-\x9f]*)?|\.[^./\\:\x00-\x1f\x7f-\x9f][^/\\\x00-\x1f\x7f-\x9f]*|\.\.[^/\\\x00-\x1f\x7f-\x9f]+)(?:/(?:[^./\\\x00-\x1f\x7f-\x9f](?:[^/\\:\x00-\x1f\x7f-\x9f][^/\\\x00-\x1f\x7f-\x9f]*)?|\.[^./\\:\x00-\x1f\x7f-\x9f][^/\\\x00-\x1f\x7f-\x9f]*|\.\.[^/\\\x00-\x1f\x7f-\x9f]+))*$";
+pub(crate) const IDENTIFIER_PATTERN: &str =
+    r"^[^\s\x00-\x1f\x7f-\x9f](?:[^\x00-\x1f\x7f-\x9f]*[^\s\x00-\x1f\x7f-\x9f])?$";
+pub(crate) const NON_BLANK_TEXT_PATTERN: &str = r"^[^\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]*[^\s\x00-\x1f\x7f-\x9f][^\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]*$";
+const SHA256_PATTERN: &str = r"^[0-9A-Fa-f]{64}$";
+const MAX_RELATIVE_PATH_CHARS: usize = 512;
+
+pub(crate) fn relative_path_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": MAX_RELATIVE_PATH_CHARS,
+        "pattern": RELATIVE_PATH_PATTERN,
+    })
+}
+
+pub(crate) fn optional_relative_path_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": ["string", "null"],
+        "minLength": 1,
+        "maxLength": MAX_RELATIVE_PATH_CHARS,
+        "pattern": RELATIVE_PATH_PATTERN,
+    })
+}
+
+pub(crate) fn optional_sha256_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": ["string", "null"],
+        "pattern": SHA256_PATTERN,
+    })
+}
+
+/// Errors raised while defining or serializing evaluation protocol data.
+#[derive(Debug, Error)]
+pub enum EvalError {
+    /// The task manifest was not valid TOML.
+    #[error("failed to parse task manifest: {0}")]
+    ManifestParse(#[from] toml::de::Error),
+
+    /// A task manifest could not be serialized as TOML.
+    #[error("failed to serialize task manifest: {0}")]
+    ManifestSerialize(#[from] toml::ser::Error),
+
+    /// A JSONL evaluation record could not be encoded or decoded.
+    #[error("failed to encode or decode evaluation record: {0}")]
+    RecordJson(#[from] serde_json::Error),
+
+    /// A manifest or record used a protocol version this crate does not know.
+    #[error("unsupported {kind} version {found}; supported version is {supported}")]
+    UnsupportedVersion {
+        /// The protocol object carrying the version.
+        kind: &'static str,
+        /// The version found in the input.
+        found: u32,
+        /// The newest version understood by this crate.
+        supported: u32,
+    },
+
+    /// An external protocol value failed a domain validation rule.
+    #[error("invalid {field}: {reason}")]
+    InvalidField {
+        /// The field or nested path that failed validation.
+        field: String,
+        /// The actionable reason for rejection.
+        reason: String,
+    },
+
+    /// A JSONL record did not contain exactly one framed JSON line.
+    #[error("invalid evaluation record framing: {0}")]
+    InvalidRecordFraming(String),
+}
+
+pub(crate) fn invalid_field(field: impl Into<String>, reason: impl Into<String>) -> EvalError {
+    EvalError::InvalidField {
+        field: field.into(),
+        reason: reason.into(),
+    }
+}
+
+pub(crate) fn validate_identifier(
+    field: &str,
+    value: &str,
+    max_chars: usize,
+) -> Result<(), EvalError> {
+    if value.is_empty() {
+        return Err(invalid_field(field, "must not be empty"));
+    }
+    if value.trim() != value {
+        return Err(invalid_field(
+            field,
+            "must not have leading or trailing whitespace",
+        ));
+    }
+    if value.chars().count() > max_chars {
+        return Err(invalid_field(
+            field,
+            format!("must contain at most {max_chars} characters"),
+        ));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_field(field, "must not contain control characters"));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_text(field: &str, value: &str, max_chars: usize) -> Result<(), EvalError> {
+    if value.trim().is_empty() {
+        return Err(invalid_field(field, "must not be blank"));
+    }
+    if value.chars().count() > max_chars {
+        return Err(invalid_field(
+            field,
+            format!("must contain at most {max_chars} characters"),
+        ));
+    }
+    if value.chars().any(|character| {
+        character == '\0' || (character.is_control() && !matches!(character, '\n' | '\r' | '\t'))
+    }) {
+        return Err(invalid_field(
+            field,
+            "must not contain unsafe control characters",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_relative_path(field: &str, value: &str) -> Result<(), EvalError> {
+    if value.is_empty() {
+        return Err(invalid_field(field, "must not be empty"));
+    }
+    if value.starts_with('/') || value.starts_with('\\') || value.contains('\\') {
+        return Err(invalid_field(
+            field,
+            "must be a relative slash-separated path",
+        ));
+    }
+    if value.chars().count() > MAX_RELATIVE_PATH_CHARS {
+        return Err(invalid_field(
+            field,
+            format!("must contain at most {MAX_RELATIVE_PATH_CHARS} characters"),
+        ));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(invalid_field(field, "must not contain control characters"));
+    }
+    if value.split('/').any(|component| {
+        component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.chars().nth(1) == Some(':')
+    }) {
+        return Err(invalid_field(field, "must not escape the task workspace"));
+    }
+    Ok(())
+}

--- a/crates/merry-eval/src/lib.rs
+++ b/crates/merry-eval/src/lib.rs
@@ -1,0 +1,634 @@
+//! Provider-neutral evaluation manifests and deterministic run records.
+//!
+//! This crate is an upper-layer protocol. It describes what a harness should
+//! evaluate and records bounded metadata about the result; it does not own
+//! runtime state, provider wire payloads, secrets, or artifact contents.
+
+mod error;
+mod manifest;
+mod numeric;
+mod record;
+
+pub use error::EvalError;
+pub use manifest::{
+    ArtifactKind, CommandSpec, ExpectedArtifact, RepositorySpec, ResourceLimits, RiskPolicy,
+    SuccessCriterion, TASK_SCHEMA_VERSION, TaskSpec,
+};
+pub use record::{
+    ArtifactRecord, DenialRecord, EVALUATION_RECORD_SCHEMA_VERSION, EVALUATION_RUN_SCHEMA_VERSION,
+    EvaluationRecord, EvaluationRun, EvaluationStatus, FailureKind, TestResult,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ArtifactKind, ArtifactRecord, CommandSpec, DenialRecord, EvaluationRecord, EvaluationRun,
+        EvaluationStatus, ExpectedArtifact, FailureKind, RepositorySpec, ResourceLimits,
+        SuccessCriterion, TaskSpec, TestResult,
+    };
+    use schemars::schema_for;
+    use serde_json::{Value, json};
+
+    const VALID_MANIFEST: &str = r#"
+        schema_version = 1
+        task_id = "rust-fix-001"
+        task_version = "2026-08-17"
+        description = "Fix the parser regression."
+        write_scope = ["src/**"]
+        timeout_seconds = 300
+
+        [repository]
+        path = "fixtures/parser"
+
+        [[success_criteria]]
+        kind = "file_exists"
+        path = "src/parser.rs"
+    "#;
+
+    const NUMERIC_MANIFEST: &str = r#"
+        schema_version = 1.0
+        task_id = "numeric-001"
+        task_version = "v1"
+        description = "Exercise numeric deserializers."
+        write_scope = ["src/**"]
+        timeout_seconds = 300.0
+
+        [repository]
+        path = "fixtures/parser"
+
+        [[setup]]
+        program = "cargo"
+        timeout_seconds = 5.0
+
+        [[tests]]
+        program = "cargo"
+        timeout_seconds = 6.0
+
+        [resource_limits]
+        max_output_bytes = 1024.0
+        max_file_changes = 2.0
+        max_processes = 1.0
+
+        [[success_criteria]]
+        kind = "command_passes"
+        program = "cargo"
+        timeout_seconds = 7.0
+    "#;
+
+    #[test]
+    fn parses_a_versioned_task_manifest() {
+        let task = TaskSpec::from_toml(VALID_MANIFEST).expect("valid task manifest");
+        assert_eq!(task.task_id(), "rust-fix-001");
+        assert_eq!(task.schema_version(), 1);
+        assert_eq!(task.write_scope(), ["src/**"]);
+        assert_eq!(task.success_criteria().len(), 1);
+    }
+
+    #[test]
+    fn toml_numeric_wire_fields_accept_integral_floats() {
+        let task = TaskSpec::from_toml(NUMERIC_MANIFEST).expect("integral TOML numbers parse");
+        assert_eq!(task.schema_version(), 1);
+        assert_eq!(task.timeout_seconds(), 300);
+        assert_eq!(task.setup()[0].timeout_seconds(), Some(5));
+        assert_eq!(task.tests()[0].timeout_seconds(), Some(6));
+        assert_eq!(task.resource_limits().max_output_bytes(), Some(1024));
+        assert_eq!(task.resource_limits().max_file_changes(), Some(2));
+        assert_eq!(task.resource_limits().max_processes(), Some(1));
+        assert!(matches!(
+            task.success_criteria()[0],
+            SuccessCriterion::CommandPasses {
+                timeout_seconds: Some(7),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn toml_numeric_wire_fields_reject_fractional_floats() {
+        for (needle, replacement) in [
+            ("schema_version = 1.0", "schema_version = 1.5"),
+            ("timeout_seconds = 300.0", "timeout_seconds = 300.5"),
+            ("max_output_bytes = 1024.0", "max_output_bytes = 1024.5"),
+            ("max_file_changes = 2.0", "max_file_changes = 2.5"),
+            ("max_processes = 1.0", "max_processes = 1.5"),
+            ("timeout_seconds = 5.0", "timeout_seconds = 5.5"),
+            ("timeout_seconds = 6.0", "timeout_seconds = 6.5"),
+            ("timeout_seconds = 7.0", "timeout_seconds = 7.5"),
+        ] {
+            let manifest = NUMERIC_MANIFEST.replace(needle, replacement);
+            assert!(TaskSpec::from_toml(&manifest).is_err(), "field: {needle}");
+        }
+
+        let object_number = NUMERIC_MANIFEST.replace(
+            "timeout_seconds = 300.0",
+            "timeout_seconds = { anything = \"5\" }",
+        );
+        assert!(TaskSpec::from_toml(&object_number).is_err());
+    }
+
+    #[test]
+    fn reports_expected_artifact_index_in_manifest_errors() {
+        let manifest = format!(
+            "{VALID_MANIFEST}\n\
+             [[expected_artifacts]]\n\
+             path = \"out.json\"\n\
+             kind = \"file\"\n\
+             [[expected_artifacts]]\n\
+             path = \"../outside\"\n\
+             kind = \"file\"\n"
+        );
+        let error = TaskSpec::from_toml(&manifest).expect_err("invalid artifact path must fail");
+        assert!(error.to_string().contains("expected_artifacts[1].path"));
+    }
+
+    #[test]
+    fn rejects_unknown_manifest_fields() {
+        let manifest = format!("{VALID_MANIFEST}\nunknown = true\n");
+        let error = TaskSpec::from_toml(&manifest).expect_err("unknown fields must be rejected");
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unsupported_manifest_versions() {
+        let manifest = VALID_MANIFEST.replace("schema_version = 1", "schema_version = 2");
+        let error = TaskSpec::from_toml(&manifest).expect_err("unsupported versions must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported task manifest version 2")
+        );
+    }
+
+    #[test]
+    fn rejects_workspace_escape_in_write_scope() {
+        let manifest = VALID_MANIFEST.replace(
+            "write_scope = [\"src/**\"]",
+            "write_scope = [\"../outside\"]",
+        );
+        let error = TaskSpec::from_toml(&manifest).expect_err("workspace escapes must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("must not escape the task workspace")
+        );
+    }
+
+    #[test]
+    fn task_manifest_round_trips_without_losing_contract_fields() {
+        let task = TaskSpec::from_toml(VALID_MANIFEST).expect("valid task manifest");
+        let encoded = task.to_toml().expect("task serializes");
+        let decoded = TaskSpec::from_toml(&encoded).expect("serialized task parses");
+        assert_eq!(decoded, task);
+    }
+
+    #[test]
+    fn direct_nested_manifest_deserialization_keeps_validation_boundary() {
+        let empty_repository = serde_json::from_str::<super::RepositorySpec>(r#"{}"#);
+        assert!(empty_repository.is_err());
+        let ambiguous_repository = serde_json::from_str::<super::RepositorySpec>(
+            r#"{"path":"fixture","image":"image:latest","commit":null}"#,
+        );
+        assert!(ambiguous_repository.is_err());
+
+        let invalid_command = serde_json::from_str::<super::CommandSpec>(
+            r#"{"program":"","args":[],"working_dir":null,"timeout_seconds":0}"#,
+        );
+        assert!(invalid_command.is_err());
+
+        let invalid_limits = serde_json::from_str::<super::ResourceLimits>(
+            r#"{"max_output_bytes":0,"max_file_changes":null,"max_processes":null}"#,
+        );
+        assert!(invalid_limits.is_err());
+
+        let invalid_criterion = serde_json::from_str::<super::SuccessCriterion>(
+            r#"{"kind":"file_exists","path":"../outside"}"#,
+        );
+        assert!(invalid_criterion.is_err());
+        let unknown_criterion_field = serde_json::from_str::<super::SuccessCriterion>(
+            r#"{"kind":"file_exists","path":"src/lib.rs","extra":true}"#,
+        );
+        assert!(unknown_criterion_field.is_err());
+
+        let invalid_artifact = serde_json::from_str::<super::ExpectedArtifact>(
+            r#"{"path":"out.json","kind":"json","sha256":"bad"}"#,
+        );
+        assert!(invalid_artifact.is_err());
+    }
+
+    #[test]
+    fn public_manifest_constructors_validate_and_round_trip() {
+        let repository = RepositorySpec::from_path("fixtures/parser")
+            .expect("valid repository path")
+            .with_commit("abc123")
+            .expect("valid repository commit");
+        assert_eq!(repository.path(), Some("fixtures/parser"));
+        assert_eq!(repository.commit(), Some("abc123"));
+
+        let command = CommandSpec::new("cargo", &["test"])
+            .expect("valid command")
+            .with_working_dir("crates/merry-eval")
+            .expect("valid command directory")
+            .with_timeout_seconds(60)
+            .expect("valid command timeout");
+        assert_eq!(command.program(), "cargo");
+        assert_eq!(command.timeout_seconds(), Some(60));
+
+        let limits = ResourceLimits::new(Some(1024), Some(2), Some(1)).expect("valid limits");
+        assert_eq!(limits.max_file_changes(), Some(2));
+
+        let criterion = SuccessCriterion::FileExists {
+            path: "src/lib.rs".to_owned(),
+        };
+        assert!(criterion.validate().is_ok());
+        let artifact = ExpectedArtifact::new("target/report.json", ArtifactKind::Json, None)
+            .expect("valid expected artifact");
+        assert_eq!(artifact.kind(), ArtifactKind::Json);
+
+        let criterion_json = serde_json::to_string(&criterion).expect("criterion serializes");
+        let decoded_criterion: SuccessCriterion =
+            serde_json::from_str(&criterion_json).expect("criterion parses");
+        assert_eq!(decoded_criterion, criterion);
+    }
+
+    #[test]
+    fn generated_task_schema_preserves_manifest_bounds() {
+        let schema = serde_json::to_value(schema_for!(TaskSpec)).expect("schema serializes");
+        assert_eq!(schema["properties"]["task_id"]["minLength"], json!(1));
+        assert_eq!(schema["properties"]["write_scope"]["minItems"], json!(1));
+        assert_eq!(
+            schema["properties"]["success_criteria"]["minItems"],
+            json!(1)
+        );
+        assert_eq!(schema["properties"]["timeout_seconds"]["minimum"], json!(1));
+        assert_eq!(
+            schema["properties"]["timeout_seconds"]["maximum"],
+            json!(604800)
+        );
+        assert!(!schema["required"].as_array().unwrap().iter().any(|field| {
+            matches!(
+                field.as_str(),
+                Some("setup" | "tests" | "resource_limits" | "risk_policy" | "expected_artifacts")
+            )
+        }));
+
+        let validator = jsonschema::validator_for(&schema).expect("TaskSpec schema compiles");
+        let valid: Value = serde_json::from_str(
+            r#"{
+                "schema_version": 1,
+                "task_id": "task-1",
+                "task_version": "v1",
+                "description": "Read and fix the fixture.",
+                "repository": {"path": "fixtures/ab:c"},
+                "write_scope": ["src/**"],
+                "timeout_seconds": 300,
+                "success_criteria": [{"kind": "file_exists", "path": "src/lib.rs"}]
+            }"#,
+        )
+        .expect("valid schema fixture parses");
+        assert!(validator.is_valid(&valid));
+
+        let mut integral_timeout = valid.clone();
+        integral_timeout["timeout_seconds"] = json!(300.0);
+        assert!(validator.is_valid(&integral_timeout));
+        assert!(serde_json::from_value::<TaskSpec>(integral_timeout).is_ok());
+
+        let mut drive_like_path = valid.clone();
+        drive_like_path["repository"] = json!({"path": "fixtures/a:b"});
+        assert!(!validator.is_valid(&drive_like_path));
+
+        let mut whitespace_identifier = valid.clone();
+        whitespace_identifier["task_id"] = json!(" task-1");
+        assert!(!validator.is_valid(&whitespace_identifier));
+
+        let mut unknown_criterion_field = valid.clone();
+        unknown_criterion_field["success_criteria"][0]["extra"] = json!(true);
+        assert!(!validator.is_valid(&unknown_criterion_field));
+
+        let mut blank_command_program = valid.clone();
+        blank_command_program["success_criteria"] = json!([{
+            "kind": "command_passes",
+            "program": " ",
+            "args": [],
+            "working_dir": null,
+            "timeout_seconds": null
+        }]);
+        assert!(!validator.is_valid(&blank_command_program));
+        assert!(serde_json::from_value::<TaskSpec>(blank_command_program).is_err());
+
+        let invalid: Value = serde_json::from_str(
+            r#"{
+                "schema_version": 1,
+                "task_id": "task-1",
+                "task_version": "v1",
+                "description": "Read and fix the fixture.",
+                "repository": {},
+                "write_scope": ["../outside"],
+                "timeout_seconds": 0,
+                "success_criteria": [{"kind": "file_exists", "path": "src/lib.rs"}]
+            }"#,
+        )
+        .expect("invalid schema fixture parses");
+        assert!(!validator.is_valid(&invalid));
+    }
+
+    #[test]
+    fn generated_record_schema_preserves_nested_bounds() {
+        let schema =
+            serde_json::to_value(schema_for!(EvaluationRecord)).expect("schema serializes");
+        let base = &schema["allOf"][0];
+        assert_eq!(base["properties"]["schema_version"]["const"], json!(1));
+        assert_eq!(
+            schema["$defs"]["DenialRecord"]["properties"]["count"]["minimum"],
+            json!(1)
+        );
+        assert_eq!(
+            schema["$defs"]["ArtifactRecord"]["properties"]["sha256"]["pattern"],
+            json!("^[0-9A-Fa-f]{64}$")
+        );
+        assert_eq!(base["properties"]["tests"]["maxItems"], json!(1024));
+        assert_eq!(base["properties"]["turns"]["maximum"], json!(u32::MAX));
+        assert_eq!(base["properties"]["latency_ms"]["maximum"], json!(u64::MAX));
+        assert_eq!(
+            schema["$defs"]["EvaluationRun"]["properties"]["started_at_ms"]["maximum"],
+            json!(u64::MAX)
+        );
+        assert_eq!(
+            schema["$defs"]["TestResult"]["properties"]["duration_ms"]["maximum"],
+            json!(u64::MAX)
+        );
+        assert_eq!(
+            schema["$defs"]["DenialRecord"]["properties"]["count"]["maximum"],
+            json!(u32::MAX)
+        );
+
+        let validator = jsonschema::validator_for(&schema).expect("record schema compiles");
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        for (status, failure_kind) in [
+            (EvaluationStatus::Passed, None),
+            (EvaluationStatus::Failed, Some(FailureKind::Test)),
+            (EvaluationStatus::Blocked, Some(FailureKind::Permission)),
+            (EvaluationStatus::Cancelled, Some(FailureKind::Cancelled)),
+            (EvaluationStatus::Error, Some(FailureKind::Runtime)),
+            (EvaluationStatus::Error, Some(FailureKind::Timeout)),
+        ] {
+            let record = EvaluationRecord::try_new(run.clone(), status, failure_kind)
+                .expect("valid status combination");
+            let value = serde_json::to_value(record).expect("valid record serializes");
+            assert!(
+                validator.is_valid(&value),
+                "schema rejected valid record: {value}"
+            );
+        }
+
+        let valid = serde_json::to_value(EvaluationRecord::new(run, EvaluationStatus::Passed))
+            .expect("valid record serializes");
+        assert!(validator.is_valid(&valid));
+
+        let mut missing_failure = valid.clone();
+        missing_failure["status"] = json!("failed");
+        assert!(!validator.is_valid(&missing_failure));
+
+        let mut blocked_with_test_failure = valid.clone();
+        blocked_with_test_failure["status"] = json!("blocked");
+        blocked_with_test_failure["failure_kind"] = json!("test");
+        assert!(!validator.is_valid(&blocked_with_test_failure));
+
+        let mut unknown_failure_kind = valid.clone();
+        unknown_failure_kind["status"] = json!("failed");
+        unknown_failure_kind["failure_kind"] = json!("future_kind");
+        assert!(!validator.is_valid(&unknown_failure_kind));
+
+        let mut unknown_test_field = valid.clone();
+        unknown_test_field["tests"] = json!([{
+            "name": "unit",
+            "passed": true,
+            "duration_ms": null,
+            "extra": true
+        }]);
+        assert!(!validator.is_valid(&unknown_test_field));
+
+        let mut passed_with_failed_test = valid;
+        passed_with_failed_test["tests"] = json!([{
+            "name": "unit",
+            "passed": false,
+            "duration_ms": null
+        }]);
+        assert!(!validator.is_valid(&passed_with_failed_test));
+    }
+
+    #[test]
+    fn schema_integer_numbers_deserialize_through_record_wire() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let mut value: Value = serde_json::to_value(record).expect("record encodes");
+        value["turns"] = json!(1.0);
+        value["tool_calls"] = json!(1e2);
+        value["retries"] = json!(0.0);
+        value["latency_ms"] = json!(1.0);
+        value["cost_micros"] = json!(2e2);
+
+        let schema =
+            serde_json::to_value(schema_for!(EvaluationRecord)).expect("schema serializes");
+        let validator = jsonschema::validator_for(&schema).expect("record schema compiles");
+        assert!(
+            validator.is_valid(&value),
+            "schema errors: {:?}",
+            validator.iter_errors(&value).collect::<Vec<_>>()
+        );
+        let decoded =
+            serde_json::from_value::<EvaluationRecord>(value).expect("integral numbers parse");
+        assert_eq!(decoded.turns(), 1);
+        assert_eq!(decoded.tool_calls(), 100);
+        assert_eq!(decoded.retries(), 0);
+        assert_eq!(decoded.latency_ms(), Some(1));
+        assert_eq!(decoded.cost_micros(), Some(200));
+
+        let mut fractional: Value = serde_json::to_value(EvaluationRecord::new(
+            EvaluationRun::new("run-002", "task-001", "v1", 1000).expect("valid run"),
+            EvaluationStatus::Passed,
+        ))
+        .expect("record encodes");
+        fractional["turns"] = json!(1.5);
+        assert!(!validator.is_valid(&fractional));
+        assert!(serde_json::from_value::<EvaluationRecord>(fractional).is_err());
+
+        let mut negative = serde_json::to_value(EvaluationRecord::new(
+            EvaluationRun::new("run-003", "task-001", "v1", 1000).expect("valid run"),
+            EvaluationStatus::Passed,
+        ))
+        .expect("record encodes");
+        negative["turns"] = json!(-1);
+        assert!(!validator.is_valid(&negative));
+        assert!(serde_json::from_value::<EvaluationRecord>(negative).is_err());
+
+        let mut overflow = serde_json::to_value(EvaluationRecord::new(
+            EvaluationRun::new("run-004", "task-001", "v1", 1000).expect("valid run"),
+            EvaluationStatus::Passed,
+        ))
+        .expect("record encodes");
+        overflow["turns"] = json!(u64::from(u32::MAX) + 1);
+        assert!(!validator.is_valid(&overflow));
+        assert!(serde_json::from_value::<EvaluationRecord>(overflow).is_err());
+    }
+
+    #[test]
+    fn json_integral_float_preserves_large_integer_digits() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let line = record
+            .to_jsonl()
+            .expect("record serializes")
+            .replace("\"latency_ms\":null", "\"latency_ms\":9007199254740993.0");
+        let payload: Value = serde_json::from_str(line.trim_end()).expect("payload parses");
+        let schema =
+            serde_json::to_value(schema_for!(EvaluationRecord)).expect("schema serializes");
+        let validator = jsonschema::validator_for(&schema).expect("record schema compiles");
+        assert!(validator.is_valid(&payload));
+        let decoded = EvaluationRecord::from_jsonl(&line).expect("large integral float parses");
+        assert_eq!(decoded.latency_ms(), Some(9_007_199_254_740_993));
+
+        let fractional = line.replace("9007199254740993.0", "9007199254740993.5");
+        let fractional_payload: Value =
+            serde_json::from_str(fractional.trim_end()).expect("payload parses");
+        // The jsonschema crate currently rounds very large JSON numbers while validating;
+        // the protocol deserializer retains the raw number and rejects the fraction.
+        assert!(fractional_payload["latency_ms"].is_number());
+        assert!(EvaluationRecord::from_jsonl(&fractional).is_err());
+
+        let object_number = line.replace(
+            "\"latency_ms\":9007199254740993.0",
+            "\"latency_ms\":{\"anything\":\"5\"}",
+        );
+        assert!(EvaluationRecord::from_jsonl(&object_number).is_err());
+    }
+
+    #[test]
+    fn direct_record_deserialization_keeps_validation_boundary() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let mut value: Value = serde_json::to_value(record).expect("record encodes");
+        value["failure_kind"] = json!("test");
+        let error = serde_json::from_value::<EvaluationRecord>(value)
+            .expect_err("passed record with failure must fail");
+        assert!(error.to_string().contains("must be absent"));
+    }
+
+    #[test]
+    fn evaluation_record_is_one_stable_jsonl_line() {
+        let run = EvaluationRun::new("run-001", "rust-fix-001", "2026-08-17", 1000)
+            .expect("valid run")
+            .with_provider("fixture")
+            .expect("valid provider")
+            .with_model("fake-model")
+            .expect("valid model")
+            .with_prompt_hash("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+            .expect("valid prompt hash");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Failed)
+            .with_failure_kind(FailureKind::Test)
+            .with_metrics(2, 3, 1, Some(42), Some(7))
+            .with_test(TestResult::new("cargo test", false, Some(40)).expect("valid test"))
+            .with_denial(DenialRecord::new("network", 1).expect("valid denial"))
+            .with_artifact(
+                ArtifactRecord::new(
+                    "target/report.json",
+                    super::ArtifactKind::Json,
+                    Some("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+                )
+                .expect("valid artifact"),
+            );
+
+        let line = record.to_jsonl().expect("record serializes");
+        assert!(line.ends_with('\n'));
+        assert_eq!(line.matches('\n').count(), 1);
+        let object: Value = serde_json::from_str(&line).expect("JSONL line is an object");
+        assert!(object["run"]["prompt_hash"].is_string());
+        assert!(!object.to_string().contains("api_key"));
+        assert_eq!(
+            EvaluationRecord::from_jsonl(&line).expect("record parses"),
+            record
+        );
+    }
+
+    #[test]
+    fn jsonl_escapes_unicode_line_separator_characters() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000)
+            .expect("valid run")
+            .with_model("model\u{2028}\u{2029}name")
+            .expect("line separators are valid inside metadata");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let line = record.to_jsonl().expect("record serializes");
+        assert!(!line.contains('\u{2028}'));
+        assert!(!line.contains('\u{2029}'));
+        assert_eq!(
+            EvaluationRecord::from_jsonl(&line).expect("escaped record parses"),
+            record
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_record_statuses() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let failed = EvaluationRecord::new(run.clone(), EvaluationStatus::Failed);
+        assert!(failed.finish().is_err());
+        let blocked = EvaluationRecord::new(run.clone(), EvaluationStatus::Blocked)
+            .with_failure_kind(FailureKind::Test);
+        assert!(blocked.finish().is_err());
+        let cancelled = EvaluationRecord::new(run.clone(), EvaluationStatus::Cancelled)
+            .with_failure_kind(FailureKind::Cancelled);
+        assert!(cancelled.finish().is_ok());
+        let passed = EvaluationRecord::new(run, EvaluationStatus::Passed)
+            .with_test(TestResult::new("cargo test", false, None).expect("valid test"));
+        assert!(passed.finish().is_err());
+    }
+
+    #[test]
+    fn rejects_extra_jsonl_framing() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let line = record.to_jsonl().expect("record serializes");
+        assert!(EvaluationRecord::from_jsonl(&format!("{line}\n")).is_err());
+        assert!(EvaluationRecord::from_jsonl(&format!(" {line}")).is_err());
+        assert!(EvaluationRecord::from_jsonl(line.trim_end()).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_nested_record_values_through_serde() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let mut value: Value = serde_json::to_value(record).expect("record encodes");
+        value["denials"] = json!([{ "code": "network", "count": 0 }]);
+        assert!(serde_json::from_value::<EvaluationRecord>(value).is_err());
+
+        let run = EvaluationRun::new("run-002", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let mut value: Value = serde_json::to_value(record).expect("record encodes");
+        value["tests"] = json!([{ "name": "", "passed": true, "duration_ms": null }]);
+        assert!(serde_json::from_value::<EvaluationRecord>(value).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_record_fields_and_unsupported_versions() {
+        let run = EvaluationRun::new("run-001", "task-001", "v1", 1000).expect("valid run");
+        let record = EvaluationRecord::new(run, EvaluationStatus::Passed);
+        let encoded = serde_json::to_string(&record).expect("record encodes");
+        let with_unknown = format!(
+            r#"{{"unknown":true,{encoded_trimmed}}}"#,
+            encoded_trimmed = &encoded[1..]
+        );
+        let error =
+            EvaluationRecord::from_jsonl(&with_unknown).expect_err("unknown field must fail");
+        assert!(error.to_string().contains("unknown field"));
+
+        let mut unsupported_value: Value =
+            serde_json::from_str(&encoded).expect("record JSON object");
+        unsupported_value["schema_version"] = json!(2);
+        let unsupported = serde_json::to_string(&unsupported_value).expect("record JSON");
+        let error = EvaluationRecord::from_jsonl(&unsupported)
+            .expect_err("unsupported record version must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported evaluation record version 2")
+        );
+    }
+}

--- a/crates/merry-eval/src/manifest.rs
+++ b/crates/merry-eval/src/manifest.rs
@@ -1,0 +1,1020 @@
+use crate::error::{
+    EvalError, IDENTIFIER_PATTERN, NON_BLANK_TEXT_PATTERN, RELATIVE_PATH_PATTERN, invalid_field,
+    optional_relative_path_schema, optional_sha256_schema, relative_path_schema,
+    validate_identifier, validate_relative_path, validate_text,
+};
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::Error as SerdeError};
+
+use crate::numeric::{
+    deserialize_option_u32, deserialize_option_u64, deserialize_u32, deserialize_u64,
+    optional_positive_u32_schema, optional_positive_u64_schema, task_timeout_schema,
+    version_schema,
+};
+
+#[path = "manifest_validation.rs"]
+mod validation;
+use validation::{validate_repository, validate_scope, validate_sha256, validate_text_field};
+
+/// The only task-manifest schema version understood by this crate.
+pub const TASK_SCHEMA_VERSION: u32 = 1;
+
+const MAX_DESCRIPTION_CHARS: usize = 16 * 1024;
+const MAX_DIFF_CHARS: usize = 1024 * 1024;
+const MAX_COMMAND_ARGS: usize = 256;
+const MAX_COMMAND_ARG_CHARS: usize = 16 * 1024;
+const MAX_SCOPE_CHARS: usize = 512;
+const MAX_PATH_CHARS: usize = 512;
+
+/// A repository or image from which an evaluation task is prepared.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[schemars(schema_with = "repository_spec_schema")]
+#[serde(try_from = "RepositorySpecWire")]
+pub struct RepositorySpec {
+    /// Relative fixture path, when the task uses a checked-out repository.
+    path: Option<String>,
+    /// Container or VM image reference, when the task uses an image.
+    image: Option<String>,
+    /// Optional source revision to check out inside the repository or image.
+    commit: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct RepositorySpecWire {
+    path: Option<String>,
+    image: Option<String>,
+    commit: Option<String>,
+}
+
+impl TryFrom<RepositorySpecWire> for RepositorySpec {
+    type Error = EvalError;
+
+    fn try_from(wire: RepositorySpecWire) -> Result<Self, Self::Error> {
+        let repository = Self {
+            path: wire.path,
+            image: wire.image,
+            commit: wire.commit,
+        };
+        validate_repository(&repository)?;
+        Ok(repository)
+    }
+}
+
+impl RepositorySpec {
+    /// Creates a repository specification backed by a relative fixture path.
+    pub fn from_path(path: &str) -> Result<Self, EvalError> {
+        validate_relative_path("repository.path", path)?;
+        Ok(Self {
+            path: Some(path.to_owned()),
+            image: None,
+            commit: None,
+        })
+    }
+
+    /// Creates a repository specification backed by an image reference.
+    pub fn from_image(image: &str) -> Result<Self, EvalError> {
+        validate_text("repository.image", image, MAX_PATH_CHARS)?;
+        Ok(Self {
+            path: None,
+            image: Some(image.to_owned()),
+            commit: None,
+        })
+    }
+
+    /// Adds a source revision to this repository specification.
+    pub fn with_commit(mut self, commit: &str) -> Result<Self, EvalError> {
+        validate_identifier("repository.commit", commit, 256)?;
+        self.commit = Some(commit.to_owned());
+        Ok(self)
+    }
+
+    /// Returns the optional relative fixture path.
+    #[must_use]
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+
+    /// Returns the optional image reference.
+    #[must_use]
+    pub fn image(&self) -> Option<&str> {
+        self.image.as_deref()
+    }
+
+    /// Returns the optional source revision.
+    #[must_use]
+    pub fn commit(&self) -> Option<&str> {
+        self.commit.as_deref()
+    }
+}
+
+fn repository_spec_schema(generator: &mut SchemaGenerator) -> Schema {
+    let path_schema = relative_path_schema(generator);
+    let image_schema = json_schema!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": MAX_PATH_CHARS,
+        "pattern": NON_BLANK_TEXT_PATTERN,
+    });
+    let commit_schema = json_schema!({
+        "type": ["string", "null"],
+        "minLength": 1,
+        "maxLength": 256,
+        "pattern": IDENTIFIER_PATTERN,
+    });
+    json_schema!({
+        "oneOf": [
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["path"],
+                "properties": {
+                    "path": path_schema,
+                    "image": {"type": "null"},
+                    "commit": commit_schema,
+                }
+            },
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["image"],
+                "properties": {
+                    "path": {"type": "null"},
+                    "image": image_schema,
+                    "commit": commit_schema,
+                }
+            }
+        ]
+    })
+}
+
+/// A typed executable command used by setup and test stages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(try_from = "CommandSpecWire")]
+pub struct CommandSpec {
+    /// Executable token; shell interpretation is not implied.
+    #[schemars(
+        length(min = 1, max = MAX_PATH_CHARS),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    program: String,
+    /// Explicit arguments passed to the executable.
+    #[serde(default)]
+    #[schemars(
+        length(max = MAX_COMMAND_ARGS),
+        inner(
+            length(max = MAX_COMMAND_ARG_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )
+    )]
+    args: Vec<String>,
+    /// Optional relative working directory inside the task workspace.
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_relative_path_schema")]
+    working_dir: Option<String>,
+    /// Optional command-specific timeout.
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default, schema_with = "optional_positive_u64_schema")]
+    timeout_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct CommandSpecWire {
+    #[schemars(
+        length(min = 1, max = MAX_PATH_CHARS),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    program: String,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(max = MAX_COMMAND_ARGS),
+        inner(
+            length(max = MAX_COMMAND_ARG_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )
+    )]
+    args: Vec<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_relative_path_schema")]
+    working_dir: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default, schema_with = "optional_positive_u64_schema")]
+    timeout_seconds: Option<u64>,
+}
+
+impl TryFrom<CommandSpecWire> for CommandSpec {
+    type Error = EvalError;
+
+    fn try_from(wire: CommandSpecWire) -> Result<Self, Self::Error> {
+        let command = Self {
+            program: wire.program,
+            args: wire.args,
+            working_dir: wire.working_dir,
+            timeout_seconds: wire.timeout_seconds,
+        };
+        command.validate("command")?;
+        Ok(command)
+    }
+}
+
+impl CommandSpec {
+    /// Creates a command with explicit executable arguments.
+    pub fn new(program: &str, args: &[&str]) -> Result<Self, EvalError> {
+        let command = Self {
+            program: program.to_owned(),
+            args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+            working_dir: None,
+            timeout_seconds: None,
+        };
+        command.validate("command")?;
+        Ok(command)
+    }
+
+    /// Returns the executable token.
+    #[must_use]
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// Returns explicit command arguments.
+    #[must_use]
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+
+    /// Returns the optional working directory.
+    #[must_use]
+    pub fn working_dir(&self) -> Option<&str> {
+        self.working_dir.as_deref()
+    }
+
+    /// Sets a relative working directory for this command.
+    pub fn with_working_dir(mut self, working_dir: &str) -> Result<Self, EvalError> {
+        validate_relative_path("command.working_dir", working_dir)?;
+        self.working_dir = Some(working_dir.to_owned());
+        Ok(self)
+    }
+
+    /// Sets a positive command-specific timeout.
+    pub fn with_timeout_seconds(mut self, timeout_seconds: u64) -> Result<Self, EvalError> {
+        if timeout_seconds == 0 {
+            return Err(invalid_field(
+                "command.timeout_seconds",
+                "must be greater than zero when provided",
+            ));
+        }
+        self.timeout_seconds = Some(timeout_seconds);
+        Ok(self)
+    }
+
+    /// Returns the optional command timeout.
+    #[must_use]
+    pub fn timeout_seconds(&self) -> Option<u64> {
+        self.timeout_seconds
+    }
+
+    fn validate(&self, field: &str) -> Result<(), EvalError> {
+        validate_text_field(&format!("{field}.program"), &self.program, MAX_PATH_CHARS)?;
+        if self.args.len() > MAX_COMMAND_ARGS {
+            return Err(invalid_field(
+                format!("{field}.args"),
+                format!("must contain at most {MAX_COMMAND_ARGS} arguments"),
+            ));
+        }
+        for (index, arg) in self.args.iter().enumerate() {
+            validate_text_field(
+                &format!("{field}.args[{index}]"),
+                arg,
+                MAX_COMMAND_ARG_CHARS,
+            )?;
+        }
+        if let Some(working_dir) = self.working_dir.as_deref() {
+            validate_relative_path(&format!("{field}.working_dir"), working_dir)?;
+        }
+        if self.timeout_seconds == Some(0) {
+            return Err(invalid_field(
+                format!("{field}.timeout_seconds"),
+                "must be greater than zero when provided",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// The amount of external authority a task may use while it runs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskPolicy {
+    /// The task may inspect its workspace but must not mutate it.
+    ReadOnly,
+    /// The task may mutate files inside its declared workspace scope.
+    #[default]
+    WorkspaceWrite,
+    /// The task may mutate its workspace and access the network.
+    WorkspaceWriteAndNetwork,
+}
+
+/// Resource ceilings applied by an evaluation harness.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(try_from = "ResourceLimitsWire")]
+pub struct ResourceLimits {
+    /// Maximum captured process output in bytes.
+    #[schemars(default, schema_with = "optional_positive_u64_schema")]
+    max_output_bytes: Option<u64>,
+    /// Maximum number of files a task may change.
+    #[serde(default, deserialize_with = "deserialize_option_u32")]
+    #[schemars(default, schema_with = "optional_positive_u32_schema")]
+    max_file_changes: Option<u32>,
+    /// Maximum number of concurrently running processes.
+    #[serde(default, deserialize_with = "deserialize_option_u32")]
+    #[schemars(default, schema_with = "optional_positive_u32_schema")]
+    max_processes: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ResourceLimitsWire {
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(schema_with = "optional_positive_u64_schema")]
+    max_output_bytes: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_u32")]
+    #[schemars(schema_with = "optional_positive_u32_schema")]
+    max_file_changes: Option<u32>,
+    #[serde(default, deserialize_with = "deserialize_option_u32")]
+    #[schemars(schema_with = "optional_positive_u32_schema")]
+    max_processes: Option<u32>,
+}
+
+impl TryFrom<ResourceLimitsWire> for ResourceLimits {
+    type Error = EvalError;
+
+    fn try_from(wire: ResourceLimitsWire) -> Result<Self, Self::Error> {
+        let limits = Self {
+            max_output_bytes: wire.max_output_bytes,
+            max_file_changes: wire.max_file_changes,
+            max_processes: wire.max_processes,
+        };
+        limits.validate()?;
+        Ok(limits)
+    }
+}
+
+impl ResourceLimits {
+    /// Creates validated resource ceilings for one task.
+    pub fn new(
+        max_output_bytes: Option<u64>,
+        max_file_changes: Option<u32>,
+        max_processes: Option<u32>,
+    ) -> Result<Self, EvalError> {
+        let limits = Self {
+            max_output_bytes,
+            max_file_changes,
+            max_processes,
+        };
+        limits.validate()?;
+        Ok(limits)
+    }
+
+    /// Returns the maximum captured output size.
+    #[must_use]
+    pub fn max_output_bytes(&self) -> Option<u64> {
+        self.max_output_bytes
+    }
+
+    /// Returns the maximum file-change count.
+    #[must_use]
+    pub fn max_file_changes(&self) -> Option<u32> {
+        self.max_file_changes
+    }
+
+    /// Returns the maximum process count.
+    #[must_use]
+    pub fn max_processes(&self) -> Option<u32> {
+        self.max_processes
+    }
+
+    fn validate(&self) -> Result<(), EvalError> {
+        if self.max_output_bytes == Some(0) {
+            return Err(invalid_field(
+                "resource_limits.max_output_bytes",
+                "must be greater than zero when provided",
+            ));
+        }
+        if self.max_file_changes == Some(0) {
+            return Err(invalid_field(
+                "resource_limits.max_file_changes",
+                "must be greater than zero when provided",
+            ));
+        }
+        if self.max_processes == Some(0) {
+            return Err(invalid_field(
+                "resource_limits.max_processes",
+                "must be greater than zero when provided",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// A typed expected artifact emitted by a successful task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(try_from = "ExpectedArtifactWire")]
+pub struct ExpectedArtifact {
+    /// Relative path of the expected artifact.
+    #[schemars(schema_with = "relative_path_schema")]
+    path: String,
+    /// Provider-neutral artifact kind.
+    kind: ArtifactKind,
+    /// Optional SHA-256 digest of the artifact bytes.
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ExpectedArtifactWire {
+    #[schemars(schema_with = "relative_path_schema")]
+    path: String,
+    kind: ArtifactKind,
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    sha256: Option<String>,
+}
+
+impl TryFrom<ExpectedArtifactWire> for ExpectedArtifact {
+    type Error = EvalError;
+
+    fn try_from(wire: ExpectedArtifactWire) -> Result<Self, Self::Error> {
+        Self::from_wire_at(wire, "expected_artifact")
+    }
+}
+
+impl ExpectedArtifact {
+    fn from_wire_at(wire: ExpectedArtifactWire, field: &str) -> Result<Self, EvalError> {
+        let artifact = Self {
+            path: wire.path,
+            kind: wire.kind,
+            sha256: wire.sha256,
+        };
+        artifact.validate_at(field)?;
+        Ok(artifact)
+    }
+    /// Creates a validated expected artifact reference.
+    pub fn new(path: &str, kind: ArtifactKind, sha256: Option<&str>) -> Result<Self, EvalError> {
+        let artifact = Self {
+            path: path.to_owned(),
+            kind,
+            sha256: sha256.map(str::to_owned),
+        };
+        artifact.validate_at("expected_artifact")?;
+        Ok(artifact)
+    }
+
+    /// Returns the expected artifact path.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the expected artifact kind.
+    #[must_use]
+    pub fn kind(&self) -> ArtifactKind {
+        self.kind
+    }
+
+    /// Returns the optional expected SHA-256 digest.
+    #[must_use]
+    pub fn sha256(&self) -> Option<&str> {
+        self.sha256.as_deref()
+    }
+
+    fn validate_at(&self, field: &str) -> Result<(), EvalError> {
+        validate_relative_path(&format!("{field}.path"), &self.path)?;
+        if let Some(digest) = self.sha256.as_deref() {
+            validate_sha256(&format!("{field}.sha256"), digest)?;
+        }
+        Ok(())
+    }
+}
+
+/// Provider-neutral kinds for expected task artifacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    /// A regular file.
+    File,
+    /// A directory tree.
+    Directory,
+    /// UTF-8 text.
+    Text,
+    /// Structured JSON.
+    Json,
+    /// A patch or diff.
+    Diff,
+}
+
+/// A machine-checkable condition for task success.
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SuccessCriterion {
+    /// Requires a relative file path to exist.
+    FileExists {
+        /// Relative path to check.
+        #[schemars(schema_with = "relative_path_schema")]
+        path: String,
+    },
+    /// Requires a file to contain an exact text fragment.
+    FileContains {
+        /// Relative path to inspect.
+        #[schemars(schema_with = "relative_path_schema")]
+        path: String,
+        /// Text fragment to find.
+        #[schemars(
+            length(min = 1, max = MAX_DIFF_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )]
+        text: String,
+    },
+    /// Runs an explicit command and requires a successful exit.
+    CommandPasses {
+        /// Executable token.
+        #[schemars(
+            length(min = 1, max = MAX_PATH_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )]
+        program: String,
+        /// Explicit command arguments.
+        #[serde(default)]
+        #[schemars(
+        default,
+        length(max = MAX_COMMAND_ARGS),
+        inner(
+            length(max = MAX_COMMAND_ARG_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )
+    )]
+        args: Vec<String>,
+        /// Optional relative working directory.
+        #[serde(default)]
+        #[schemars(default, schema_with = "optional_relative_path_schema")]
+        working_dir: Option<String>,
+        /// Optional command timeout.
+        #[serde(default, deserialize_with = "deserialize_option_u64")]
+        #[schemars(default, schema_with = "optional_positive_u64_schema")]
+        timeout_seconds: Option<u64>,
+    },
+    /// Compares a relative file's content with an expected diff.
+    DiffMatches {
+        /// Relative path to inspect.
+        #[schemars(schema_with = "relative_path_schema")]
+        path: String,
+        /// Expected diff content.
+        #[schemars(
+            length(min = 1, max = MAX_DIFF_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )]
+        expected: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum SuccessCriterionWire {
+    FileExists {
+        #[schemars(schema_with = "relative_path_schema")]
+        path: String,
+    },
+    FileContains {
+        #[schemars(schema_with = "relative_path_schema")]
+        path: String,
+        #[schemars(
+            length(min = 1, max = MAX_DIFF_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )]
+        text: String,
+    },
+    CommandPasses {
+        #[schemars(
+            length(min = 1, max = MAX_PATH_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )]
+        program: String,
+        #[serde(default)]
+        #[schemars(
+        default,
+        length(max = MAX_COMMAND_ARGS),
+        inner(
+            length(max = MAX_COMMAND_ARG_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )
+    )]
+        args: Vec<String>,
+        #[serde(default)]
+        #[schemars(default, schema_with = "optional_relative_path_schema")]
+        working_dir: Option<String>,
+        #[serde(default, deserialize_with = "deserialize_option_u64")]
+        #[schemars(default, schema_with = "optional_positive_u64_schema")]
+        timeout_seconds: Option<u64>,
+    },
+    DiffMatches {
+        #[schemars(schema_with = "relative_path_schema")]
+        path: String,
+        #[schemars(
+            length(min = 1, max = MAX_DIFF_CHARS),
+            regex(pattern = NON_BLANK_TEXT_PATTERN)
+        )]
+        expected: String,
+    },
+}
+
+impl TryFrom<SuccessCriterionWire> for SuccessCriterion {
+    type Error = EvalError;
+
+    fn try_from(wire: SuccessCriterionWire) -> Result<Self, Self::Error> {
+        let criterion = match wire {
+            SuccessCriterionWire::FileExists { path } => Self::FileExists { path },
+            SuccessCriterionWire::FileContains { path, text } => Self::FileContains { path, text },
+            SuccessCriterionWire::CommandPasses {
+                program,
+                args,
+                working_dir,
+                timeout_seconds,
+            } => Self::CommandPasses {
+                program,
+                args,
+                working_dir,
+                timeout_seconds,
+            },
+            SuccessCriterionWire::DiffMatches { path, expected } => {
+                Self::DiffMatches { path, expected }
+            }
+        };
+        criterion.validate()?;
+        Ok(criterion)
+    }
+}
+
+impl<'de> Deserialize<'de> for SuccessCriterion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SuccessCriterionWire::deserialize(deserializer)?;
+        Self::try_from(wire).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for SuccessCriterion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate().map_err(S::Error::custom)?;
+        let wire = match self {
+            Self::FileExists { path } => SuccessCriterionWire::FileExists { path: path.clone() },
+            Self::FileContains { path, text } => SuccessCriterionWire::FileContains {
+                path: path.clone(),
+                text: text.clone(),
+            },
+            Self::CommandPasses {
+                program,
+                args,
+                working_dir,
+                timeout_seconds,
+            } => SuccessCriterionWire::CommandPasses {
+                program: program.clone(),
+                args: args.clone(),
+                working_dir: working_dir.clone(),
+                timeout_seconds: *timeout_seconds,
+            },
+            Self::DiffMatches { path, expected } => SuccessCriterionWire::DiffMatches {
+                path: path.clone(),
+                expected: expected.clone(),
+            },
+        };
+        wire.serialize(serializer)
+    }
+}
+
+impl SuccessCriterion {
+    /// Validates paths, command arguments, and expected text in this criterion.
+    pub fn validate(&self) -> Result<(), EvalError> {
+        self.validate_at("success_criteria[0]")
+    }
+
+    fn validate_indexed(&self, index: usize) -> Result<(), EvalError> {
+        self.validate_at(&format!("success_criteria[{index}]"))
+    }
+
+    fn validate_at(&self, field: &str) -> Result<(), EvalError> {
+        match self {
+            Self::FileExists { path } => validate_relative_path(&format!("{field}.path"), path),
+            Self::FileContains { path, text } => {
+                validate_relative_path(&format!("{field}.path"), path)?;
+                validate_text_field(&format!("{field}.text"), text, MAX_DIFF_CHARS)
+            }
+            Self::CommandPasses {
+                program,
+                args,
+                working_dir,
+                timeout_seconds,
+            } => CommandSpec {
+                program: program.clone(),
+                args: args.clone(),
+                working_dir: working_dir.clone(),
+                timeout_seconds: *timeout_seconds,
+            }
+            .validate(field),
+            Self::DiffMatches { path, expected } => {
+                validate_relative_path(&format!("{field}.path"), path)?;
+                validate_text_field(&format!("{field}.expected"), expected, MAX_DIFF_CHARS)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct TaskSpecWire {
+    #[serde(deserialize_with = "deserialize_u32")]
+    #[schemars(schema_with = "version_schema")]
+    schema_version: u32,
+    #[schemars(
+        length(min = 1, max = 128),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    task_id: String,
+    #[schemars(
+        length(min = 1, max = 128),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    task_version: String,
+    #[schemars(
+        length(min = 1, max = MAX_DESCRIPTION_CHARS),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    description: String,
+    repository: RepositorySpec,
+    #[schemars(
+        length(min = 1),
+        inner(length(max = MAX_SCOPE_CHARS), regex(pattern = RELATIVE_PATH_PATTERN))
+    )]
+    write_scope: Vec<String>,
+    #[serde(default)]
+    setup: Vec<CommandSpec>,
+    #[serde(default)]
+    tests: Vec<CommandSpec>,
+    #[serde(deserialize_with = "deserialize_u64")]
+    #[schemars(schema_with = "task_timeout_schema")]
+    timeout_seconds: u64,
+    #[serde(default)]
+    #[schemars(default)]
+    resource_limits: ResourceLimits,
+    #[serde(default)]
+    #[schemars(default)]
+    risk_policy: RiskPolicy,
+    #[schemars(length(min = 1))]
+    success_criteria: Vec<SuccessCriterion>,
+    #[serde(default)]
+    #[schemars(default)]
+    expected_artifacts: Vec<ExpectedArtifactWire>,
+    #[schemars(
+        default,
+        length(min = 1, max = MAX_DIFF_CHARS),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    expected_diff: Option<String>,
+}
+
+/// A validated, versioned manifest describing one evaluation task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TaskSpec {
+    #[schemars(schema_with = "version_schema")]
+    schema_version: u32,
+    #[schemars(
+        length(min = 1, max = 128),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    task_id: String,
+    #[schemars(
+        length(min = 1, max = 128),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    task_version: String,
+    #[schemars(
+        length(min = 1, max = MAX_DESCRIPTION_CHARS),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    description: String,
+    repository: RepositorySpec,
+    #[schemars(
+        length(min = 1),
+        inner(length(max = MAX_SCOPE_CHARS), regex(pattern = RELATIVE_PATH_PATTERN))
+    )]
+    write_scope: Vec<String>,
+    #[serde(default)]
+    #[schemars(default)]
+    setup: Vec<CommandSpec>,
+    #[serde(default)]
+    #[schemars(default)]
+    tests: Vec<CommandSpec>,
+    #[schemars(schema_with = "task_timeout_schema")]
+    timeout_seconds: u64,
+    #[serde(default)]
+    #[schemars(default)]
+    resource_limits: ResourceLimits,
+    #[serde(default)]
+    #[schemars(default)]
+    risk_policy: RiskPolicy,
+    #[schemars(length(min = 1))]
+    success_criteria: Vec<SuccessCriterion>,
+    #[serde(default)]
+    #[schemars(default)]
+    expected_artifacts: Vec<ExpectedArtifact>,
+    #[schemars(
+        default,
+        length(min = 1, max = MAX_DIFF_CHARS),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    expected_diff: Option<String>,
+}
+
+impl TaskSpec {
+    /// Parses and validates a strict TOML task manifest.
+    pub fn from_toml(source: &str) -> Result<Self, EvalError> {
+        let wire: TaskSpecWire = toml::from_str(source)?;
+        Self::from_wire(wire)
+    }
+
+    /// Serializes this validated task manifest as canonical TOML.
+    pub fn to_toml(&self) -> Result<String, EvalError> {
+        Ok(toml::to_string_pretty(self)?)
+    }
+
+    /// Returns the manifest schema version.
+    #[must_use]
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Returns the stable task identifier.
+    #[must_use]
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
+
+    /// Returns the task version.
+    #[must_use]
+    pub fn task_version(&self) -> &str {
+        &self.task_version
+    }
+
+    /// Returns the task description.
+    #[must_use]
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Returns the repository or image specification.
+    #[must_use]
+    pub fn repository(&self) -> &RepositorySpec {
+        &self.repository
+    }
+
+    /// Returns the declared writable path patterns.
+    #[must_use]
+    pub fn write_scope(&self) -> &[String] {
+        &self.write_scope
+    }
+
+    /// Returns setup commands in declaration order.
+    #[must_use]
+    pub fn setup(&self) -> &[CommandSpec] {
+        &self.setup
+    }
+
+    /// Returns verification commands in declaration order.
+    #[must_use]
+    pub fn tests(&self) -> &[CommandSpec] {
+        &self.tests
+    }
+
+    /// Returns the task timeout in seconds.
+    #[must_use]
+    pub fn timeout_seconds(&self) -> u64 {
+        self.timeout_seconds
+    }
+
+    /// Returns resource ceilings.
+    #[must_use]
+    pub fn resource_limits(&self) -> &ResourceLimits {
+        &self.resource_limits
+    }
+
+    /// Returns the task's risk policy.
+    #[must_use]
+    pub fn risk_policy(&self) -> RiskPolicy {
+        self.risk_policy
+    }
+
+    /// Returns machine-checkable success conditions.
+    #[must_use]
+    pub fn success_criteria(&self) -> &[SuccessCriterion] {
+        &self.success_criteria
+    }
+
+    /// Returns expected artifacts.
+    #[must_use]
+    pub fn expected_artifacts(&self) -> &[ExpectedArtifact] {
+        &self.expected_artifacts
+    }
+
+    /// Returns an optional expected diff.
+    #[must_use]
+    pub fn expected_diff(&self) -> Option<&str> {
+        self.expected_diff.as_deref()
+    }
+
+    fn from_wire(wire: TaskSpecWire) -> Result<Self, EvalError> {
+        if wire.schema_version != TASK_SCHEMA_VERSION {
+            return Err(EvalError::UnsupportedVersion {
+                kind: "task manifest",
+                found: wire.schema_version,
+                supported: TASK_SCHEMA_VERSION,
+            });
+        }
+        validate_identifier("task_id", &wire.task_id, 128)?;
+        validate_identifier("task_version", &wire.task_version, 128)?;
+        validate_text("description", &wire.description, MAX_DESCRIPTION_CHARS)?;
+        validate_repository(&wire.repository)?;
+        validate_scope(&wire.write_scope)?;
+        for (index, command) in wire.setup.iter().enumerate() {
+            command.validate(&format!("setup[{index}]"))?;
+        }
+        for (index, command) in wire.tests.iter().enumerate() {
+            command.validate(&format!("tests[{index}]"))?;
+        }
+        if wire.timeout_seconds == 0 {
+            return Err(invalid_field(
+                "timeout_seconds",
+                "must be greater than zero",
+            ));
+        }
+        if wire.timeout_seconds > 7 * 24 * 60 * 60 {
+            return Err(invalid_field(
+                "timeout_seconds",
+                "must not exceed seven days",
+            ));
+        }
+        wire.resource_limits.validate()?;
+        if wire.success_criteria.is_empty() {
+            return Err(invalid_field(
+                "success_criteria",
+                "must contain at least one criterion",
+            ));
+        }
+        for (index, criterion) in wire.success_criteria.iter().enumerate() {
+            criterion.validate_indexed(index)?;
+        }
+        let expected_artifacts = wire
+            .expected_artifacts
+            .into_iter()
+            .enumerate()
+            .map(|(index, artifact)| {
+                ExpectedArtifact::from_wire_at(artifact, &format!("expected_artifacts[{index}]"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if let Some(expected_diff) = wire.expected_diff.as_deref() {
+            validate_text("expected_diff", expected_diff, MAX_DIFF_CHARS)?;
+        }
+
+        Ok(Self {
+            schema_version: wire.schema_version,
+            task_id: wire.task_id,
+            task_version: wire.task_version,
+            description: wire.description,
+            repository: wire.repository,
+            write_scope: wire.write_scope,
+            setup: wire.setup,
+            tests: wire.tests,
+            timeout_seconds: wire.timeout_seconds,
+            resource_limits: wire.resource_limits,
+            risk_policy: wire.risk_policy,
+            success_criteria: wire.success_criteria,
+            expected_artifacts,
+            expected_diff: wire.expected_diff,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = TaskSpecWire::deserialize(deserializer)?;
+        Self::from_wire(wire).map_err(de::Error::custom)
+    }
+}

--- a/crates/merry-eval/src/manifest_validation.rs
+++ b/crates/merry-eval/src/manifest_validation.rs
@@ -1,0 +1,66 @@
+use super::{MAX_PATH_CHARS, MAX_SCOPE_CHARS, RepositorySpec};
+use crate::error::{
+    EvalError, invalid_field, validate_identifier, validate_relative_path, validate_text,
+};
+
+pub(super) fn validate_repository(repository: &RepositorySpec) -> Result<(), EvalError> {
+    if repository.path.is_some() == repository.image.is_some() {
+        return Err(invalid_field(
+            "repository",
+            "must define exactly one of path or image",
+        ));
+    }
+    if let Some(path) = repository.path.as_deref() {
+        validate_relative_path("repository.path", path)?;
+    }
+    if let Some(image) = repository.image.as_deref() {
+        validate_text("repository.image", image, MAX_PATH_CHARS)?;
+    }
+    if let Some(commit) = repository.commit.as_deref() {
+        validate_identifier("repository.commit", commit, 256)?;
+    }
+    Ok(())
+}
+
+pub(super) fn validate_scope(scope: &[String]) -> Result<(), EvalError> {
+    if scope.is_empty() {
+        return Err(invalid_field(
+            "write_scope",
+            "must contain at least one path pattern",
+        ));
+    }
+    for (index, pattern) in scope.iter().enumerate() {
+        validate_relative_path(&format!("write_scope[{index}]"), pattern)?;
+        if pattern.chars().count() > MAX_SCOPE_CHARS {
+            return Err(invalid_field(
+                format!("write_scope[{index}]"),
+                format!("must contain at most {MAX_SCOPE_CHARS} characters"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_text_field(
+    field: &str,
+    value: &str,
+    max_chars: usize,
+) -> Result<(), EvalError> {
+    if value.trim().is_empty() {
+        return Err(invalid_field(field, "must not be blank"));
+    }
+    validate_text("value", value, max_chars).map_err(|error| match error {
+        EvalError::InvalidField { reason, .. } => invalid_field(field, reason),
+        other => other,
+    })
+}
+
+pub(super) fn validate_sha256(field: &str, value: &str) -> Result<(), EvalError> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid_field(
+            field,
+            "must be a 64-character hexadecimal SHA-256 digest",
+        ));
+    }
+    Ok(())
+}

--- a/crates/merry-eval/src/numeric.rs
+++ b/crates/merry-eval/src/numeric.rs
@@ -1,0 +1,274 @@
+use schemars::{Schema, SchemaGenerator, json_schema};
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use std::fmt;
+
+const U64_EXCLUSIVE_UPPER_BOUND: f64 = 18_446_744_073_709_551_616.0;
+const SERDE_JSON_NUMBER_KEY: &str = "$serde_json::private::Number";
+
+pub(crate) fn nonnegative_u64_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": "number",
+        "minimum": 0,
+        "maximum": u64::MAX,
+        "multipleOf": 1,
+    })
+}
+
+pub(crate) fn optional_nonnegative_u64_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": ["number", "null"],
+        "minimum": 0,
+        "maximum": u64::MAX,
+        "multipleOf": 1,
+    })
+}
+
+pub(crate) fn positive_u32_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": "number",
+        "minimum": 1,
+        "maximum": u32::MAX,
+        "multipleOf": 1,
+    })
+}
+
+pub(crate) fn optional_positive_u32_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": ["number", "null"],
+        "minimum": 1,
+        "maximum": u32::MAX,
+        "multipleOf": 1,
+    })
+}
+
+pub(crate) fn optional_positive_u64_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": ["number", "null"],
+        "minimum": 1,
+        "maximum": u64::MAX,
+        "multipleOf": 1,
+    })
+}
+
+pub(crate) fn task_timeout_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": "number",
+        "minimum": 1,
+        "maximum": 604800,
+        "multipleOf": 1,
+    })
+}
+
+pub(crate) fn version_schema(_: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": "number",
+        "const": 1,
+        "multipleOf": 1,
+    })
+}
+
+fn parse_integral_decimal(raw: &str) -> Result<u64, &'static str> {
+    let (negative, raw) = raw
+        .strip_prefix('-')
+        .map_or((false, raw), |rest| (true, rest));
+    let (mantissa, exponent) = raw
+        .split_once(['e', 'E'])
+        .map_or((raw, 0_i64), |(mantissa, exponent)| {
+            (mantissa, exponent.parse::<i64>().unwrap_or(i64::MIN))
+        });
+    if exponent == i64::MIN || mantissa.is_empty() {
+        return Err("number has an invalid exponent");
+    }
+
+    let (whole, fraction) = mantissa
+        .split_once('.')
+        .map_or((mantissa, ""), |parts| parts);
+    if whole.is_empty() || !whole.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("number has an invalid integer part");
+    }
+    if !fraction.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("number has an invalid fractional part");
+    }
+
+    let digits = format!("{whole}{fraction}");
+    let first_nonzero = digits.bytes().position(|byte| byte != b'0');
+    let Some(first_nonzero) = first_nonzero else {
+        return Ok(0);
+    };
+    if negative {
+        return Err("number must not be negative");
+    }
+
+    let scale = exponent
+        .checked_sub(i64::try_from(fraction.len()).map_err(|_| "fraction is too long")?)
+        .ok_or("number exponent underflow")?;
+    if scale < 0 {
+        let remove = usize::try_from(scale.unsigned_abs()).map_err(|_| "number is too small")?;
+        if remove >= digits.len() {
+            return Err("number must be an integer");
+        }
+        let split = digits.len() - remove;
+        if digits[split..].bytes().any(|byte| byte != b'0') {
+            return Err("number must be an integer");
+        }
+        return parse_u64_digits(&digits[..split]);
+    }
+
+    let significant = &digits[first_nonzero..];
+    let zeros = usize::try_from(scale).map_err(|_| "number exceeds u64 range")?;
+    if significant.len().saturating_add(zeros) > 20 {
+        return Err("number exceeds u64 range");
+    }
+    let mut value = parse_u64_digits(significant)?;
+    for _ in 0..zeros {
+        value = value.checked_mul(10).ok_or("number exceeds u64 range")?;
+    }
+    Ok(value)
+}
+
+fn parse_u64_digits(digits: &str) -> Result<u64, &'static str> {
+    digits.bytes().try_fold(0_u64, |value, byte| {
+        value
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(u64::from(byte - b'0')))
+            .ok_or("number exceeds u64 range")
+    })
+}
+
+struct IntegralNumberVisitor;
+
+impl<'de> Visitor<'de> for IntegralNumberVisitor {
+    type Value = u64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a non-negative integer or an integral JSON number")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        u64::try_from(value).map_err(|_| E::custom("integer exceeds u64 range"))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        u64::try_from(value).map_err(|_| E::custom("integer must not be negative"))
+    }
+
+    fn visit_i128<E>(self, value: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        u64::try_from(value).map_err(|_| E::custom("integer must be non-negative and fit u64"))
+    }
+
+    fn visit_f32<E>(self, value: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_f64(f64::from(value))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+            return Err(E::custom("number must be a finite non-negative integer"));
+        }
+        if value >= U64_EXCLUSIVE_UPPER_BOUND {
+            return Err(E::custom("number exceeds u64 range"));
+        }
+        Ok(value as u64)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let Some(key) = map.next_key::<String>()? else {
+            return Err(de::Error::custom("number is missing its value"));
+        };
+        if key != SERDE_JSON_NUMBER_KEY {
+            return Err(de::Error::custom("unexpected map while parsing a number"));
+        }
+        let raw = map.next_value::<String>()?;
+        if map.next_key::<String>()?.is_some() {
+            return Err(de::Error::custom("number has multiple values"));
+        }
+        parse_integral_decimal(&raw).map_err(de::Error::custom)
+    }
+}
+
+pub(crate) fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(IntegralNumberVisitor)
+}
+
+pub(crate) fn deserialize_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = deserialize_u64(deserializer)?;
+    u32::try_from(value).map_err(|_| de::Error::custom("integer exceeds u32 range"))
+}
+
+struct OptionalIntegralNumberVisitor;
+
+impl<'de> Visitor<'de> for OptionalIntegralNumberVisitor {
+    type Value = Option<u64>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("null or a non-negative integer")
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_u64(deserializer).map(Some)
+    }
+}
+
+pub(crate) fn deserialize_option_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_option(OptionalIntegralNumberVisitor)
+}
+
+pub(crate) fn deserialize_option_u32<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_option_u64(deserializer)?
+        .map(u32::try_from)
+        .transpose()
+        .map_err(|_| de::Error::custom("integer exceeds u32 range"))
+}

--- a/crates/merry-eval/src/record.rs
+++ b/crates/merry-eval/src/record.rs
@@ -1,0 +1,961 @@
+use crate::error::{
+    EvalError, IDENTIFIER_PATTERN, NON_BLANK_TEXT_PATTERN, invalid_field, optional_sha256_schema,
+    relative_path_schema, validate_identifier, validate_relative_path, validate_text,
+};
+use crate::manifest::ArtifactKind;
+use crate::numeric::{
+    deserialize_option_u64, deserialize_u32, deserialize_u64, nonnegative_u64_schema,
+    optional_nonnegative_u64_schema, positive_u32_schema, version_schema,
+};
+use schemars::JsonSchema;
+
+#[path = "record_schema.rs"]
+mod record_schema;
+use record_schema::evaluation_record_schema;
+use serde::{Deserialize, Serialize, Serializer, ser::Error as SerdeError};
+
+/// The only evaluation-run schema version understood by this crate.
+pub const EVALUATION_RUN_SCHEMA_VERSION: u32 = 1;
+/// The only JSONL evaluation-record schema version understood by this crate.
+pub const EVALUATION_RECORD_SCHEMA_VERSION: u32 = 1;
+
+const MAX_JSONL_BYTES: usize = 4 * 1024 * 1024;
+const MAX_RECORD_ITEMS: usize = 1024;
+
+/// Terminal state recorded for an evaluation run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluationStatus {
+    /// The task satisfied its success criteria.
+    Passed,
+    /// The task ran but did not satisfy its success criteria.
+    Failed,
+    /// A policy or permission decision prevented completion.
+    Blocked,
+    /// The run was cancelled before completion.
+    Cancelled,
+    /// The harness could not complete the run due to an infrastructure error.
+    Error,
+}
+
+/// A normalized reason for a non-passing evaluation result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    /// The model response was invalid or incomplete.
+    Model,
+    /// A tool invocation failed.
+    Tool,
+    /// A permission or risk policy denied an action.
+    Permission,
+    /// The runtime failed independently of a tool or model.
+    Runtime,
+    /// A success criterion or verification command failed.
+    Test,
+    /// A configured timeout expired.
+    Timeout,
+    /// The run was cancelled by its owner.
+    Cancelled,
+}
+
+/// Metadata identifying one evaluation attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, try_from = "EvaluationRunWire")]
+pub struct EvaluationRun {
+    #[schemars(schema_with = "version_schema")]
+    schema_version: u32,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    run_id: String,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    task_id: String,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    task_version: String,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    runner_version: String,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(min = 1, max = 256),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    source_commit: Option<String>,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(min = 1, max = 128),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    provider: Option<String>,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(min = 1, max = 256),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    model: Option<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    prompt_hash: Option<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    profile_hash: Option<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    tool_schema_hash: Option<String>,
+    #[schemars(schema_with = "nonnegative_u64_schema")]
+    started_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct EvaluationRunWire {
+    #[serde(deserialize_with = "deserialize_u32")]
+    #[schemars(schema_with = "version_schema")]
+    schema_version: u32,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    run_id: String,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    task_id: String,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    task_version: String,
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    runner_version: String,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(min = 1, max = 256),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    source_commit: Option<String>,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(min = 1, max = 128),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    provider: Option<String>,
+    #[serde(default)]
+    #[schemars(
+        default,
+        length(min = 1, max = 256),
+        regex(pattern = IDENTIFIER_PATTERN)
+    )]
+    model: Option<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    prompt_hash: Option<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    profile_hash: Option<String>,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    tool_schema_hash: Option<String>,
+    #[serde(deserialize_with = "deserialize_u64")]
+    #[schemars(schema_with = "nonnegative_u64_schema")]
+    started_at_ms: u64,
+}
+
+impl TryFrom<EvaluationRunWire> for EvaluationRun {
+    type Error = EvalError;
+
+    fn try_from(wire: EvaluationRunWire) -> Result<Self, Self::Error> {
+        let run = Self {
+            schema_version: wire.schema_version,
+            run_id: wire.run_id,
+            task_id: wire.task_id,
+            task_version: wire.task_version,
+            runner_version: wire.runner_version,
+            source_commit: wire.source_commit,
+            provider: wire.provider,
+            model: wire.model,
+            prompt_hash: wire.prompt_hash,
+            profile_hash: wire.profile_hash,
+            tool_schema_hash: wire.tool_schema_hash,
+            started_at_ms: wire.started_at_ms,
+        };
+        run.validate()?;
+        Ok(run)
+    }
+}
+
+impl EvaluationRun {
+    /// Creates a run with stable task identity and a start timestamp.
+    pub fn new(
+        run_id: &str,
+        task_id: &str,
+        task_version: &str,
+        started_at_ms: u64,
+    ) -> Result<Self, EvalError> {
+        validate_identifier("run_id", run_id, 128)?;
+        validate_identifier("task_id", task_id, 128)?;
+        validate_identifier("task_version", task_version, 128)?;
+        Ok(Self {
+            schema_version: EVALUATION_RUN_SCHEMA_VERSION,
+            run_id: run_id.to_owned(),
+            task_id: task_id.to_owned(),
+            task_version: task_version.to_owned(),
+            runner_version: env!("CARGO_PKG_VERSION").to_owned(),
+            source_commit: None,
+            provider: None,
+            model: None,
+            prompt_hash: None,
+            profile_hash: None,
+            tool_schema_hash: None,
+            started_at_ms,
+        })
+    }
+
+    /// Adds the source revision used to prepare the evaluation workspace.
+    pub fn with_source_commit(mut self, source_commit: &str) -> Result<Self, EvalError> {
+        validate_identifier("source_commit", source_commit, 256)?;
+        self.source_commit = Some(source_commit.to_owned());
+        Ok(self)
+    }
+
+    /// Adds a provider label without storing provider wire payloads.
+    pub fn with_provider(mut self, provider: &str) -> Result<Self, EvalError> {
+        validate_identifier("provider", provider, 128)?;
+        self.provider = Some(provider.to_owned());
+        Ok(self)
+    }
+
+    /// Adds a model label without storing a request or response.
+    pub fn with_model(mut self, model: &str) -> Result<Self, EvalError> {
+        validate_identifier("model", model, 256)?;
+        self.model = Some(model.to_owned());
+        Ok(self)
+    }
+
+    /// Sets the version of the evaluation runner that produced the record.
+    pub fn with_runner_version(mut self, runner_version: &str) -> Result<Self, EvalError> {
+        validate_identifier("runner_version", runner_version, 128)?;
+        self.runner_version = runner_version.to_owned();
+        Ok(self)
+    }
+
+    /// Adds the stable hash of provider-visible prompt text used for the run.
+    pub fn with_prompt_hash(mut self, prompt_hash: &str) -> Result<Self, EvalError> {
+        validate_hash("prompt_hash", prompt_hash)?;
+        self.prompt_hash = Some(prompt_hash.to_owned());
+        Ok(self)
+    }
+
+    /// Adds the stable coding-profile hash used for the run.
+    pub fn with_profile_hash(mut self, profile_hash: &str) -> Result<Self, EvalError> {
+        validate_hash("profile_hash", profile_hash)?;
+        self.profile_hash = Some(profile_hash.to_owned());
+        Ok(self)
+    }
+
+    /// Adds the stable tool-schema hash used for the run.
+    pub fn with_tool_schema_hash(mut self, tool_schema_hash: &str) -> Result<Self, EvalError> {
+        validate_hash("tool_schema_hash", tool_schema_hash)?;
+        self.tool_schema_hash = Some(tool_schema_hash.to_owned());
+        Ok(self)
+    }
+
+    /// Returns the run schema version.
+    #[must_use]
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Returns the stable run identifier.
+    #[must_use]
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// Returns the task identifier.
+    #[must_use]
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
+
+    /// Returns the task version.
+    #[must_use]
+    pub fn task_version(&self) -> &str {
+        &self.task_version
+    }
+
+    /// Returns the evaluation runner version.
+    #[must_use]
+    pub fn runner_version(&self) -> &str {
+        &self.runner_version
+    }
+
+    /// Returns the source revision, when recorded.
+    #[must_use]
+    pub fn source_commit(&self) -> Option<&str> {
+        self.source_commit.as_deref()
+    }
+
+    /// Returns the provider label, when recorded.
+    #[must_use]
+    pub fn provider(&self) -> Option<&str> {
+        self.provider.as_deref()
+    }
+
+    /// Returns the model label, when recorded.
+    #[must_use]
+    pub fn model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
+    /// Returns the prompt hash, when recorded.
+    #[must_use]
+    pub fn prompt_hash(&self) -> Option<&str> {
+        self.prompt_hash.as_deref()
+    }
+
+    /// Returns the coding-profile hash, when recorded.
+    #[must_use]
+    pub fn profile_hash(&self) -> Option<&str> {
+        self.profile_hash.as_deref()
+    }
+
+    /// Returns the tool-schema hash, when recorded.
+    #[must_use]
+    pub fn tool_schema_hash(&self) -> Option<&str> {
+        self.tool_schema_hash.as_deref()
+    }
+
+    /// Returns the start timestamp in milliseconds since the Unix epoch.
+    #[must_use]
+    pub fn started_at_ms(&self) -> u64 {
+        self.started_at_ms
+    }
+
+    fn validate(&self) -> Result<(), EvalError> {
+        if self.schema_version != EVALUATION_RUN_SCHEMA_VERSION {
+            return Err(EvalError::UnsupportedVersion {
+                kind: "evaluation run",
+                found: self.schema_version,
+                supported: EVALUATION_RUN_SCHEMA_VERSION,
+            });
+        }
+        validate_identifier("run_id", &self.run_id, 128)?;
+        validate_identifier("task_id", &self.task_id, 128)?;
+        validate_identifier("task_version", &self.task_version, 128)?;
+        if let Some(source_commit) = self.source_commit.as_deref() {
+            validate_identifier("source_commit", source_commit, 256)?;
+        }
+        if let Some(provider) = self.provider.as_deref() {
+            validate_identifier("provider", provider, 128)?;
+        }
+        validate_identifier("runner_version", &self.runner_version, 128)?;
+        if let Some(model) = self.model.as_deref() {
+            validate_identifier("model", model, 256)?;
+        }
+        if let Some(prompt_hash) = self.prompt_hash.as_deref() {
+            validate_hash("prompt_hash", prompt_hash)?;
+        }
+        if let Some(profile_hash) = self.profile_hash.as_deref() {
+            validate_hash("profile_hash", profile_hash)?;
+        }
+        if let Some(tool_schema_hash) = self.tool_schema_hash.as_deref() {
+            validate_hash("tool_schema_hash", tool_schema_hash)?;
+        }
+        Ok(())
+    }
+}
+
+/// Result of one verification command, without its potentially sensitive output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, try_from = "TestResultWire")]
+pub struct TestResult {
+    #[schemars(
+        length(min = 1, max = 256),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    name: String,
+    passed: bool,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default, schema_with = "optional_nonnegative_u64_schema")]
+    duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct TestResultWire {
+    #[schemars(
+        length(min = 1, max = 256),
+        regex(pattern = NON_BLANK_TEXT_PATTERN)
+    )]
+    name: String,
+    passed: bool,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default, schema_with = "optional_nonnegative_u64_schema")]
+    duration_ms: Option<u64>,
+}
+
+impl TryFrom<TestResultWire> for TestResult {
+    type Error = EvalError;
+
+    fn try_from(wire: TestResultWire) -> Result<Self, Self::Error> {
+        Self::new(&wire.name, wire.passed, wire.duration_ms)
+    }
+}
+
+impl TestResult {
+    /// Creates a normalized test result.
+    pub fn new(name: &str, passed: bool, duration_ms: Option<u64>) -> Result<Self, EvalError> {
+        validate_text("test.name", name, 256)?;
+        Ok(Self {
+            name: name.to_owned(),
+            passed,
+            duration_ms,
+        })
+    }
+
+    /// Returns the test name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns whether the test passed.
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.passed
+    }
+
+    /// Returns the optional test duration.
+    #[must_use]
+    pub fn duration_ms(&self) -> Option<u64> {
+        self.duration_ms
+    }
+}
+
+/// Count of actions denied by a named policy boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, try_from = "DenialRecordWire")]
+pub struct DenialRecord {
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    code: String,
+    #[schemars(schema_with = "positive_u32_schema")]
+    count: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct DenialRecordWire {
+    #[schemars(length(min = 1, max = 128), regex(pattern = IDENTIFIER_PATTERN))]
+    code: String,
+    #[serde(deserialize_with = "deserialize_u32")]
+    #[schemars(schema_with = "positive_u32_schema")]
+    count: u32,
+}
+
+impl TryFrom<DenialRecordWire> for DenialRecord {
+    type Error = EvalError;
+
+    fn try_from(wire: DenialRecordWire) -> Result<Self, Self::Error> {
+        Self::new(&wire.code, wire.count)
+    }
+}
+
+impl DenialRecord {
+    /// Creates a non-empty denial count.
+    pub fn new(code: &str, count: u32) -> Result<Self, EvalError> {
+        validate_identifier("denial.code", code, 128)?;
+        if count == 0 {
+            return Err(invalid_field("denial.count", "must be greater than zero"));
+        }
+        Ok(Self {
+            code: code.to_owned(),
+            count,
+        })
+    }
+
+    /// Returns the stable denial code.
+    #[must_use]
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    /// Returns the number of occurrences.
+    #[must_use]
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+}
+
+/// A reference to an artifact produced by an evaluation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, try_from = "ArtifactRecordWire")]
+pub struct ArtifactRecord {
+    #[schemars(schema_with = "relative_path_schema")]
+    path: String,
+    kind: ArtifactKind,
+    #[schemars(schema_with = "optional_sha256_schema")]
+    sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ArtifactRecordWire {
+    #[schemars(schema_with = "relative_path_schema")]
+    path: String,
+    kind: ArtifactKind,
+    #[serde(default)]
+    #[schemars(default, schema_with = "optional_sha256_schema")]
+    sha256: Option<String>,
+}
+
+impl TryFrom<ArtifactRecordWire> for ArtifactRecord {
+    type Error = EvalError;
+
+    fn try_from(wire: ArtifactRecordWire) -> Result<Self, Self::Error> {
+        Self::new(&wire.path, wire.kind, wire.sha256.as_deref())
+    }
+}
+
+impl ArtifactRecord {
+    /// Creates a relative artifact reference without copying its contents.
+    pub fn new(path: &str, kind: ArtifactKind, sha256: Option<&str>) -> Result<Self, EvalError> {
+        validate_relative_path("artifact.path", path)?;
+        if let Some(sha256) = sha256 {
+            validate_hash("artifact.sha256", sha256)?;
+        }
+        Ok(Self {
+            path: path.to_owned(),
+            kind,
+            sha256: sha256.map(str::to_owned),
+        })
+    }
+
+    /// Returns the relative artifact path.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the provider-neutral artifact kind.
+    #[must_use]
+    pub fn kind(&self) -> ArtifactKind {
+        self.kind
+    }
+
+    /// Returns the optional artifact digest.
+    #[must_use]
+    pub fn sha256(&self) -> Option<&str> {
+        self.sha256.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct EvaluationRecordWire {
+    #[serde(deserialize_with = "deserialize_u32")]
+    #[schemars(schema_with = "version_schema")]
+    schema_version: u32,
+    run: EvaluationRun,
+    status: EvaluationStatus,
+    #[serde(default)]
+    #[schemars(default)]
+    failure_kind: Option<FailureKind>,
+    #[serde(deserialize_with = "deserialize_u32")]
+    turns: u32,
+    #[serde(deserialize_with = "deserialize_u32")]
+    tool_calls: u32,
+    #[serde(deserialize_with = "deserialize_u32")]
+    retries: u32,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default)]
+    latency_ms: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default)]
+    cost_micros: Option<u64>,
+    #[schemars(length(max = MAX_RECORD_ITEMS))]
+    tests: Vec<TestResult>,
+    #[schemars(length(max = MAX_RECORD_ITEMS))]
+    denials: Vec<DenialRecord>,
+    #[schemars(length(max = MAX_RECORD_ITEMS))]
+    artifacts: Vec<ArtifactRecord>,
+}
+
+/// One deterministic JSONL result emitted by an evaluation harness.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+#[schemars(schema_with = "evaluation_record_schema")]
+#[serde(try_from = "EvaluationRecordWire")]
+pub struct EvaluationRecord {
+    #[schemars(schema_with = "version_schema")]
+    schema_version: u32,
+    run: EvaluationRun,
+    status: EvaluationStatus,
+    #[serde(default)]
+    #[schemars(default)]
+    failure_kind: Option<FailureKind>,
+    #[serde(deserialize_with = "deserialize_u32")]
+    turns: u32,
+    #[serde(deserialize_with = "deserialize_u32")]
+    tool_calls: u32,
+    #[serde(deserialize_with = "deserialize_u32")]
+    retries: u32,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default)]
+    latency_ms: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_u64")]
+    #[schemars(default)]
+    cost_micros: Option<u64>,
+    #[schemars(length(max = MAX_RECORD_ITEMS))]
+    tests: Vec<TestResult>,
+    #[schemars(length(max = MAX_RECORD_ITEMS))]
+    denials: Vec<DenialRecord>,
+    #[schemars(length(max = MAX_RECORD_ITEMS))]
+    artifacts: Vec<ArtifactRecord>,
+}
+
+impl TryFrom<EvaluationRecordWire> for EvaluationRecord {
+    type Error = EvalError;
+
+    fn try_from(wire: EvaluationRecordWire) -> Result<Self, Self::Error> {
+        let record = Self {
+            schema_version: wire.schema_version,
+            run: wire.run,
+            status: wire.status,
+            failure_kind: wire.failure_kind,
+            turns: wire.turns,
+            tool_calls: wire.tool_calls,
+            retries: wire.retries,
+            latency_ms: wire.latency_ms,
+            cost_micros: wire.cost_micros,
+            tests: wire.tests,
+            denials: wire.denials,
+            artifacts: wire.artifacts,
+        };
+        record.validate_inner()?;
+        Ok(record)
+    }
+}
+
+impl Serialize for EvaluationRecord {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate_inner().map_err(S::Error::custom)?;
+        let wire = EvaluationRecordWire {
+            schema_version: self.schema_version,
+            run: self.run.clone(),
+            status: self.status,
+            failure_kind: self.failure_kind,
+            turns: self.turns,
+            tool_calls: self.tool_calls,
+            retries: self.retries,
+            latency_ms: self.latency_ms,
+            cost_micros: self.cost_micros,
+            tests: self.tests.clone(),
+            denials: self.denials.clone(),
+            artifacts: self.artifacts.clone(),
+        };
+        wire.serialize(serializer)
+    }
+}
+
+impl EvaluationRecord {
+    /// Creates a provisional result that can be completed with the builder methods.
+    #[must_use]
+    pub fn new(run: EvaluationRun, status: EvaluationStatus) -> Self {
+        Self {
+            schema_version: EVALUATION_RECORD_SCHEMA_VERSION,
+            run,
+            status,
+            failure_kind: None,
+            turns: 0,
+            tool_calls: 0,
+            retries: 0,
+            latency_ms: None,
+            cost_micros: None,
+            tests: Vec::new(),
+            denials: Vec::new(),
+            artifacts: Vec::new(),
+        }
+    }
+
+    /// Creates and validates a complete result in one operation.
+    pub fn try_new(
+        run: EvaluationRun,
+        status: EvaluationStatus,
+        failure_kind: Option<FailureKind>,
+    ) -> Result<Self, EvalError> {
+        let mut record = Self::new(run, status);
+        record.failure_kind = failure_kind;
+        record.validate_inner()?;
+        Ok(record)
+    }
+
+    /// Validates and returns a completed result after builder methods are applied.
+    pub fn finish(self) -> Result<Self, EvalError> {
+        self.validate_inner()?;
+        Ok(self)
+    }
+
+    /// Adds a normalized failure category to a non-passing result.
+    pub fn with_failure_kind(mut self, failure_kind: FailureKind) -> Self {
+        self.failure_kind = Some(failure_kind);
+        self
+    }
+
+    /// Records aggregate execution counters and optional timing/cost metrics.
+    pub fn with_metrics(
+        mut self,
+        turns: u32,
+        tool_calls: u32,
+        retries: u32,
+        latency_ms: Option<u64>,
+        cost_micros: Option<u64>,
+    ) -> Self {
+        self.turns = turns;
+        self.tool_calls = tool_calls;
+        self.retries = retries;
+        self.latency_ms = latency_ms;
+        self.cost_micros = cost_micros;
+        self
+    }
+
+    /// Appends a verification result while preserving declaration order.
+    pub fn with_test(mut self, test: TestResult) -> Self {
+        self.tests.push(test);
+        self
+    }
+
+    /// Appends a policy-denial summary while preserving event order.
+    pub fn with_denial(mut self, denial: DenialRecord) -> Self {
+        self.denials.push(denial);
+        self
+    }
+
+    /// Appends an artifact reference without copying artifact contents.
+    pub fn with_artifact(mut self, artifact: ArtifactRecord) -> Self {
+        self.artifacts.push(artifact);
+        self
+    }
+
+    /// Returns the record schema version.
+    #[must_use]
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Returns the run metadata.
+    #[must_use]
+    pub fn run(&self) -> &EvaluationRun {
+        &self.run
+    }
+
+    /// Returns the terminal evaluation status.
+    #[must_use]
+    pub fn status(&self) -> EvaluationStatus {
+        self.status
+    }
+
+    /// Returns the normalized failure category, when present.
+    #[must_use]
+    pub fn failure_kind(&self) -> Option<FailureKind> {
+        self.failure_kind
+    }
+
+    /// Returns the number of model turns.
+    #[must_use]
+    pub fn turns(&self) -> u32 {
+        self.turns
+    }
+
+    /// Returns the number of tool calls.
+    #[must_use]
+    pub fn tool_calls(&self) -> u32 {
+        self.tool_calls
+    }
+
+    /// Returns the number of retries.
+    #[must_use]
+    pub fn retries(&self) -> u32 {
+        self.retries
+    }
+
+    /// Returns the optional elapsed time in milliseconds.
+    #[must_use]
+    pub fn latency_ms(&self) -> Option<u64> {
+        self.latency_ms
+    }
+
+    /// Returns the optional cost in provider-neutral micro-units.
+    #[must_use]
+    pub fn cost_micros(&self) -> Option<u64> {
+        self.cost_micros
+    }
+
+    /// Returns verification results in declaration order.
+    #[must_use]
+    pub fn tests(&self) -> &[TestResult] {
+        &self.tests
+    }
+
+    /// Returns policy-denial summaries in event order.
+    #[must_use]
+    pub fn denials(&self) -> &[DenialRecord] {
+        &self.denials
+    }
+
+    /// Returns artifact references in declaration order.
+    #[must_use]
+    pub fn artifacts(&self) -> &[ArtifactRecord] {
+        &self.artifacts
+    }
+
+    /// Validates the complete record, including nested values and status invariants.
+    pub fn validate(&self) -> Result<(), EvalError> {
+        self.validate_inner()
+    }
+
+    /// Serializes the record as exactly one newline-terminated JSONL line.
+    pub fn to_jsonl(&self) -> Result<String, EvalError> {
+        self.validate()?;
+        // Escape Unicode line/paragraph separators so splitlines-style consumers see one physical line.
+        let json = serde_json::to_string(self)?
+            .replace('\u{2028}', "\\u2028")
+            .replace('\u{2029}', "\\u2029");
+        if json.len() + 1 > MAX_JSONL_BYTES {
+            return Err(EvalError::InvalidRecordFraming(format!(
+                "record exceeds the {} byte limit",
+                MAX_JSONL_BYTES
+            )));
+        }
+        Ok(format!("{json}\n"))
+    }
+
+    /// Parses and validates exactly one JSONL record line.
+    pub fn from_jsonl(line: &str) -> Result<Self, EvalError> {
+        if line.len() > MAX_JSONL_BYTES {
+            return Err(EvalError::InvalidRecordFraming(format!(
+                "record exceeds the {} byte limit",
+                MAX_JSONL_BYTES
+            )));
+        }
+        let payload = match line.strip_suffix('\n') {
+            Some(payload) => payload.strip_suffix('\r').unwrap_or(payload),
+            None => line,
+        };
+        if payload.is_empty() || payload.contains(['\r', '\n']) {
+            return Err(EvalError::InvalidRecordFraming(
+                "expected one JSON object with at most one line terminator".to_owned(),
+            ));
+        }
+        if payload.trim_start() != payload || payload.trim_end() != payload {
+            return Err(EvalError::InvalidRecordFraming(
+                "leading and trailing whitespace are not allowed".to_owned(),
+            ));
+        }
+        let record: Self = serde_json::from_str(payload)?;
+        record.validate()?;
+        Ok(record)
+    }
+
+    fn validate_inner(&self) -> Result<(), EvalError> {
+        if self.schema_version != EVALUATION_RECORD_SCHEMA_VERSION {
+            return Err(EvalError::UnsupportedVersion {
+                kind: "evaluation record",
+                found: self.schema_version,
+                supported: EVALUATION_RECORD_SCHEMA_VERSION,
+            });
+        }
+        self.run.validate()?;
+        for (name, length) in [
+            ("tests", self.tests.len()),
+            ("denials", self.denials.len()),
+            ("artifacts", self.artifacts.len()),
+        ] {
+            if length > MAX_RECORD_ITEMS {
+                return Err(invalid_field(
+                    name,
+                    format!("must contain at most {MAX_RECORD_ITEMS} items"),
+                ));
+            }
+        }
+        for (index, test) in self.tests.iter().enumerate() {
+            validate_text(&format!("tests[{index}].name"), &test.name, 256)?;
+        }
+        for (index, denial) in self.denials.iter().enumerate() {
+            validate_identifier("denial.code", &denial.code, 128).map_err(|error| match error {
+                EvalError::InvalidField { reason, .. } => {
+                    invalid_field(format!("denials[{index}].code"), reason)
+                }
+                other => other,
+            })?;
+            if denial.count == 0 {
+                return Err(invalid_field(
+                    format!("denials[{index}].count"),
+                    "must be greater than zero",
+                ));
+            }
+        }
+        for (index, artifact) in self.artifacts.iter().enumerate() {
+            validate_relative_path("artifact.path", &artifact.path).map_err(
+                |error| match error {
+                    EvalError::InvalidField { reason, .. } => {
+                        invalid_field(format!("artifacts[{index}].path"), reason)
+                    }
+                    other => other,
+                },
+            )?;
+            if let Some(sha256) = artifact.sha256.as_deref() {
+                validate_hash(&format!("artifacts[{index}].sha256"), sha256)?;
+            }
+        }
+        match self.status {
+            EvaluationStatus::Passed => {
+                if self.failure_kind.is_some() {
+                    return Err(invalid_field(
+                        "failure_kind",
+                        "must be absent for a passed evaluation",
+                    ));
+                }
+                if self.tests.iter().any(|test| !test.passed) {
+                    return Err(invalid_field(
+                        "tests",
+                        "must not contain a failed test for a passed evaluation",
+                    ));
+                }
+            }
+            EvaluationStatus::Failed
+            | EvaluationStatus::Blocked
+            | EvaluationStatus::Cancelled
+            | EvaluationStatus::Error => {
+                let Some(failure_kind) = self.failure_kind else {
+                    return Err(invalid_field(
+                        "failure_kind",
+                        "is required for a non-passed evaluation",
+                    ));
+                };
+                let matches_status = match self.status {
+                    EvaluationStatus::Failed => true,
+                    EvaluationStatus::Blocked => failure_kind == FailureKind::Permission,
+                    EvaluationStatus::Cancelled => failure_kind == FailureKind::Cancelled,
+                    EvaluationStatus::Error => {
+                        matches!(failure_kind, FailureKind::Runtime | FailureKind::Timeout)
+                    }
+                    EvaluationStatus::Passed => false,
+                };
+                if !matches_status {
+                    return Err(invalid_field(
+                        "failure_kind",
+                        "does not match the evaluation status",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_hash(field: &str, value: &str) -> Result<(), EvalError> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(invalid_field(
+            field,
+            "must be a 64-character hexadecimal digest",
+        ));
+    }
+    Ok(())
+}

--- a/crates/merry-eval/src/record_schema.rs
+++ b/crates/merry-eval/src/record_schema.rs
@@ -1,0 +1,120 @@
+use super::{
+    ArtifactRecord, DenialRecord, EVALUATION_RECORD_SCHEMA_VERSION, EvaluationRun,
+    EvaluationStatus, FailureKind, MAX_RECORD_ITEMS, TestResult,
+};
+use schemars::{Schema, SchemaGenerator, json_schema};
+
+pub(super) fn evaluation_record_schema(generator: &mut SchemaGenerator) -> Schema {
+    let run_schema = generator.subschema_for::<EvaluationRun>();
+    let status_schema = generator.subschema_for::<EvaluationStatus>();
+    let failure_kind_schema = generator.subschema_for::<Option<FailureKind>>();
+    let counter_schema = json_schema!({
+        "type": "number",
+        "minimum": 0,
+        "maximum": u32::MAX,
+        "multipleOf": 1,
+    });
+    let optional_metric_schema = json_schema!({
+        "type": ["number", "null"],
+        "minimum": 0,
+        "maximum": u64::MAX,
+        "multipleOf": 1,
+    });
+    let tests_schema = json_schema!({
+        "type": "array",
+        "maxItems": MAX_RECORD_ITEMS,
+        "items": generator.subschema_for::<TestResult>(),
+    });
+    let denials_schema = json_schema!({
+        "type": "array",
+        "maxItems": MAX_RECORD_ITEMS,
+        "items": generator.subschema_for::<DenialRecord>(),
+    });
+    let artifacts_schema = json_schema!({
+        "type": "array",
+        "maxItems": MAX_RECORD_ITEMS,
+        "items": generator.subschema_for::<ArtifactRecord>(),
+    });
+    let base_schema = json_schema!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+            "schema_version",
+            "run",
+            "status",
+            "turns",
+            "tool_calls",
+            "retries",
+            "tests",
+            "denials",
+            "artifacts"
+        ],
+        "properties": {
+            "schema_version": {
+                "type": "number",
+                "const": EVALUATION_RECORD_SCHEMA_VERSION,
+                "multipleOf": 1,
+            },
+            "run": run_schema,
+            "status": status_schema,
+            "failure_kind": failure_kind_schema,
+            "turns": counter_schema,
+            "tool_calls": counter_schema,
+            "retries": counter_schema,
+            "latency_ms": optional_metric_schema,
+            "cost_micros": optional_metric_schema,
+            "tests": tests_schema,
+            "denials": denials_schema,
+            "artifacts": artifacts_schema,
+        }
+    });
+    json_schema!({
+        "allOf": [
+            base_schema,
+            {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "status": {"const": "passed"},
+                            "failure_kind": {"type": "null"},
+                            "tests": {
+                                "items": {
+                                    "required": ["passed"],
+                                    "properties": {"passed": {"const": true}}
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "required": ["failure_kind"],
+                        "properties": {
+                            "status": {"const": "failed"},
+                            "failure_kind": {"type": "string"}
+                        }
+                    },
+                    {
+                        "required": ["failure_kind"],
+                        "properties": {
+                            "status": {"const": "blocked"},
+                            "failure_kind": {"const": "permission"}
+                        }
+                    },
+                    {
+                        "required": ["failure_kind"],
+                        "properties": {
+                            "status": {"const": "cancelled"},
+                            "failure_kind": {"const": "cancelled"}
+                        }
+                    },
+                    {
+                        "required": ["failure_kind"],
+                        "properties": {
+                            "status": {"const": "error"},
+                            "failure_kind": {"enum": ["runtime", "timeout"]}
+                        }
+                    }
+                ]
+            }
+        ]
+    })
+}

--- a/crates/merry-eval/tests/fixtures/adapter-task.toml
+++ b/crates/merry-eval/tests/fixtures/adapter-task.toml
@@ -1,0 +1,37 @@
+schema_version = 1
+task_id = "adapter-fixture"
+task_version = "v1"
+description = "Fix the adapter fixture."
+repository = { path = "fixtures/adapter" }
+write_scope = ["src/**"]
+timeout_seconds = 120
+
+[[setup]]
+program = "cargo"
+args = ["fmt", "--check"]
+timeout_seconds = 30
+
+[[tests]]
+program = "cargo"
+args = ["test"]
+timeout_seconds = 60
+
+[resource_limits]
+max_output_bytes = 65536
+max_file_changes = 8
+max_processes = 1
+
+[[success_criteria]]
+kind = "file_exists"
+path = "src/lib.rs"
+
+[[success_criteria]]
+kind = "command_passes"
+program = "cargo"
+args = ["test"]
+working_dir = "fixtures/adapter"
+timeout_seconds = 90
+
+[[expected_artifacts]]
+path = "target/evaluation.json"
+kind = "json"

--- a/crates/merry-eval/tests/task_spec_adapter.rs
+++ b/crates/merry-eval/tests/task_spec_adapter.rs
@@ -1,0 +1,30 @@
+use merry_eval::{ArtifactKind, SuccessCriterion, TaskSpec};
+
+const ADAPTER_TASK_SPEC: &str = include_str!("fixtures/adapter-task.toml");
+
+#[test]
+fn local_suite_consumes_the_shared_task_spec_fixture() {
+    let task = TaskSpec::from_toml(ADAPTER_TASK_SPEC).expect("shared fixture parses");
+
+    assert_eq!(task.task_id(), "adapter-fixture");
+    assert_eq!(task.repository().path(), Some("fixtures/adapter"));
+    assert_eq!(task.write_scope(), ["src/**"]);
+    assert_eq!(task.setup().len(), 1);
+    assert_eq!(task.tests().len(), 1);
+    assert_eq!(task.timeout_seconds(), 120);
+    assert_eq!(task.success_criteria().len(), 2);
+    assert!(matches!(
+        &task.success_criteria()[0],
+        SuccessCriterion::FileExists { path } if path == "src/lib.rs"
+    ));
+    assert!(matches!(
+        &task.success_criteria()[1],
+        SuccessCriterion::CommandPasses {
+            program,
+            working_dir: Some(working_dir),
+            timeout_seconds: Some(90),
+            ..
+        } if program == "cargo" && working_dir == "fixtures/adapter"
+    ));
+    assert_eq!(task.expected_artifacts()[0].kind(), ArtifactKind::Json);
+}


### PR DESCRIPTION
## Summary

- Add the provider-neutral merry-eval TaskSpec and evaluation record protocol.
- Add strict manifest/schema/runtime validation, deterministic JSONL records, and exact numeric handling.
- Prove reuse of one serialized TaskSpec through a Rust local-suite consumer and the Python Harbor adapter.
- Align the T1 roadmap label with issue #8.

## Scope

The Rust protocol remains an upper-layer contract. Runtime state, provider wire types, secrets, and Harbor models do not enter the protocol crate. The optional MERRY_TASK_SPEC_PATH setting preserves the existing Harbor instruction path when unset.

T2 Offline Harness and later evaluator consumers can build on this public contract; they are not duplicated here.

## Validation

- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --workspace --all-targets
- cargo test --all
- cargo metadata --no-deps --format-version 1
- cargo package -p merry-eval --allow-dirty
- benchmark ruff check .
- benchmark ty check
- benchmark pytest: 16 passed
- git diff --check

## Notes

- serde_json arbitrary_precision is intentionally enabled at the workspace dependency-unification boundary for exact protocol numbers.
- manifest.rs is temporarily above the 1000-line guideline; follow-up extraction should split CommandSpec and SuccessCriterion ownership.
- cargo package reports missing crates.io metadata; merry-eval is currently an internal workspace crate.
- No live Harbor cloud evaluation was run because it requires external benchmark credentials; the adapter boundary is covered by deterministic Harbor environment tests.

Closes: #8