### PR TITLE
refactor(coding): unify runtime composition entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
 name = "merry-coding"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "libc",
  "merry-core",
  "merry-llm",
@@ -1519,6 +1520,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.19",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ issues. This file keeps only the major delivery sequence and its dependencies.
 - [x] [T2: Deterministic Offline Harness (closed; covered by Rust unit/integration tests)](https://github.com/locez/merry/issues/11)
 - [x] [T3: Establish the unique CodingAgentProfile (implemented; shared facade/CLI profile, stable-prefix and admission evidence)](https://github.com/locez/merry/issues/12)
 - [x] [T4: Internal Coding Eval Suite (closed; no standalone runner)](https://github.com/locez/merry/issues/13)
-- [ ] [T5: Unify CLI, Debug, and Rust Runtime Builder](https://github.com/locez/merry/issues/14)
+- [x] [T5: Unify CLI, Debug, and Rust Runtime Builder](https://github.com/locez/merry/issues/14) (shared builder, validated permission policy, parent-child inheritance tests, full Rust verification; read-only capability-closure follow-up deferred by approval)
 - [ ] [T6: Establish production reliability, security, and observability harness](https://github.com/locez/merry/issues/15)
 - [ ] [T7: Release a stable Rust SDK](https://github.com/locez/merry/issues/16)
 - [ ] [T8: Align Python and Rust SDK capabilities](https://github.com/locez/merry/issues/17)

--- a/crates/merry-cli/src/cmd.rs
+++ b/crates/merry-cli/src/cmd.rs
@@ -6,12 +6,12 @@ use crate::provider_config::{
     openai_provider_config_bundle,
 };
 use crate::runtime_config::automatic_compaction_config;
-use merry::profiles::{coding_agent, load_root_project_rules};
-use merry_core::{ErrorInfo, PendingToolCall, ToolInputSchema, ToolName, ToolSpec};
+use merry::profiles::{CodingRuntime, CodingRuntimeBuilder, CodingRuntimeInput};
+use merry_core::{ErrorInfo, PendingToolCall, SessionId, ToolInputSchema, ToolName, ToolSpec};
 use merry_llm::{ModelName, ModelProvider, ModelRetryPolicy};
 use merry_runtime::{
     AgentLoopConfig, AgentLoopStatus, AutomaticCompactionConfig, RegisteredTool, Runtime,
-    SkillCatalog, StepContext, StepInput, ToolExecutionContext, ToolExecutionOutcome, ToolExecutor,
+    StepContext, StepInput, ToolExecutionContext, ToolExecutionOutcome, ToolExecutor,
     ToolExecutorFuture,
 };
 use schemars::JsonSchema;
@@ -240,39 +240,23 @@ Runtime environment:
 }
 
 pub(crate) fn build_runtime(input: RuntimeInput<'_>) -> Result<Runtime, CliError> {
-    let session_id = merry_core::SessionId::new(input.session_id).map_err(unexpected)?;
-    let mut builder = Runtime::builder(session_id)
-        .automatic_compaction(input.automatic_compaction)
-        .model_provider(input.provider, input.model);
+    let session_id = SessionId::new(input.session_id).map_err(unexpected)?;
+    let mut coding_input =
+        CodingRuntimeInput::read_only(session_id, input.root, input.provider, input.model)
+            .with_automatic_compaction(input.automatic_compaction)
+            .with_allow_hidden_workspace_paths(input.allow_hidden_workspace_paths)
+            .with_skill_roots(input.skill_roots)
+            .with_extra_tools([cmd_check_command_tool(input.environment)?]);
     if let Some(role_provider) = input.context_compaction {
-        builder = builder.model_provider_for_role(
-            role_provider.role,
-            role_provider.provider,
-            role_provider.model,
-        );
-    }
-    let project_rules = load_root_project_rules(input.root).map_err(unexpected)?;
-    let skill_catalog = if input.skill_roots.is_empty() {
-        None
-    } else {
-        Some(SkillCatalog::load_from_roots(input.skill_roots.clone()).map_err(unexpected)?)
-    };
-    let mut profile = coding_agent(input.root)
-        .readonly_resource_roots(input.skill_roots.clone())
-        .allow_hidden(input.allow_hidden_workspace_paths)
-        .register_tool(cmd_check_command_tool(input.environment)?);
-    if let Some(project_rules) = project_rules {
-        profile = profile.project_rules(project_rules);
-    }
-    if let Some(skill_catalog) = skill_catalog {
-        profile = profile.skill_catalog(skill_catalog);
+        coding_input = coding_input.with_model_role(role_provider);
     }
     if let Some(policy) = input.retry_policy {
-        profile = profile.retry_policy(policy);
+        coding_input = coding_input.with_retry_policy(policy);
     }
-    let profile = profile.build().map_err(unexpected)?;
-    let builder = profile.apply_to(builder).map_err(unexpected)?;
-    builder.build().map_err(unexpected)
+    CodingRuntimeBuilder::for_command_generation(coding_input)
+        .build()
+        .map(CodingRuntime::into_runtime)
+        .map_err(|error| unexpected(error.to_string()))
 }
 
 pub(crate) async fn generate_command_plan(

--- a/crates/merry-cli/src/coding/error.rs
+++ b/crates/merry-cli/src/coding/error.rs
@@ -1,17 +1,10 @@
-use merry::profiles::{CodingAgentProfileBuildError, ProjectRulesLoadError};
+use merry::profiles::CodingRuntimeBuildError;
 use merry_core::CoreError;
 use merry_process::ProcessBackendError;
-use merry_runtime::{AgentLoopConfigError, RuntimeError, SkillError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum CodingRuntimeError {
-    #[error("invalid coding agent loop config: {source}")]
-    AgentLoopConfig {
-        #[from]
-        source: AgentLoopConfigError,
-    },
-
     #[error("core protocol error while building coding runtime: {source}")]
     Core {
         #[from]
@@ -24,29 +17,11 @@ pub(crate) enum CodingRuntimeError {
         source: ProcessBackendError,
     },
 
-    #[error("failed to load project rules: {source}")]
-    ProjectRules {
+    #[error("invalid coding runtime composition: {source}")]
+    CodingRuntime {
         #[from]
-        source: ProjectRulesLoadError,
+        source: CodingRuntimeBuildError,
     },
-
-    #[error("invalid shared coding-agent profile: {source}")]
-    CodingAgentProfile {
-        #[from]
-        source: CodingAgentProfileBuildError,
-    },
-
-    #[error("failed to load skill catalog: {source}")]
-    SkillCatalog {
-        #[from]
-        source: SkillError,
-    },
-
-    #[error("failed to apply runtime profile to builder: {source}")]
-    RuntimeProfileApply { source: RuntimeError },
-
-    #[error("failed to build runtime: {source}")]
-    RuntimeBuild { source: RuntimeError },
 }
 
 impl From<CodingRuntimeError> for crate::cli_error::CliError {

--- a/crates/merry-cli/src/coding/mod.rs
+++ b/crates/merry-cli/src/coding/mod.rs
@@ -1,10 +1,13 @@
 mod error;
 mod process;
-mod roles;
 mod runtime;
 mod sandbox;
 
 pub(crate) use error::CodingRuntimeError;
+pub(crate) use merry::profiles::{
+    CodingModelRoleConfig as RuntimeRoleProviderConfig, CodingPermissionPolicy,
+    CodingSubagentsConfig,
+};
 #[cfg(test)]
 pub(crate) use process::ActionProcessBackend;
 #[cfg(test)]
@@ -13,14 +16,13 @@ pub(crate) use process::{
     ActionProcessBackendOptions, ProcessExecutionMode, action_process_runner,
     action_process_runner_for_mode,
 };
-pub(crate) use roles::RuntimeRoleProviderConfig;
+#[cfg(test)]
+pub(crate) use runtime::build_headless_coding;
 #[cfg(test)]
 pub(crate) use runtime::{CodingRuntimeOptions, build_coding_runtime, resume_headless_coding};
 pub(crate) use runtime::{
-    CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
-    build_headless_coding_with_permission_review_mode,
-    build_headless_coding_with_permission_source, coding_agent_loop_config,
-    resume_headless_coding_with_permission_source,
+    HeadlessCodingRuntimeInput, build_headless_coding_composition,
+    build_headless_coding_with_policy_composition, resume_headless_coding_composition_with_policy,
 };
 pub(crate) use sandbox::{coding_agent_process_admission, coding_agent_requires_sandbox_error};
 

--- a/crates/merry-cli/src/coding/roles.rs
+++ b/crates/merry-cli/src/coding/roles.rs
@@ -1,9 +1,0 @@
-use merry_llm::{ModelName, ModelProvider};
-use merry_runtime::RuntimeModelRole;
-use std::sync::Arc;
-
-pub(crate) struct RuntimeRoleProviderConfig {
-    pub(crate) role: RuntimeModelRole,
-    pub(crate) provider: Arc<dyn ModelProvider>,
-    pub(crate) model: ModelName,
-}

--- a/crates/merry-cli/src/coding/runtime.rs
+++ b/crates/merry-cli/src/coding/runtime.rs
@@ -1,26 +1,20 @@
 use super::CodingRuntimeError;
+use super::RuntimeRoleProviderConfig;
 use super::process::ActionProcessBackend;
-use super::roles::RuntimeRoleProviderConfig;
-use merry::coding_agent_loop_config as shared_coding_agent_loop_config;
 use merry::profiles::{
-    CodingAgentProfileBuilder, CodingChildRuntimeFactory, coding_agent, load_root_project_rules,
+    CodingPermissionPolicy, CodingRuntime as SharedCodingRuntime, CodingRuntimeBuilder,
+    CodingRuntimeInput,
 };
 use merry_llm::{ModelName, ModelProvider, ModelRetryPolicy};
-use merry_runtime::{
-    AutomaticCompactionConfig, ChildRuntimeFactory, FileSessionStore, PermissionAdmissionSource,
-    PermissionReviewMode, RegisteredTool, Runtime, RuntimeBuilder, SubagentConfig, SubagentManager,
-    subagent_registered_tools,
-};
+#[cfg(test)]
+use merry_runtime::Runtime;
+use merry_runtime::{AutomaticCompactionConfig, FileSessionStore, RegisteredTool};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-pub(crate) fn coding_agent_loop_config()
--> Result<merry_runtime::AgentLoopConfig, CodingRuntimeError> {
-    shared_coding_agent_loop_config().map_err(CodingRuntimeError::from)
-}
-
+#[cfg(test)]
 pub(crate) struct CodingRuntimeOptions {
     pub(crate) allow_hidden_workspace_paths: bool,
     pub(crate) approval_review: Option<RuntimeRoleProviderConfig>,
@@ -30,45 +24,8 @@ pub(crate) struct CodingRuntimeOptions {
     pub(crate) process_backend: ActionProcessBackend,
     pub(crate) extra_tools: Vec<RegisteredTool>,
     pub(crate) skill_roots: Vec<PathBuf>,
-    pub(crate) subagents: CodingSubagentsConfig,
+    pub(crate) subagents: super::CodingSubagentsConfig,
     pub(crate) workspace_tool_limits: Option<merry_tool_workspace::WorkspaceToolLimits>,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct CodingSubagentsConfig {
-    installed: bool,
-    enabled: bool,
-    limits: SubagentConfig,
-}
-
-impl CodingSubagentsConfig {
-    pub(crate) fn enabled(limits: SubagentConfig) -> Self {
-        Self {
-            installed: true,
-            enabled: true,
-            limits,
-        }
-    }
-
-    pub(crate) fn runtime_controlled(enabled: bool, limits: SubagentConfig) -> Self {
-        Self {
-            installed: true,
-            enabled,
-            limits,
-        }
-    }
-
-    pub(crate) fn is_installed(self) -> bool {
-        self.installed
-    }
-
-    pub(crate) fn is_enabled(self) -> bool {
-        self.enabled
-    }
-
-    pub(crate) fn limits(self) -> SubagentConfig {
-        self.limits
-    }
 }
 
 pub(crate) struct HeadlessCodingRuntimeInput<'a> {
@@ -84,91 +41,61 @@ pub(crate) struct HeadlessCodingRuntimeInput<'a> {
     pub(crate) context_compaction: Option<RuntimeRoleProviderConfig>,
     pub(crate) approval_review: Option<RuntimeRoleProviderConfig>,
     pub(crate) skill_roots: Vec<PathBuf>,
-    pub(crate) subagents: CodingSubagentsConfig,
+    pub(crate) subagents: super::CodingSubagentsConfig,
+    pub(crate) workspace_tool_limits: Option<merry_tool_workspace::WorkspaceToolLimits>,
 }
 
+#[cfg(test)]
 pub(crate) fn build_headless_coding(
     input: HeadlessCodingRuntimeInput<'_>,
 ) -> Result<Runtime, CodingRuntimeError> {
-    build_coding_runtime_from_headless_input(input, None, None)?
-        .build()
-        .map_err(|source| CodingRuntimeError::RuntimeBuild { source })
+    build_headless_coding_composition(input).map(SharedCodingRuntime::into_runtime)
 }
 
-pub(crate) fn build_headless_coding_with_permission_review_mode(
+pub(crate) fn build_headless_coding_composition(
     input: HeadlessCodingRuntimeInput<'_>,
-    mode: PermissionReviewMode,
-) -> Result<Runtime, CodingRuntimeError> {
-    build_coding_runtime_from_headless_input(input, None, Some(mode))?
-        .build()
-        .map_err(|source| CodingRuntimeError::RuntimeBuild { source })
+) -> Result<SharedCodingRuntime, CodingRuntimeError> {
+    build_headless_coding_with_policy_composition(input, CodingPermissionPolicy::default())
 }
 
-pub(crate) fn build_headless_coding_with_permission_source(
+pub(crate) fn build_headless_coding_with_policy_composition(
     input: HeadlessCodingRuntimeInput<'_>,
-    source: Arc<dyn PermissionAdmissionSource>,
-    mode: PermissionReviewMode,
-) -> Result<Runtime, CodingRuntimeError> {
-    build_coding_runtime_from_headless_input(input, Some((source, mode)), None)?
+    permission: CodingPermissionPolicy,
+) -> Result<SharedCodingRuntime, CodingRuntimeError> {
+    build_coding_runtime_from_headless_input(input, permission)?
         .build()
-        .map_err(|source| CodingRuntimeError::RuntimeBuild { source })
+        .map_err(CodingRuntimeError::from)
+}
+
+pub(crate) async fn resume_headless_coding_composition_with_policy(
+    input: HeadlessCodingRuntimeInput<'_>,
+    store: FileSessionStore,
+    permission: CodingPermissionPolicy,
+) -> Result<SharedCodingRuntime, CodingRuntimeError> {
+    build_coding_runtime_from_headless_input(input, permission)?
+        .resume_from_store_without_automatic_savepoints(store)
+        .await
+        .map_err(CodingRuntimeError::from)
 }
 
 #[allow(dead_code)]
+#[cfg(test)]
 pub(crate) async fn resume_headless_coding(
     input: HeadlessCodingRuntimeInput<'_>,
     store: FileSessionStore,
 ) -> Result<Runtime, CodingRuntimeError> {
-    build_coding_runtime_from_headless_input(input, None, None)?
-        .resume_from_store_without_automatic_savepoints(store)
+    resume_headless_coding_composition(input, store)
         .await
-        .map_err(|source| CodingRuntimeError::RuntimeBuild { source })
+        .map(SharedCodingRuntime::into_runtime)
 }
 
-pub(crate) async fn resume_headless_coding_with_permission_source(
+#[cfg(test)]
+async fn resume_headless_coding_composition(
     input: HeadlessCodingRuntimeInput<'_>,
     store: FileSessionStore,
-    source: Arc<dyn PermissionAdmissionSource>,
-    mode: PermissionReviewMode,
-) -> Result<Runtime, CodingRuntimeError> {
-    build_coding_runtime_from_headless_input(input, Some((source, mode)), None)?
-        .resume_from_store_without_automatic_savepoints(store)
+) -> Result<SharedCodingRuntime, CodingRuntimeError> {
+    resume_headless_coding_composition_with_policy(input, store, CodingPermissionPolicy::default())
         .await
-        .map_err(|source| CodingRuntimeError::RuntimeBuild { source })
-}
-
-fn build_coding_runtime_from_headless_input(
-    input: HeadlessCodingRuntimeInput<'_>,
-    permission_source: Option<(Arc<dyn PermissionAdmissionSource>, PermissionReviewMode)>,
-    permission_review_mode: Option<PermissionReviewMode>,
-) -> Result<RuntimeBuilder, CodingRuntimeError> {
-    let mut builder = configure_coding_runtime_builder(
-        input.session_id,
-        input.root,
-        input.provider,
-        input.model,
-        CodingRuntimeOptions {
-            allow_hidden_workspace_paths: input.allow_hidden_workspace_paths,
-            approval_review: input.approval_review,
-            automatic_compaction: input.automatic_compaction,
-            retry_policy: input.retry_policy,
-            context_compaction: input.context_compaction,
-            process_backend: input.process_backend,
-            extra_tools: input.extra_tools,
-            skill_roots: input.skill_roots,
-            subagents: input.subagents,
-            workspace_tool_limits: None,
-        },
-    )?;
-    if let Some(mode) = permission_review_mode {
-        builder = builder.permission_review_mode(mode);
-    }
-    if let Some((source, mode)) = permission_source {
-        builder = builder
-            .permission_review_mode(mode)
-            .permission_admission_source(source);
-    }
-    Ok(builder)
 }
 
 #[cfg(test)]
@@ -179,123 +106,52 @@ pub(crate) fn build_coding_runtime(
     model: ModelName,
     options: CodingRuntimeOptions,
 ) -> Result<Runtime, CodingRuntimeError> {
-    configure_coding_runtime_builder(session_id, root, provider, model, options)?
-        .build()
-        .map_err(|source| CodingRuntimeError::RuntimeBuild { source })
+    build_headless_coding(HeadlessCodingRuntimeInput {
+        session_id,
+        root,
+        provider,
+        model,
+        process_backend: options.process_backend,
+        extra_tools: options.extra_tools,
+        allow_hidden_workspace_paths: options.allow_hidden_workspace_paths,
+        automatic_compaction: options.automatic_compaction,
+        retry_policy: options.retry_policy,
+        context_compaction: options.context_compaction,
+        approval_review: options.approval_review,
+        skill_roots: options.skill_roots,
+        subagents: options.subagents,
+        workspace_tool_limits: options.workspace_tool_limits,
+    })
 }
 
-fn configure_coding_runtime_builder(
-    session_id: &str,
-    root: &Path,
-    provider: Arc<dyn ModelProvider>,
-    model: ModelName,
-    options: CodingRuntimeOptions,
-) -> Result<RuntimeBuilder, CodingRuntimeError> {
-    let parent_session_id = merry_core::SessionId::new(session_id)?;
-    let project_rules = load_root_project_rules(root)?;
-    let process_backend = options.process_backend;
-    let process_session = process_backend.new_session();
-    let mut builder = Runtime::builder(parent_session_id.clone())
-        .automatic_compaction(options.automatic_compaction)
-        .coordinator_plan_tools()
-        .model_provider(Arc::clone(&provider), model.clone());
-    if let Some(role_provider) = options.context_compaction {
-        builder = builder.model_provider_for_role(
-            role_provider.role,
-            role_provider.provider,
-            role_provider.model,
-        );
+fn build_coding_runtime_from_headless_input(
+    input: HeadlessCodingRuntimeInput<'_>,
+    permission: CodingPermissionPolicy,
+) -> Result<CodingRuntimeBuilder, CodingRuntimeError> {
+    let session_id = merry_core::SessionId::new(input.session_id)?;
+    let mut coding_input = CodingRuntimeInput::new(
+        session_id,
+        input.root,
+        input.provider,
+        input.model,
+        input.process_backend,
+    )
+    .with_extra_tools(input.extra_tools)
+    .with_allow_hidden_workspace_paths(input.allow_hidden_workspace_paths)
+    .with_automatic_compaction(input.automatic_compaction)
+    .with_skill_roots(input.skill_roots)
+    .with_subagents(input.subagents);
+    if let Some(limits) = input.workspace_tool_limits {
+        coding_input = coding_input.with_workspace_tool_limits(limits);
     }
-    if let Some(role_provider) = options.approval_review {
-        builder = builder.model_provider_for_role(
-            role_provider.role,
-            role_provider.provider,
-            role_provider.model,
-        );
+    if let Some(policy) = input.retry_policy {
+        coding_input = coding_input.with_retry_policy(policy);
     }
-    let skill_catalog = if !options.skill_roots.is_empty() {
-        let catalog = merry_runtime::SkillCatalog::load_from_roots(options.skill_roots.clone())?;
-        let skill_names = catalog
-            .skills()
-            .iter()
-            .map(|skill| skill.name())
-            .collect::<Vec<_>>();
-        let skill_paths = catalog
-            .skills()
-            .iter()
-            .map(|skill| skill.skill_md_path().display().to_string())
-            .collect::<Vec<_>>();
-        tracing::info!(
-            event = "runtime.skill_catalog.load",
-            session_id,
-            configured_root_count = options.skill_roots.len(),
-            readable_root_count = options
-                .skill_roots
-                .iter()
-                .filter(|root| root.is_dir())
-                .count(),
-            skill_count = catalog.skills().len(),
-            warning_count = catalog.warnings().len(),
-            skill_names = ?skill_names,
-            skill_paths = ?skill_paths,
-            "runtime skill catalog loaded"
-        );
-        Some(catalog)
-    } else {
-        None
-    };
-
-    let mut profile_builder: CodingAgentProfileBuilder = coding_agent(root)
-        .readonly_resource_roots(options.skill_roots.clone())
-        .allow_hidden(options.allow_hidden_workspace_paths)
-        .limits(options.workspace_tool_limits.unwrap_or_default())
-        .patch_tool()
-        .accepted_process_session(process_session.clone())
-        .register_tools(options.extra_tools);
-    if let Some(skill_catalog) = skill_catalog {
-        profile_builder = profile_builder.skill_catalog(skill_catalog);
+    if let Some(role) = input.context_compaction {
+        coding_input = coding_input.with_model_role(role);
     }
-    if let Some(project_rules) = project_rules {
-        profile_builder = profile_builder.project_rules(project_rules);
+    if let Some(role) = input.approval_review {
+        coding_input = coding_input.with_model_role(role);
     }
-
-    let child_factory: Arc<dyn ChildRuntimeFactory> = Arc::new(CodingChildRuntimeFactory::new(
-        profile_builder.clone(),
-        Arc::clone(&provider),
-        model.clone(),
-        Arc::clone(&process_backend),
-        options.subagents.limits(),
-        options.automatic_compaction,
-    ));
-
-    let mut profile_tools = Vec::new();
-    if options.subagents.is_installed() {
-        let manager = SubagentManager::runtime_controlled(
-            parent_session_id.clone(),
-            options.subagents.limits(),
-            child_factory,
-            options.subagents.is_enabled(),
-        );
-        let [spawn_tool, wait_tool, cancel_tool] = subagent_registered_tools(manager.clone())?;
-        builder = builder.subagent_manager(manager);
-        profile_tools.extend([spawn_tool, wait_tool, cancel_tool]);
-        tracing::info!(
-            event = "runtime.subagents.enabled",
-            session_id,
-            enabled = options.subagents.is_enabled(),
-            max_threads = options.subagents.limits().max_threads(),
-            max_depth = options.subagents.limits().max_depth(),
-            "runtime subagent tools registered"
-        );
-    }
-
-    let mut profile = profile_builder.register_tools(profile_tools);
-    if let Some(policy) = options.retry_policy {
-        profile = profile.retry_policy(policy);
-    }
-    let profile = profile.build()?;
-    let builder = profile
-        .apply_to(builder)
-        .map_err(|source| CodingRuntimeError::RuntimeProfileApply { source })?;
-    Ok(builder)
+    Ok(CodingRuntimeBuilder::new(coding_input).permission_policy(permission))
 }

--- a/crates/merry-cli/src/coding/tests.rs
+++ b/crates/merry-cli/src/coding/tests.rs
@@ -86,6 +86,7 @@ fn headless_input<'a>(
         approval_review: None,
         skill_roots: Vec::new(),
         subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
     }
 }
 
@@ -487,6 +488,7 @@ async fn headless_runtime_uses_coding_agent_profile() {
         approval_review: None,
         skill_roots: Vec::new(),
         subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
     })
     .expect("headless coding runtime should build");
 
@@ -556,6 +558,7 @@ async fn headless_runtime_registers_extra_tools() {
         approval_review: None,
         skill_roots: Vec::new(),
         subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
         extra_tools: vec![RegisteredTool::read_only(spec, Arc::new(StaticOkExecutor))],
     })
     .expect("headless coding runtime should build");

--- a/crates/merry-cli/src/provider_config.rs
+++ b/crates/merry-cli/src/provider_config.rs
@@ -157,11 +157,12 @@ fn runtime_role_provider(
     model: String,
     map_usage_error: fn(String) -> CliError,
 ) -> Result<RuntimeRoleProviderConfig, CliError> {
-    Ok(RuntimeRoleProviderConfig {
+    RuntimeRoleProviderConfig::new(
         role,
-        provider: model_provider(provider, map_usage_error)?,
-        model: ModelName::new(&model).map_err(|error| map_usage_error(error.to_string()))?,
-    })
+        model_provider(provider, map_usage_error)?,
+        ModelName::new(&model).map_err(|error| map_usage_error(error.to_string()))?,
+    )
+    .map_err(|error| map_usage_error(error.to_string()))
 }
 
 fn model_provider(
@@ -335,9 +336,9 @@ pub(crate) fn apply_openai_context_compaction_provider(
     if let Some(config) = context_compaction {
         let role_provider = openai_context_compaction_provider(config)?;
         builder = builder.model_provider_for_role(
-            role_provider.role,
-            role_provider.provider,
-            role_provider.model,
+            role_provider.role(),
+            role_provider.provider(),
+            role_provider.model().clone(),
         );
     }
     Ok(builder)
@@ -358,11 +359,12 @@ pub(crate) fn openai_role_provider_config(
     config: OpenAiConfig,
     map_usage_error: fn(String) -> CliError,
 ) -> Result<RuntimeRoleProviderConfig, CliError> {
-    Ok(RuntimeRoleProviderConfig {
+    RuntimeRoleProviderConfig::new(
         role,
-        provider: Arc::new(OpenAiProvider::new(config.provider)),
-        model: ModelName::new(&config.model).map_err(|error| map_usage_error(error.to_string()))?,
-    })
+        Arc::new(OpenAiProvider::new(config.provider)),
+        ModelName::new(&config.model).map_err(|error| map_usage_error(error.to_string()))?,
+    )
+    .map_err(|error| map_usage_error(error.to_string()))
 }
 
 pub(crate) fn openai_provider_bundle(
@@ -680,8 +682,8 @@ model = "gpt-compact"
         let compaction = bundle
             .context_compaction
             .expect("compaction override should be present");
-        assert_eq!(compaction.provider.name().as_str(), "compat");
-        assert_eq!(compaction.model.as_str(), "gpt-compact");
+        assert_eq!(compaction.provider().name().as_str(), "compat");
+        assert_eq!(compaction.model().as_str(), "gpt-compact");
     }
 
     #[test]
@@ -725,8 +727,8 @@ model = "gpt-compact"
         let compaction = bundle
             .context_compaction
             .expect("compaction override should remain configured");
-        assert_eq!(compaction.provider.name().as_str(), "compat");
-        assert_eq!(compaction.model.as_str(), "gpt-compact");
+        assert_eq!(compaction.provider().name().as_str(), "compat");
+        assert_eq!(compaction.model().as_str(), "gpt-compact");
     }
 
     #[test]
@@ -776,13 +778,16 @@ model = "gpt-review"
         let context_compaction = bundle
             .context_compaction
             .expect("context compaction provider should be materialized");
-        assert_eq!(context_compaction.role, RuntimeModelRole::ContextCompaction);
-        assert_eq!(context_compaction.model.as_str(), "gpt-compact");
+        assert_eq!(
+            context_compaction.role(),
+            RuntimeModelRole::ContextCompaction
+        );
+        assert_eq!(context_compaction.model().as_str(), "gpt-compact");
         let approval_review = bundle
             .approval_review
             .expect("approval review provider should be materialized");
-        assert_eq!(approval_review.role, RuntimeModelRole::ApprovalReview);
-        assert_eq!(approval_review.model.as_str(), "gpt-review");
+        assert_eq!(approval_review.role(), RuntimeModelRole::ApprovalReview);
+        assert_eq!(approval_review.model().as_str(), "gpt-review");
         assert_eq!(
             bundle
                 .retry_policy

--- a/crates/merry-cli/src/run.rs
+++ b/crates/merry-cli/src/run.rs
@@ -1,8 +1,9 @@
 use crate::cli_error::{CliError, debug_openai_usage_error, stdout_error, unexpected};
 use crate::coding::{
-    HeadlessCodingRuntimeInput, ProcessExecutionMode, action_process_runner_for_mode,
-    build_headless_coding, build_headless_coding_with_permission_review_mode,
-    coding_agent_loop_config, coding_agent_process_admission, coding_agent_requires_sandbox_error,
+    CodingPermissionPolicy, HeadlessCodingRuntimeInput, ProcessExecutionMode,
+    action_process_runner_for_mode, build_headless_coding_composition,
+    build_headless_coding_with_policy_composition, coding_agent_process_admission,
+    coding_agent_requires_sandbox_error,
 };
 use crate::config::MerryConfig;
 use crate::mcp_tools::discover_configured_mcp_tools;
@@ -97,36 +98,26 @@ pub(crate) async fn run(
             .map_err(unexpected)?
             .unwrap_or_default(),
         subagents: subagents_config(merry_config).map_err(unexpected)?.into(),
+        workspace_tool_limits: None,
     };
-    let runtime = if fully_trusted {
-        build_headless_coding_with_permission_review_mode(
+    let coding_runtime = if fully_trusted {
+        build_headless_coding_with_policy_composition(
             runtime_input,
-            merry_runtime::PermissionReviewMode::FullyTrusted,
+            CodingPermissionPolicy::fully_trusted(),
         )?
     } else {
-        build_headless_coding(runtime_input)?
+        build_headless_coding_composition(runtime_input)?
     };
+    let loop_config = coding_runtime.loop_config();
+    let runtime = coding_runtime.into_runtime();
     let input = StepInput::user_text(&args.task).map_err(unexpected)?;
     let context = StepContext::default()
         .with_generation_config(generation_config(merry_config).map_err(unexpected)?);
     if args.events_jsonl {
-        write_agent_loop_jsonl_output(
-            &runtime,
-            input,
-            coding_agent_loop_config()?,
-            context,
-            tokio::io::stdout(),
-        )
-        .await
+        write_agent_loop_jsonl_output(&runtime, input, loop_config, context, tokio::io::stdout())
+            .await
     } else {
-        write_agent_loop_output(
-            &runtime,
-            input,
-            coding_agent_loop_config()?,
-            context,
-            tokio::io::stdout(),
-        )
-        .await
+        write_agent_loop_output(&runtime, input, loop_config, context, tokio::io::stdout()).await
     }
 }
 
@@ -564,6 +555,7 @@ mod tests {
             approval_review: None,
             skill_roots: Vec::new(),
             subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: None,
         })
         .expect("runtime should build");
 
@@ -631,6 +623,7 @@ mod tests {
             approval_review: None,
             skill_roots: Vec::new(),
             subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: None,
         })
         .expect("runtime should build");
 
@@ -689,6 +682,7 @@ mod tests {
             approval_review: None,
             skill_roots: Vec::new(),
             subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: None,
         })
         .expect("runtime should build");
 
@@ -754,6 +748,7 @@ mod tests {
             approval_review: None,
             skill_roots: Vec::new(),
             subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: None,
         })
         .expect("runtime should build");
 

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -1,8 +1,8 @@
 use crate::cli_error::{CliError, debug_openai_usage_error, unexpected};
 use crate::coding::{
-    HeadlessCodingRuntimeInput, ProcessExecutionMode, action_process_runner_for_mode,
-    build_headless_coding_with_permission_source, coding_agent_loop_config,
-    coding_agent_process_admission, resume_headless_coding_with_permission_source,
+    CodingPermissionPolicy, HeadlessCodingRuntimeInput, ProcessExecutionMode,
+    action_process_runner_for_mode, build_headless_coding_with_policy_composition,
+    coding_agent_process_admission, resume_headless_coding_composition_with_policy,
 };
 use crate::config::MerryConfig;
 use crate::mcp_tools::discover_configured_mcp_tools;
@@ -24,8 +24,8 @@ use merry_llm::GenerationConfig;
 use merry_runtime::{
     AgentLoopControl, AgentLoopInput, AutomaticCompactionConfig, ChannelPermissionAdmissionSource,
     InteractivePrimaryModel, InteractiveRunEventStream, InteractiveSettingsUpdate,
-    InteractiveSubagentSettings, PermissionReviewMode, PermissionReviewRequest, Runtime,
-    SessionTranscriptItem, SkillMetadata, StepContext, SubagentActivityReceiver,
+    InteractiveSubagentSettings, PermissionReviewRequest, Runtime, SessionTranscriptItem,
+    SkillMetadata, StepContext, SubagentActivityReceiver,
 };
 use std::{collections::VecDeque, env, num::NonZeroU64, path::PathBuf, sync::Arc};
 use tokio::sync::mpsc;
@@ -129,28 +129,25 @@ pub(crate) async fn start_tui_runtime_session(
             subagents.is_enabled(),
             subagents.limits(),
         ),
+        workspace_tool_limits: None,
     };
-    let permission_review_mode = if fully_trusted {
-        PermissionReviewMode::FullyTrusted
+    let permission_policy = if fully_trusted {
+        CodingPermissionPolicy::fully_trusted()
     } else {
-        PermissionReviewMode::ModelThenHostFallback
+        CodingPermissionPolicy::model_then_host_fallback(permission_source)
     };
-    let runtime = if should_resume {
-        resume_headless_coding_with_permission_source(
+    let coding_runtime = if should_resume {
+        resume_headless_coding_composition_with_policy(
             runtime_input,
             session_store.session_state_store(),
-            permission_source,
-            permission_review_mode,
+            permission_policy,
         )
         .await?
     } else {
-        build_headless_coding_with_permission_source(
-            runtime_input,
-            permission_source,
-            permission_review_mode,
-        )?
+        build_headless_coding_with_policy_composition(runtime_input, permission_policy)?
     };
-    let loop_config = coding_agent_loop_config()?;
+    let loop_config = coding_runtime.loop_config();
+    let runtime = coding_runtime.into_runtime();
     let skills = runtime.skills().await;
     let interactive = runtime
         .start_interactive_agent_run(

--- a/crates/merry-cli/src/tui/tests.rs
+++ b/crates/merry-cli/src/tui/tests.rs
@@ -3249,7 +3249,7 @@ fn projector_shows_permission_allow_rationale_on_success() {
                 "request_permissions",
                 json!({
                     "requested": { "network": true },
-                    "for_action": { "kind": "process", "command": "cargo test", "cwd": null }
+                    "for_action": { "command": "cargo test", "cwd": null }
                 }),
             ),
             source: source(),

--- a/crates/merry-coding/Cargo.toml
+++ b/crates/merry-coding/Cargo.toml
@@ -12,10 +12,14 @@ merry-runtime = { path = "../merry-runtime", version = "0.1.0" }
 merry-tool-workspace = { path = "../merry-tool-workspace", version = "0.1.0" }
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
+futures-util.workspace = true
+merry-llm = { path = "../merry-llm", version = "0.1.0", features = ["test-utils"] }
 schemars.workspace = true
 tempfile.workspace = true
+tokio.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/merry-coding/src/child_runtime.rs
+++ b/crates/merry-coding/src/child_runtime.rs
@@ -1,4 +1,4 @@
-use crate::CodingAgentProfileBuilder;
+use crate::{CodingAgentProfileBuilder, runtime::CodingRuntimePolicy};
 use merry_llm::{ModelName, ModelProvider};
 use merry_process::ProcessBackend;
 use merry_runtime::{
@@ -15,43 +15,35 @@ use std::sync::Arc;
 /// scope, subagent, admission, and plan-link state. It deliberately accepts a
 /// host-process backend contract instead of a CLI or sandbox type.
 #[derive(Clone)]
-pub struct CodingChildRuntimeFactory {
-    profile_builder: CodingAgentProfileBuilder,
-    provider: Arc<dyn ModelProvider>,
-    model: ModelName,
-    process_backend: Arc<dyn ProcessBackend>,
-    subagent_config: SubagentConfig,
-    automatic_compaction: AutomaticCompactionConfig,
+pub(crate) struct CodingChildRuntimeFactory {
+    composition: CodingRuntimeComposition,
+}
+
+/// Normalized parent/child inputs shared by coding runtime composition.
+///
+/// The parent builder creates this value once after selecting provider, process,
+/// subagent, and compaction policy. Child runtimes reuse the same composition
+/// instead of receiving a second set of independently assembled dependencies.
+#[derive(Clone)]
+pub(crate) struct CodingRuntimeComposition {
+    pub(crate) profile_builder: CodingAgentProfileBuilder,
+    pub(crate) provider: Arc<dyn ModelProvider>,
+    pub(crate) model: ModelName,
+    pub(crate) process_backend: Arc<dyn ProcessBackend>,
+    pub(crate) subagent_config: SubagentConfig,
+    pub(crate) automatic_compaction: AutomaticCompactionConfig,
+    pub(crate) policy: CodingRuntimePolicy,
 }
 
 impl CodingChildRuntimeFactory {
-    /// Creates a coding child-runtime factory from explicit composition inputs.
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "child runtime dependencies remain explicit at the composition boundary"
-    )]
-    pub fn new(
-        profile_builder: CodingAgentProfileBuilder,
-        provider: Arc<dyn ModelProvider>,
-        model: ModelName,
-        process_backend: Arc<dyn ProcessBackend>,
-        subagent_config: SubagentConfig,
-        automatic_compaction: AutomaticCompactionConfig,
-    ) -> Self {
-        Self {
-            profile_builder,
-            provider,
-            model,
-            process_backend,
-            subagent_config,
-            automatic_compaction,
-        }
+    pub(crate) fn from_composition(composition: CodingRuntimeComposition) -> Self {
+        Self { composition }
     }
 }
 
 impl ChildRuntimeFactory for CodingChildRuntimeFactory {
     fn build_child(&self, input: ChildRuntimeInput) -> Result<Runtime, RuntimeError> {
-        let process_session = self.process_backend.new_session();
+        let process_session = self.composition.process_backend.new_session();
         let runner = process_session.runner();
         let allow_local_workspace_process = input
             .allowed_tools
@@ -59,8 +51,11 @@ impl ChildRuntimeFactory for CodingChildRuntimeFactory {
             .any(|tool| tool.as_str() == CODING_LOOP_PROCESS_TOOL);
         let mut builder = Runtime::builder(input.session_id.clone())
             .task_anchor(input.task_anchor)
-            .automatic_compaction(self.automatic_compaction)
-            .model_provider(Arc::clone(&self.provider), self.model.clone())
+            .automatic_compaction(self.composition.automatic_compaction)
+            .model_provider(
+                Arc::clone(&self.composition.provider),
+                self.composition.model.clone(),
+            )
             .tool_admission(ToolAdmission::allow_only(input.allowed_tools.clone()));
         if let Some(activity_hub) = input.activity_hub.clone() {
             builder = builder.subagent_activity_hub(activity_hub);
@@ -69,7 +64,7 @@ impl ChildRuntimeFactory for CodingChildRuntimeFactory {
         let child_factory: Arc<dyn ChildRuntimeFactory> = Arc::new(self.clone());
         let child_manager = SubagentManager::runtime_controlled_at_depth(
             input.session_id.clone(),
-            self.subagent_config,
+            self.composition.subagent_config,
             child_factory,
             input
                 .allowed_tools
@@ -96,6 +91,7 @@ impl ChildRuntimeFactory for CodingChildRuntimeFactory {
         let has_child_workspace_boundary =
             child_has_workspace_boundary(&workspace_scope, write_scope_is_explicit);
         let mut profile = self
+            .composition
             .profile_builder
             .clone()
             .patch_write_scope(workspace_scope.write_scope().to_vec())
@@ -111,7 +107,8 @@ impl ChildRuntimeFactory for CodingChildRuntimeFactory {
             .map_err(|source| RuntimeError::ChildRuntimeBuild {
                 message: source.to_string(),
             })?;
-        profile.apply_to(builder)?.build()
+        let builder = profile.apply_to(builder)?;
+        self.composition.policy.apply_to(builder).build()
     }
 }
 
@@ -130,7 +127,30 @@ fn child_has_workspace_boundary(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use merry_runtime::SubagentTaskSpec;
+    use crate::{CodingAgentProfileBuilder, CodingModelRoleConfig, CodingPermissionPolicy};
+    use futures_util::StreamExt;
+    use merry_core::{
+        RuntimeJournalEvent, RuntimeJournalPayload, SessionId, ToolCallResultStatus, ToolName,
+    };
+    use merry_llm::{
+        FinishReason, GenerationConfig, ModelEvent, ModelName, ModelOutput, ModelProvider,
+        ModelResponse, ModelRetryPolicy, ModelToolCall, ModelToolCallId, ToolArguments,
+        testing::FakeModelProvider,
+    };
+    use merry_process::{LocalProcessBackend, ProcessBackend, ProcessSession, TokioProcessRunner};
+    use merry_runtime::{
+        AcceptedLocalWorkspaceProcessAdmission, AutomaticCompactionConfig,
+        CitationCompactionPolicy, PermissionAdmissionContext, PermissionAdmissionDecision,
+        PermissionAdmissionFuture, PermissionAdmissionSource,
+        ProcessRunner as RuntimeProcessRunner, Runtime, RuntimeModelRole,
+        StaticPermissionedProcessRunnerFactory, StepContext, StepInput, SubagentConfig,
+        SubagentTaskSpec, TaskAnchor,
+    };
+    use serde_json::json;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     #[test]
     fn explicit_empty_write_scope_is_a_child_workspace_boundary() {
@@ -144,5 +164,310 @@ mod tests {
             &scope,
             task.write_scope_is_explicit()
         ));
+    }
+
+    fn process_backend() -> Arc<dyn ProcessBackend> {
+        let runner: Arc<dyn RuntimeProcessRunner> = Arc::new(TokioProcessRunner::new());
+        let permissioned_factory = Arc::new(StaticPermissionedProcessRunnerFactory::new(
+            Arc::clone(&runner),
+        ));
+        let session = ProcessSession::from_parts(
+            AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+            runner,
+            permissioned_factory,
+        );
+        Arc::new(LocalProcessBackend::from_session(session))
+    }
+
+    fn build_factory(
+        root: &std::path::Path,
+        provider: Arc<dyn ModelProvider>,
+        policy: CodingRuntimePolicy,
+    ) -> CodingChildRuntimeFactory {
+        let profile_builder = CodingAgentProfileBuilder::new(root)
+            .patch_tool()
+            .retry_policy(ModelRetryPolicy::disabled())
+            .accepted_process_session({
+                let runner: Arc<dyn RuntimeProcessRunner> = Arc::new(TokioProcessRunner::new());
+                let permissioned_factory = Arc::new(StaticPermissionedProcessRunnerFactory::new(
+                    Arc::clone(&runner),
+                ));
+                ProcessSession::from_parts(
+                    AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+                    runner,
+                    permissioned_factory,
+                )
+            });
+        CodingChildRuntimeFactory::from_composition(CodingRuntimeComposition {
+            profile_builder,
+            provider,
+            model: ModelName::new("child-primary").expect("child model should be valid"),
+            process_backend: process_backend(),
+            subagent_config: SubagentConfig::new(1, 1).expect("subagent config should be valid"),
+            automatic_compaction: AutomaticCompactionConfig::disabled(),
+            policy,
+        })
+    }
+
+    fn child_input(session: &str, allowed_tools: Vec<ToolName>) -> ChildRuntimeInput {
+        let task = SubagentTaskSpec::new("Exercise the child runtime.", 4)
+            .expect("child task should be valid");
+        ChildRuntimeInput {
+            session_id: SessionId::new(session).expect("child session should be valid"),
+            task_anchor: TaskAnchor::new("Exercise the child runtime.")
+                .expect("child task anchor should be valid"),
+            task,
+            allowed_tools,
+            workspace_scope: ChildWorkspaceScope::workspace_root(),
+            depth: 0,
+            generation_config: GenerationConfig::default(),
+            plan_subagent_control: None,
+            plan_subagent_scope: None,
+            plan_link: None,
+            plan_link_runtime: None,
+            activity_hub: None,
+        }
+    }
+
+    async fn run_text_step(runtime: &Runtime, text: &str) -> Vec<RuntimeJournalEvent> {
+        runtime
+            .step(
+                StepInput::user_text(text).expect("step input should be valid"),
+                StepContext::default(),
+            )
+            .expect("child step should start")
+            .collect()
+            .await
+    }
+
+    fn completed_text(text: &str) -> ModelEvent {
+        ModelEvent::Completed {
+            response: ModelResponse::new(vec![ModelOutput::text(text)], FinishReason::Stop, None),
+        }
+    }
+
+    fn compaction_candidate() -> ModelEvent {
+        completed_text(
+            r#"{
+  "confirmed_decisions": [],
+  "rejected_approaches": [],
+  "constraints_preferences_boundaries": [],
+  "corrected_misunderstandings": [],
+  "durable_conclusions": [{"id": "child-c1", "text": "The child runtime compacted its history.", "refs": ["h0"]}],
+  "open_questions": [],
+  "current_progress_and_next_steps": [],
+  "exact_details": [],
+  "handoffs": []
+}"#,
+        )
+    }
+
+    fn permission_call_event() -> ModelEvent {
+        let call = ModelToolCall::new(
+            ModelToolCallId::new("child-permission-call").expect("call id should be valid"),
+            ToolName::new("request_permissions").expect("tool name should be valid"),
+            ToolArguments::try_from(json!({
+                "reason": "Run the exact child command.",
+                "requested": {"network": true},
+                "for_action": {
+                    "command": "printf child-permission",
+                    "cwd": "."
+                }
+            }))
+            .expect("permission arguments should be valid"),
+        );
+        ModelEvent::Completed {
+            response: ModelResponse::new(
+                vec![ModelOutput::tool_call(call)],
+                FinishReason::ToolCalls,
+                None,
+            ),
+        }
+    }
+
+    fn approval_event() -> ModelEvent {
+        completed_text(
+            r#"{"schema_version":"permission_review.v1","decision":"approve","risk":"low","user_authorization":"high","rationale":"The child task authorizes this exact command."}"#,
+        )
+    }
+
+    fn permission_tool_name() -> ToolName {
+        ToolName::new("request_permissions").expect("permission tool name should be valid")
+    }
+
+    fn resolved_success(events: &[RuntimeJournalEvent]) -> bool {
+        events.iter().any(|event| {
+            matches!(
+                &event.payload,
+                RuntimeJournalPayload::ToolCallResolved { result }
+                    if result.status() == ToolCallResultStatus::Succeeded
+            )
+        })
+    }
+
+    #[derive(Clone)]
+    struct CountingAdmission {
+        calls: Arc<AtomicUsize>,
+        decision: PermissionAdmissionDecision,
+    }
+
+    impl CountingAdmission {
+        fn approving() -> Self {
+            Self {
+                calls: Arc::new(AtomicUsize::new(0)),
+                decision: PermissionAdmissionDecision::approved("host approved"),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl PermissionAdmissionSource for CountingAdmission {
+        fn review<'a>(
+            &'a self,
+            _request: merry_runtime::PermissionRequest,
+            _context: PermissionAdmissionContext,
+        ) -> PermissionAdmissionFuture<'a> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(self.decision.clone())
+            })
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn child_runtime_uses_composed_context_compaction_provider() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let primary = Arc::new(FakeModelProvider::new(vec![
+            Ok(completed_text("first child turn")),
+            Ok(completed_text("second child turn")),
+        ]));
+        let compactor = Arc::new(FakeModelProvider::new(vec![Ok(compaction_candidate())]));
+        let compaction_role = CodingModelRoleConfig::new(
+            RuntimeModelRole::ContextCompaction,
+            compactor.clone(),
+            ModelName::new("child-compactor").expect("compaction model should be valid"),
+        )
+        .expect("context compaction role should be valid");
+        let policy =
+            CodingRuntimePolicy::try_new(vec![compaction_role], CodingPermissionPolicy::default())
+                .expect("child policy should not contain duplicate roles");
+        let factory = build_factory(temp.path(), primary.clone(), policy);
+        let runtime = factory
+            .build_child(child_input("child-compaction", Vec::new()))
+            .expect("child runtime should build");
+
+        run_text_step(&runtime, "old child history").await;
+        run_text_step(&runtime, "retained child history").await;
+        let policy = CitationCompactionPolicy::new(None, None, 1)
+            .expect("compaction policy should be valid");
+        let outcome = runtime
+            .compact_context_once(policy, StepContext::default())
+            .await
+            .expect("child compaction should complete")
+            .expect("child history should be compactable");
+
+        assert!(outcome.covered_history_item_count() > 0);
+        assert_eq!(compactor.recorded_requests().len(), 1);
+        assert_eq!(
+            compactor.recorded_requests()[0].model().as_str(),
+            "child-compactor"
+        );
+        assert_eq!(primary.recorded_requests().len(), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn child_runtime_uses_composed_approval_review_provider() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let primary = Arc::new(FakeModelProvider::new(vec![Ok(permission_call_event())]));
+        let approval = Arc::new(FakeModelProvider::new(vec![Ok(approval_event())]));
+        let approval_role = CodingModelRoleConfig::new(
+            RuntimeModelRole::ApprovalReview,
+            approval.clone(),
+            ModelName::new("child-approval").expect("approval model should be valid"),
+        )
+        .expect("approval role should be valid");
+        let policy =
+            CodingRuntimePolicy::try_new(vec![approval_role], CodingPermissionPolicy::default())
+                .expect("child policy should not contain duplicate roles");
+        let factory = build_factory(temp.path(), primary.clone(), policy);
+        let runtime = factory
+            .build_child(child_input(
+                "child-approval-provider",
+                vec![permission_tool_name()],
+            ))
+            .expect("child runtime should build");
+
+        run_text_step(&runtime, "Run the exact child command.").await;
+        let pending = runtime.pending_tool_calls().await;
+        assert_eq!(pending.len(), 1);
+        let resolved = runtime
+            .execute_tool_call(
+                pending[0].id(),
+                merry_runtime::ToolExecutionContext::default(),
+            )
+            .await
+            .expect("child permission request should resolve");
+
+        assert!(resolved_success(&resolved));
+        assert_eq!(approval.recorded_requests().len(), 1);
+        assert_eq!(
+            approval.recorded_requests()[0].model().as_str(),
+            "child-approval"
+        );
+        assert_eq!(primary.recorded_requests().len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn child_runtime_propagates_host_only_and_fully_trusted_permission_modes() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let host_only = CountingAdmission::approving();
+        let primary = Arc::new(FakeModelProvider::new(vec![Ok(permission_call_event())]));
+        let policy = CodingRuntimePolicy::try_new(
+            Vec::new(),
+            CodingPermissionPolicy::host_decision_only(Arc::new(host_only.clone())),
+        )
+        .expect("child policy should not contain duplicate roles");
+        let factory = build_factory(temp.path(), primary.clone(), policy);
+        let runtime = factory
+            .build_child(child_input("child-host-only", vec![permission_tool_name()]))
+            .expect("host-only child runtime should build");
+        run_text_step(&runtime, "Run through the host admission source.").await;
+        let pending = runtime.pending_tool_calls().await;
+        let events = runtime
+            .execute_tool_call(
+                pending[0].id(),
+                merry_runtime::ToolExecutionContext::default(),
+            )
+            .await
+            .expect("host-only permission request should resolve");
+        assert!(resolved_success(&events));
+        assert_eq!(host_only.calls(), 1);
+
+        let fully_trusted_source = CountingAdmission::approving();
+        let trusted_primary = Arc::new(FakeModelProvider::new(vec![Ok(permission_call_event())]));
+        let trusted_policy =
+            CodingRuntimePolicy::try_new(Vec::new(), CodingPermissionPolicy::fully_trusted())
+                .expect("child policy should not contain duplicate roles");
+        let trusted_factory = build_factory(temp.path(), trusted_primary, trusted_policy);
+        let trusted_runtime = trusted_factory
+            .build_child(child_input(
+                "child-fully-trusted",
+                vec![permission_tool_name()],
+            ))
+            .expect("fully trusted child runtime should build");
+        run_text_step(&trusted_runtime, "Run through fully trusted admission.").await;
+        let pending = trusted_runtime.pending_tool_calls().await;
+        let events = trusted_runtime
+            .execute_tool_call(
+                pending[0].id(),
+                merry_runtime::ToolExecutionContext::default(),
+            )
+            .await
+            .expect("fully trusted permission request should resolve");
+        assert!(resolved_success(&events));
+        assert_eq!(fully_trusted_source.calls(), 0);
     }
 }

--- a/crates/merry-coding/src/lib.rs
+++ b/crates/merry-coding/src/lib.rs
@@ -1,21 +1,26 @@
 //! Provider-neutral coding composition for Merry.
 //!
-//! This crate is the single owner of the coding-agent profile: workspace
-//! tools, project-rule and skill projections, process admission lanes, tool
-//! order, and the stable composition identity. The facade and CLI consume
-//! these types rather than assembling a second coding policy.
+//! This crate is the single owner of coding composition: the parent runtime
+//! builder, child-runtime inputs, workspace tools, project-rule and skill
+//! projections, process admission lanes, tool order, and stable composition
+//! identity. The facade and CLI consume these types rather than assembling a
+//! second coding policy.
 
 mod child_runtime;
 mod project_rules;
+mod runtime;
 mod workspace;
 
 #[cfg(test)]
 mod tests;
 
-pub use child_runtime::CodingChildRuntimeFactory;
 pub use project_rules::{
     MAX_ROOT_PROJECT_RULES_BYTES, ProjectRulesLoadError, ROOT_PROJECT_RULES_FILE,
     load_root_project_rules,
+};
+pub use runtime::{
+    CodingModelRoleConfig, CodingModelRoleConfigError, CodingPermissionPolicy, CodingRuntime,
+    CodingRuntimeBuildError, CodingRuntimeBuilder, CodingRuntimeInput, CodingSubagentsConfig,
 };
 
 use merry_core::{CoreError, ToolName};

--- a/crates/merry-coding/src/runtime.rs
+++ b/crates/merry-coding/src/runtime.rs
@@ -1,0 +1,660 @@
+//! Parent coding-runtime composition.
+//!
+//! This module owns the typed assembly boundary between a coding surface and
+//! the provider-neutral runtime. It constructs runtime state through
+//! [`merry_runtime::RuntimeBuilder`], but it does not own that state after the
+//! builder returns a [`CodingRuntime`].
+
+use crate::child_runtime::{CodingChildRuntimeFactory, CodingRuntimeComposition};
+use crate::{
+    CodingAgentProfile, CodingAgentProfileBuildError, CodingAgentProfileBuilder,
+    ProjectRulesLoadError, coding_agent, load_root_project_rules,
+};
+use merry_core::{CoreError, SessionId};
+use merry_llm::{ModelName, ModelProvider, ModelRetryPolicy};
+use merry_process::ProcessBackend;
+use merry_runtime::{
+    AgentLoopConfig, AgentLoopConfigError, AutomaticCompactionConfig, ChildRuntimeFactory,
+    FileSessionStore, PermissionAdmissionSource, PermissionReviewMode, RegisteredTool, Runtime,
+    RuntimeBuilder, RuntimeError, RuntimeModelRole, SkillCatalog, SkillError, SubagentConfig,
+    SubagentManager, subagent_registered_tools,
+};
+use merry_tool_workspace::WorkspaceToolLimits;
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+use thiserror::Error;
+
+/// A provider-neutral model/provider pair for one non-primary runtime role.
+///
+/// Provider adapters are represented by the Merry-owned [`ModelProvider`] trait;
+/// provider wire request and response types never cross this contract.
+#[derive(Clone)]
+pub struct CodingModelRoleConfig {
+    role: RuntimeModelRole,
+    provider: Arc<dyn ModelProvider>,
+    model: ModelName,
+}
+
+impl CodingModelRoleConfig {
+    /// Creates a role-specific model configuration.
+    pub fn new(
+        role: RuntimeModelRole,
+        provider: Arc<dyn ModelProvider>,
+        model: ModelName,
+    ) -> Result<Self, CodingModelRoleConfigError> {
+        if role == RuntimeModelRole::Primary {
+            return Err(CodingModelRoleConfigError::PrimaryRole);
+        }
+        Ok(Self {
+            role,
+            provider,
+            model,
+        })
+    }
+
+    /// Returns the runtime role receiving this provider/model pair.
+    #[must_use]
+    pub const fn role(&self) -> RuntimeModelRole {
+        self.role
+    }
+
+    /// Returns the provider handle for this role.
+    #[must_use]
+    pub fn provider(&self) -> Arc<dyn ModelProvider> {
+        Arc::clone(&self.provider)
+    }
+
+    /// Returns the model name for this role.
+    #[must_use]
+    pub fn model(&self) -> &ModelName {
+        &self.model
+    }
+}
+
+/// Error returned when a secondary coding role is constructed with the
+/// primary role identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum CodingModelRoleConfigError {
+    /// The primary provider/model belongs to [`CodingRuntimeInput::new`].
+    #[error("primary model must be configured as the coding runtime's primary provider")]
+    PrimaryRole,
+}
+
+/// Permission configuration shared by parent and child coding runtimes.
+///
+/// This is the only coding-layer representation of permission mode and host
+/// admission. Host-dependent variants carry their source directly, so an
+/// incomplete host policy cannot be constructed by callers.
+#[derive(Clone, Default)]
+pub enum CodingPermissionPolicy {
+    /// Use the runtime's trust-level default.
+    #[default]
+    Default,
+    /// Always route permission requests through model-backed review.
+    Required,
+    /// Route permission requests through the supplied host admission source.
+    HostDecisionOnly {
+        /// Host-owned admission source used by the runtime.
+        source: Arc<dyn PermissionAdmissionSource>,
+    },
+    /// Try model-backed review first and use the supplied host source as a fallback.
+    ModelThenHostFallback {
+        /// Host-owned admission source used by the runtime.
+        source: Arc<dyn PermissionAdmissionSource>,
+    },
+    /// Admit configured registered tools without an approval round.
+    FullyTrusted,
+}
+
+impl CodingPermissionPolicy {
+    /// Always route permission requests through model-backed review.
+    #[must_use]
+    pub const fn required() -> Self {
+        Self::Required
+    }
+
+    /// Route permission requests through the supplied host admission source.
+    #[must_use]
+    pub fn host_decision_only(source: Arc<dyn PermissionAdmissionSource>) -> Self {
+        Self::HostDecisionOnly { source }
+    }
+
+    /// Try model-backed review first and use the supplied host source as a fallback.
+    #[must_use]
+    pub fn model_then_host_fallback(source: Arc<dyn PermissionAdmissionSource>) -> Self {
+        Self::ModelThenHostFallback { source }
+    }
+
+    /// Admit configured registered tools without an approval round.
+    #[must_use]
+    pub const fn fully_trusted() -> Self {
+        Self::FullyTrusted
+    }
+
+    fn apply_to(&self, mut builder: RuntimeBuilder) -> RuntimeBuilder {
+        match self {
+            Self::Default => {}
+            Self::Required => {
+                builder = builder.permission_review_mode(PermissionReviewMode::Required);
+            }
+            Self::HostDecisionOnly { source } => {
+                builder = builder
+                    .permission_review_mode(PermissionReviewMode::HostDecisionOnly)
+                    .permission_admission_source(Arc::clone(source));
+            }
+            Self::ModelThenHostFallback { source } => {
+                builder = builder
+                    .permission_review_mode(PermissionReviewMode::ModelThenHostFallback)
+                    .permission_admission_source(Arc::clone(source));
+            }
+            Self::FullyTrusted => {
+                builder = builder.permission_review_mode(PermissionReviewMode::FullyTrusted);
+            }
+        }
+        builder
+    }
+}
+
+/// Parent/child policy that must be applied to every coding runtime builder.
+///
+/// The policy contains only validated provider-neutral inputs. Runtime owns the
+/// meaning of model roles and permission admission; this type only forwards the
+/// same values to the parent and child builders.
+#[derive(Clone, Default)]
+pub(crate) struct CodingRuntimePolicy {
+    model_roles: Vec<CodingModelRoleConfig>,
+    permission: CodingPermissionPolicy,
+}
+
+impl CodingRuntimePolicy {
+    pub(crate) fn try_new(
+        model_roles: Vec<CodingModelRoleConfig>,
+        permission: CodingPermissionPolicy,
+    ) -> Result<Self, CodingRuntimeBuildError> {
+        let mut configured_roles = BTreeSet::new();
+        for role in &model_roles {
+            if !configured_roles.insert(role.role()) {
+                return Err(CodingRuntimeBuildError::DuplicateModelRole { role: role.role() });
+            }
+        }
+        Ok(Self {
+            model_roles,
+            permission,
+        })
+    }
+
+    pub(crate) fn apply_to(&self, mut builder: RuntimeBuilder) -> RuntimeBuilder {
+        for role in &self.model_roles {
+            builder =
+                builder.model_provider_for_role(role.role(), role.provider(), role.model().clone());
+        }
+        self.permission.apply_to(builder)
+    }
+}
+
+/// Typed subagent composition policy for a parent coding runtime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CodingSubagentsConfig {
+    installed: bool,
+    enabled: bool,
+    limits: SubagentConfig,
+}
+
+impl CodingSubagentsConfig {
+    /// Installs and enables subagent tools with the supplied runtime limits.
+    #[must_use]
+    pub const fn enabled(limits: SubagentConfig) -> Self {
+        Self {
+            installed: true,
+            enabled: true,
+            limits,
+        }
+    }
+
+    /// Installs subagent tools while leaving their runtime admission disabled.
+    #[must_use]
+    pub const fn runtime_controlled(enabled: bool, limits: SubagentConfig) -> Self {
+        Self {
+            installed: true,
+            enabled,
+            limits,
+        }
+    }
+
+    /// Returns whether the parent should advertise subagent tools.
+    #[must_use]
+    pub const fn is_installed(self) -> bool {
+        self.installed
+    }
+
+    /// Returns whether new subagent work is enabled by the parent policy.
+    #[must_use]
+    pub const fn is_enabled(self) -> bool {
+        self.enabled
+    }
+
+    /// Returns the runtime-owned subagent limits.
+    #[must_use]
+    pub const fn limits(self) -> SubagentConfig {
+        self.limits
+    }
+}
+
+/// Typed parent coding-runtime inputs shared by full and read-only variants.
+///
+/// The full constructor requires a [`ProcessBackend`]. The read-only
+/// constructor intentionally has no process backend, making it impossible for
+/// the command-generation variant to install a process session by accident.
+#[derive(Clone)]
+pub struct CodingRuntimeInput {
+    session_id: SessionId,
+    root: PathBuf,
+    provider: Arc<dyn ModelProvider>,
+    model: ModelName,
+    process_backend: Option<Arc<dyn ProcessBackend>>,
+    extra_tools: Vec<RegisteredTool>,
+    allow_hidden_workspace_paths: bool,
+    automatic_compaction: AutomaticCompactionConfig,
+    retry_policy: Option<ModelRetryPolicy>,
+    model_roles: Vec<CodingModelRoleConfig>,
+    skill_roots: Vec<PathBuf>,
+    subagents: CodingSubagentsConfig,
+    workspace_tool_limits: WorkspaceToolLimits,
+}
+
+impl CodingRuntimeInput {
+    /// Creates full coding-runtime inputs with a typed process backend.
+    #[must_use]
+    pub fn new(
+        session_id: SessionId,
+        root: impl Into<PathBuf>,
+        provider: Arc<dyn ModelProvider>,
+        model: ModelName,
+        process_backend: Arc<dyn ProcessBackend>,
+    ) -> Self {
+        Self {
+            session_id,
+            root: root.into(),
+            provider,
+            model,
+            process_backend: Some(process_backend),
+            extra_tools: Vec::new(),
+            allow_hidden_workspace_paths: false,
+            automatic_compaction: AutomaticCompactionConfig::default(),
+            retry_policy: None,
+            model_roles: Vec::new(),
+            skill_roots: Vec::new(),
+            subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: WorkspaceToolLimits::default(),
+        }
+    }
+
+    /// Creates read-only command-generation inputs without a process backend.
+    #[must_use]
+    pub fn read_only(
+        session_id: SessionId,
+        root: impl Into<PathBuf>,
+        provider: Arc<dyn ModelProvider>,
+        model: ModelName,
+    ) -> Self {
+        Self {
+            session_id,
+            root: root.into(),
+            provider,
+            model,
+            process_backend: None,
+            extra_tools: Vec::new(),
+            allow_hidden_workspace_paths: false,
+            automatic_compaction: AutomaticCompactionConfig::default(),
+            retry_policy: None,
+            model_roles: Vec::new(),
+            skill_roots: Vec::new(),
+            subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: WorkspaceToolLimits::default(),
+        }
+    }
+
+    /// Adds provider-neutral tools owned by the calling surface or adapter.
+    #[must_use]
+    pub fn with_extra_tools<I>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = RegisteredTool>,
+    {
+        self.extra_tools.extend(tools);
+        self
+    }
+
+    /// Controls whether hidden workspace path components are readable.
+    #[must_use]
+    pub fn with_allow_hidden_workspace_paths(mut self, allow: bool) -> Self {
+        self.allow_hidden_workspace_paths = allow;
+        self
+    }
+
+    /// Sets automatic context compaction policy.
+    #[must_use]
+    pub fn with_automatic_compaction(mut self, config: AutomaticCompactionConfig) -> Self {
+        self.automatic_compaction = config;
+        self
+    }
+
+    /// Sets the model retry/recovery policy shared by parent and child runtimes.
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: ModelRetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Adds one non-primary runtime model role.
+    #[must_use]
+    pub fn with_model_role(mut self, role: CodingModelRoleConfig) -> Self {
+        self.model_roles.push(role);
+        self
+    }
+
+    /// Adds model roles in the supplied deterministic order.
+    #[must_use]
+    pub fn with_model_roles<I>(mut self, roles: I) -> Self
+    where
+        I: IntoIterator<Item = CodingModelRoleConfig>,
+    {
+        self.model_roles.extend(roles);
+        self
+    }
+
+    /// Sets the read-only skill/resource roots.
+    #[must_use]
+    pub fn with_skill_roots<I, P>(mut self, roots: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.skill_roots = roots.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the parent subagent policy.
+    #[must_use]
+    pub fn with_subagents(mut self, subagents: CodingSubagentsConfig) -> Self {
+        self.subagents = subagents;
+        self
+    }
+
+    /// Sets the workspace tool limits for the coding profile.
+    #[must_use]
+    pub fn with_workspace_tool_limits(mut self, limits: WorkspaceToolLimits) -> Self {
+        self.workspace_tool_limits = limits;
+        self
+    }
+}
+
+/// Internal parent coding-runtime variant selected by the surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodingRuntimeVariant {
+    /// Full coding runtime with process, patch, plan, and optional subagent lanes.
+    FullCoding,
+    /// Read-only workspace runtime for command generation.
+    ReadOnlyCommandGeneration,
+}
+
+/// Builder for parent coding runtime composition.
+pub struct CodingRuntimeBuilder {
+    input: CodingRuntimeInput,
+    variant: CodingRuntimeVariant,
+    permission: CodingPermissionPolicy,
+}
+
+impl CodingRuntimeBuilder {
+    /// Creates a full coding-runtime builder.
+    #[must_use]
+    pub fn new(input: CodingRuntimeInput) -> Self {
+        Self {
+            input,
+            variant: CodingRuntimeVariant::FullCoding,
+            permission: CodingPermissionPolicy::default(),
+        }
+    }
+
+    /// Creates the explicit read-only command-generation variant.
+    ///
+    /// Full-only inputs such as a process backend and subagent configuration
+    /// are intentionally ignored by this variant. The read-only profile is
+    /// selected by construction so those capabilities cannot be advertised or
+    /// admitted accidentally.
+    #[must_use]
+    pub fn for_command_generation(input: CodingRuntimeInput) -> Self {
+        Self {
+            input,
+            variant: CodingRuntimeVariant::ReadOnlyCommandGeneration,
+            permission: CodingPermissionPolicy::default(),
+        }
+    }
+
+    /// Sets the complete permission policy shared by parent and child runtimes.
+    #[must_use]
+    pub fn permission_policy(mut self, policy: CodingPermissionPolicy) -> Self {
+        self.permission = policy;
+        self
+    }
+
+    /// Builds a new parent runtime and its stable coding loop policy.
+    pub fn build(self) -> Result<CodingRuntime, CodingRuntimeBuildError> {
+        let (builder, profile) = self.compose()?;
+        let loop_config = profile.loop_config()?;
+        let runtime = builder
+            .build()
+            .map_err(|source| CodingRuntimeBuildError::RuntimeBuild { source })?;
+        Ok(CodingRuntime {
+            runtime,
+            profile,
+            loop_config,
+        })
+    }
+
+    /// Resumes a parent runtime without automatic savepoints.
+    pub async fn resume_from_store_without_automatic_savepoints(
+        self,
+        store: FileSessionStore,
+    ) -> Result<CodingRuntime, CodingRuntimeBuildError> {
+        let (builder, profile) = self.compose()?;
+        let loop_config = profile.loop_config()?;
+        let runtime = builder
+            .resume_from_store_without_automatic_savepoints(store)
+            .await
+            .map_err(|source| CodingRuntimeBuildError::RuntimeBuild { source })?;
+        Ok(CodingRuntime {
+            runtime,
+            profile,
+            loop_config,
+        })
+    }
+
+    fn compose(
+        self,
+    ) -> Result<(merry_runtime::RuntimeBuilder, CodingAgentProfile), CodingRuntimeBuildError> {
+        let Self {
+            input,
+            variant,
+            permission,
+        } = self;
+        let CodingRuntimeInput {
+            session_id,
+            root,
+            provider,
+            model,
+            process_backend,
+            extra_tools,
+            allow_hidden_workspace_paths,
+            automatic_compaction,
+            retry_policy,
+            model_roles,
+            skill_roots,
+            subagents,
+            workspace_tool_limits,
+        } = input;
+
+        let policy = CodingRuntimePolicy::try_new(model_roles, permission)?;
+
+        let project_rules = load_root_project_rules(&root)?;
+        let skill_catalog = if skill_roots.is_empty() {
+            None
+        } else {
+            Some(SkillCatalog::load_from_roots(skill_roots.clone())?)
+        };
+        if let Some(catalog) = skill_catalog.as_ref() {
+            const MAX_LOGGED_SKILL_NAMES: usize = 64;
+            let skill_names = catalog
+                .skills()
+                .iter()
+                .take(MAX_LOGGED_SKILL_NAMES)
+                .map(|skill| skill.name())
+                .collect::<Vec<_>>();
+            tracing::info!(
+                event = "runtime.skill_catalog.load",
+                session_id = %session_id,
+                configured_root_count = skill_roots.len(),
+                readable_root_count = skill_roots.iter().filter(|root| root.is_dir()).count(),
+                skill_count = catalog.skills().len(),
+                warning_count = catalog.warnings().len(),
+                skill_names = ?skill_names,
+                "runtime skill catalog loaded"
+            );
+        }
+        let mut runtime_builder = Runtime::builder(session_id.clone())
+            .automatic_compaction(automatic_compaction)
+            .model_provider(Arc::clone(&provider), model.clone());
+        if matches!(variant, CodingRuntimeVariant::FullCoding) {
+            runtime_builder = runtime_builder.coordinator_plan_tools();
+        }
+
+        let mut profile_builder: CodingAgentProfileBuilder = coding_agent(&root)
+            .readonly_resource_roots(skill_roots.clone())
+            .allow_hidden(allow_hidden_workspace_paths)
+            .limits(workspace_tool_limits)
+            .register_tools(extra_tools);
+        if let Some(project_rules) = project_rules {
+            profile_builder = profile_builder.project_rules(project_rules);
+        }
+        if let Some(skill_catalog) = skill_catalog {
+            profile_builder = profile_builder.skill_catalog(skill_catalog);
+        }
+        if let Some(policy) = retry_policy {
+            profile_builder = profile_builder.retry_policy(policy);
+        }
+
+        let mut profile_tools = Vec::new();
+        if matches!(variant, CodingRuntimeVariant::FullCoding) {
+            let process_backend =
+                process_backend.ok_or(CodingRuntimeBuildError::MissingProcessBackend)?;
+            let process_session = process_backend.new_session();
+            profile_builder = profile_builder
+                .patch_tool()
+                .accepted_process_session(process_session);
+
+            if subagents.is_installed() {
+                tracing::info!(
+                    event = "runtime.subagents.enabled",
+                    session_id = %session_id,
+                    enabled = subagents.is_enabled(),
+                    max_threads = subagents.limits().max_threads(),
+                    max_depth = subagents.limits().max_depth(),
+                    max_model_turns = subagents.limits().max_model_turns(),
+                    "runtime subagent tools installed"
+                );
+                let composition = CodingRuntimeComposition {
+                    profile_builder: profile_builder.clone(),
+                    provider: Arc::clone(&provider),
+                    model: model.clone(),
+                    process_backend,
+                    subagent_config: subagents.limits(),
+                    automatic_compaction,
+                    policy: policy.clone(),
+                };
+                let child_factory: Arc<dyn ChildRuntimeFactory> =
+                    Arc::new(CodingChildRuntimeFactory::from_composition(composition));
+                let manager = SubagentManager::runtime_controlled(
+                    session_id.clone(),
+                    subagents.limits(),
+                    child_factory,
+                    subagents.is_enabled(),
+                );
+                let [spawn_tool, wait_tool, cancel_tool] =
+                    subagent_registered_tools(manager.clone())?;
+                runtime_builder = runtime_builder.subagent_manager(manager);
+                profile_tools.extend([spawn_tool, wait_tool, cancel_tool]);
+            }
+        }
+
+        let profile = profile_builder.register_tools(profile_tools).build()?;
+        runtime_builder = profile
+            .apply_to(runtime_builder)
+            .map_err(|source| CodingRuntimeBuildError::RuntimeProfileApply { source })?;
+        runtime_builder = policy.apply_to(runtime_builder);
+
+        Ok((runtime_builder, profile))
+    }
+}
+
+/// A built parent coding runtime and the policy that governs its loop.
+pub struct CodingRuntime {
+    runtime: Runtime,
+    profile: CodingAgentProfile,
+    loop_config: AgentLoopConfig,
+}
+
+impl CodingRuntime {
+    /// Borrows the runtime state handle owned by this composition result.
+    #[must_use]
+    pub fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
+
+    /// Consumes the composition result and returns its runtime handle.
+    #[must_use]
+    pub fn into_runtime(self) -> Runtime {
+        self.runtime
+    }
+
+    /// Borrows the shared coding profile used by this runtime.
+    #[must_use]
+    pub fn profile(&self) -> &CodingAgentProfile {
+        &self.profile
+    }
+
+    /// Clones the loop configuration derived from the shared coding profile.
+    #[must_use]
+    pub fn loop_config(&self) -> AgentLoopConfig {
+        self.loop_config.clone()
+    }
+}
+
+/// Errors raised while composing a parent coding runtime.
+#[derive(Debug, Error)]
+pub enum CodingRuntimeBuildError {
+    /// A full coding runtime was requested without its process backend.
+    #[error("full coding runtime requires a process backend")]
+    MissingProcessBackend,
+    /// A role was configured more than once.
+    #[error("coding model role {role:?} was configured more than once")]
+    DuplicateModelRole { role: RuntimeModelRole },
+    /// A provider-neutral protocol value failed validation.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+    /// Project rules could not be loaded safely.
+    #[error(transparent)]
+    ProjectRules(#[from] ProjectRulesLoadError),
+    /// The skill catalog could not be loaded.
+    #[error(transparent)]
+    SkillCatalog(#[from] SkillError),
+    /// The coding profile was invalid.
+    #[error(transparent)]
+    CodingProfile(#[from] CodingAgentProfileBuildError),
+    /// The profile's coding loop policy was invalid.
+    #[error(transparent)]
+    LoopConfig(#[from] AgentLoopConfigError),
+    /// Applying the profile to the runtime builder failed.
+    #[error("failed to apply coding profile to runtime builder: {source}")]
+    RuntimeProfileApply { source: RuntimeError },
+    /// Runtime construction or resume failed.
+    #[error("failed to build coding runtime: {source}")]
+    RuntimeBuild { source: RuntimeError },
+}

--- a/crates/merry-coding/src/tests.rs
+++ b/crates/merry-coding/src/tests.rs
@@ -1,13 +1,32 @@
 use super::*;
-use merry_core::{ToolInputSchema, ToolName, ToolSpec};
-use merry_llm::ModelRetryPolicy;
-use merry_process::{ProcessSession, TokioProcessRunner};
+use crate::runtime::CodingRuntimePolicy;
+use futures_util::stream;
+use merry_core::{
+    ProviderName, SessionId, SubagentActivityPhase, ToolInputSchema, ToolName, ToolSpec,
+};
+use merry_llm::{
+    FinishReason, ModelCapabilities, ModelError, ModelEvent, ModelEventStream, ModelName,
+    ModelOutput, ModelProvider, ModelProviderFuture, ModelRequest, ModelResponse, ModelRetryPolicy,
+    ModelStreamContext, ModelToolCall, ModelToolCallId, ProviderErrorKind, ToolArguments,
+    testing::FakeModelProvider,
+};
+use merry_process::{LocalProcessBackend, ProcessSession, TokioProcessRunner};
 use merry_runtime::{
-    AcceptedLocalWorkspaceProcessAdmission, PermissionedProcessRunnerFactory, ProcessRunner,
-    RegisteredTool, StaticPermissionedProcessRunnerFactory,
+    AcceptedLocalWorkspaceProcessAdmission, AgentLoopConfig, AgentLoopStatus,
+    PermissionAdmissionContext, PermissionAdmissionDecision, PermissionAdmissionFuture,
+    PermissionAdmissionSource, PermissionedProcessRunnerFactory, ProcessRunner, RegisteredTool,
+    RuntimeModelRole, StaticPermissionedProcessRunnerFactory, StepContext, StepInput,
+    SubagentConfig,
 };
 use schemars::Schema;
 use serde_json::json;
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 fn bridge_tool(name: &str) -> RegisteredTool {
     bridge_tool_with_description(name, "Test bridge tool")
@@ -290,4 +309,559 @@ fn workspace_profile_can_enable_patch_tool() {
             .iter()
             .any(|tool| tool.spec().name().as_str() == "workspace_patch")
     );
+}
+
+fn completing_provider() -> Arc<FakeModelProvider> {
+    Arc::new(FakeModelProvider::new(vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(vec![ModelOutput::text("done")], FinishReason::Stop, None),
+    })]))
+}
+
+fn process_backend() -> Arc<dyn merry_process::ProcessBackend> {
+    let runner: Arc<dyn ProcessRunner> = Arc::new(TokioProcessRunner::new());
+    let session = process_session(
+        AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+        runner,
+    );
+    Arc::new(LocalProcessBackend::from_session(session))
+}
+
+#[derive(Clone)]
+struct ParentChildProvider {
+    name: ProviderName,
+    capabilities: ModelCapabilities,
+    state: Arc<Mutex<ParentChildProviderState>>,
+}
+
+struct ParentChildProviderState {
+    parent_turns: usize,
+    child_turns: usize,
+    requests: Vec<ModelRequest>,
+}
+
+impl ParentChildProvider {
+    fn new() -> Self {
+        Self {
+            name: ProviderName::new("parent-child-provider")
+                .expect("provider name should be valid"),
+            capabilities: ModelCapabilities::new(true, true, false, true, None, None)
+                .expect("provider capabilities should be valid"),
+            state: Arc::new(Mutex::new(ParentChildProviderState {
+                parent_turns: 0,
+                child_turns: 0,
+                requests: Vec::new(),
+            })),
+        }
+    }
+
+    fn recorded_requests(&self) -> Vec<ModelRequest> {
+        self.state
+            .lock()
+            .expect("provider state should not be poisoned")
+            .requests
+            .clone()
+    }
+}
+
+impl ModelProvider for ParentChildProvider {
+    fn name(&self) -> &ProviderName {
+        &self.name
+    }
+
+    fn capabilities(&self) -> &ModelCapabilities {
+        &self.capabilities
+    }
+
+    fn stream_model<'a>(
+        &'a self,
+        request: ModelRequest,
+        _context: ModelStreamContext,
+    ) -> ModelProviderFuture<'a, Result<ModelEventStream, ModelError>> {
+        Box::pin(async move {
+            let is_child = request.messages().iter().any(|message| {
+                message
+                    .content()
+                    .as_text()
+                    .contains("Run the child permission task.")
+            });
+            let event = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("provider state should not be poisoned");
+                state.requests.push(request);
+                if is_child {
+                    let event = if state.child_turns == 0 {
+                        permission_call_event()
+                    } else {
+                        completed_text("child done")
+                    };
+                    state.child_turns += 1;
+                    event
+                } else {
+                    let event = if state.parent_turns == 0 {
+                        spawn_child_event()
+                    } else {
+                        completed_text("parent done")
+                    };
+                    state.parent_turns += 1;
+                    event
+                }
+            };
+            Ok(Box::pin(stream::iter(vec![Ok(event)])) as ModelEventStream)
+        })
+    }
+}
+
+fn completed_text(text: &str) -> ModelEvent {
+    ModelEvent::Completed {
+        response: ModelResponse::new(vec![ModelOutput::text(text)], FinishReason::Stop, None),
+    }
+}
+
+fn spawn_child_event() -> ModelEvent {
+    let call = ModelToolCall::new(
+        ModelToolCallId::new("parent-spawn-child").expect("call id should be valid"),
+        ToolName::new("spawn_subagents").expect("tool name should be valid"),
+        ToolArguments::try_from(json!({
+            "tasks": [{
+                "task": "Run the child permission task.",
+                "max_model_turns": 2,
+                "allowed_tools": ["request_permissions"],
+                "write_scope": []
+            }]
+        }))
+        .expect("spawn arguments should be valid"),
+    );
+    ModelEvent::Completed {
+        response: ModelResponse::new(
+            vec![ModelOutput::tool_call(call)],
+            FinishReason::ToolCalls,
+            None,
+        ),
+    }
+}
+
+fn permission_call_event() -> ModelEvent {
+    let call = ModelToolCall::new(
+        ModelToolCallId::new("child-permission-call").expect("call id should be valid"),
+        ToolName::new("request_permissions").expect("tool name should be valid"),
+        ToolArguments::try_from(json!({
+            "reason": "Run the exact child command.",
+            "requested": {"network": true},
+            "for_action": {
+                "command": "printf child-permission",
+                "cwd": "."
+            }
+        }))
+        .expect("permission arguments should be valid"),
+    );
+    ModelEvent::Completed {
+        response: ModelResponse::new(
+            vec![ModelOutput::tool_call(call)],
+            FinishReason::ToolCalls,
+            None,
+        ),
+    }
+}
+
+fn approval_event() -> ModelEvent {
+    completed_text(
+        r#"{"schema_version":"permission_review.v1","decision":"approve","risk":"low","user_authorization":"high","rationale":"The child task authorizes this exact command."}"#,
+    )
+}
+
+#[derive(Clone)]
+struct CountingAdmission {
+    calls: Arc<AtomicUsize>,
+}
+
+impl CountingAdmission {
+    fn approving() -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl PermissionAdmissionSource for CountingAdmission {
+    fn review<'a>(
+        &'a self,
+        _request: merry_runtime::PermissionRequest,
+        _context: PermissionAdmissionContext,
+    ) -> PermissionAdmissionFuture<'a> {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(PermissionAdmissionDecision::approved("host approved"))
+        })
+    }
+}
+
+async fn run_parent_child_policy(
+    session_id: &str,
+    permission: CodingPermissionPolicy,
+    model_roles: Vec<CodingModelRoleConfig>,
+) -> Arc<ParentChildProvider> {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let primary = Arc::new(ParentChildProvider::new());
+    let input = CodingRuntimeInput::new(
+        SessionId::new(session_id).expect("session id should be valid"),
+        temp.path(),
+        primary.clone(),
+        ModelName::new("parent-primary").expect("primary model should be valid"),
+        process_backend(),
+    )
+    .with_automatic_compaction(merry_runtime::AutomaticCompactionConfig::disabled())
+    .with_retry_policy(ModelRetryPolicy::disabled())
+    .with_model_roles(model_roles)
+    .with_subagents(CodingSubagentsConfig::enabled(
+        SubagentConfig::new(1, 1).expect("subagent limits should be valid"),
+    ));
+    let coding_runtime = CodingRuntimeBuilder::new(input)
+        .permission_policy(permission)
+        .build()
+        .expect("parent coding runtime should build");
+    let mut activity = coding_runtime.runtime().subscribe_subagent_activity();
+
+    let result = coding_runtime
+        .runtime()
+        .run_agent_loop(
+            StepInput::user_text("Delegate the child permission task.")
+                .expect("input should be valid"),
+            StepContext::default(),
+            AgentLoopConfig::new(3).expect("loop config should be valid"),
+        )
+        .await
+        .expect("parent loop should complete");
+    assert_eq!(result.status(), &AgentLoopStatus::Completed);
+
+    let snapshots = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let snapshots = activity.borrow_and_update().clone();
+            if snapshots
+                .iter()
+                .any(|snapshot| matches!(snapshot.phase, SubagentActivityPhase::Completed))
+            {
+                break snapshots;
+            }
+            assert!(
+                !snapshots.iter().any(|snapshot| {
+                    matches!(
+                        snapshot.phase,
+                        SubagentActivityPhase::Failed | SubagentActivityPhase::Cancelled
+                    )
+                }),
+                "child runtime should not terminate unsuccessfully: {snapshots:?}"
+            );
+            activity
+                .changed()
+                .await
+                .expect("subagent activity stream should remain open");
+        }
+    })
+    .await
+    .expect("child runtime should complete before timeout");
+    assert!(
+        snapshots
+            .iter()
+            .any(|snapshot| matches!(snapshot.phase, SubagentActivityPhase::Completed))
+    );
+    primary
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn parent_builder_composes_full_coding_runtime_and_loop_policy() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let provider = completing_provider();
+    let provider_input: Arc<dyn ModelProvider> = provider.clone();
+    let model = ModelName::new("debug-model").expect("model name should be valid");
+    let subagents = CodingSubagentsConfig::enabled(
+        SubagentConfig::new(2, 1).expect("subagent limits should be valid"),
+    );
+    let input = CodingRuntimeInput::new(
+        SessionId::new("coding-parent-builder").expect("session id should be valid"),
+        temp.path(),
+        provider_input.clone(),
+        model.clone(),
+        process_backend(),
+    )
+    .with_automatic_compaction(merry_runtime::AutomaticCompactionConfig::disabled())
+    .with_retry_policy(ModelRetryPolicy::disabled())
+    .with_model_role(
+        CodingModelRoleConfig::new(RuntimeModelRole::ContextCompaction, provider_input, model)
+            .expect("secondary model role should be valid"),
+    )
+    .with_subagents(subagents);
+
+    let coding_runtime = CodingRuntimeBuilder::new(input)
+        .build()
+        .expect("full coding runtime should build");
+    assert_eq!(
+        coding_runtime.loop_config().max_model_turns(),
+        DEFAULT_CODING_AGENT_MAX_MODEL_TURNS
+    );
+    let tool_names = coding_runtime
+        .profile()
+        .tool_names()
+        .into_iter()
+        .map(ToolName::as_str)
+        .collect::<Vec<_>>();
+    for tool in [
+        "run_process",
+        "request_permissions",
+        "workspace_patch",
+        "spawn_subagents",
+        "wait_subagents",
+        "cancel_subagents",
+    ] {
+        assert!(tool_names.contains(&tool), "missing composed tool {tool}");
+    }
+
+    let loop_config = coding_runtime.loop_config();
+    let result = coding_runtime
+        .runtime()
+        .run_agent_loop(
+            StepInput::user_text("Inspect the workspace.").expect("input should be valid"),
+            StepContext::default(),
+            loop_config,
+        )
+        .await
+        .expect("coding loop should complete");
+    assert!(matches!(
+        result.status(),
+        merry_runtime::AgentLoopStatus::Completed
+    ));
+    assert_eq!(provider.recorded_requests().len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn parent_builder_passes_policy_to_a_real_child_runtime() {
+    let approval = Arc::new(FakeModelProvider::new(vec![Ok(approval_event())]));
+    let approval_role = CodingModelRoleConfig::new(
+        RuntimeModelRole::ApprovalReview,
+        approval.clone(),
+        ModelName::new("child-approval").expect("approval model should be valid"),
+    )
+    .expect("approval role should be valid");
+    let primary = run_parent_child_policy(
+        "coding-parent-child-policy",
+        CodingPermissionPolicy::required(),
+        vec![approval_role],
+    )
+    .await;
+    assert_eq!(approval.recorded_requests().len(), 1);
+    assert_eq!(
+        approval.recorded_requests()[0].model().as_str(),
+        "child-approval"
+    );
+    assert!(primary.recorded_requests().len() >= 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn parent_builder_passes_host_admission_to_a_real_child_runtime() {
+    let host = CountingAdmission::approving();
+    let primary = run_parent_child_policy(
+        "coding-parent-child-host-policy",
+        CodingPermissionPolicy::host_decision_only(Arc::new(host.clone())),
+        Vec::new(),
+    )
+    .await;
+    assert_eq!(host.calls(), 1);
+    assert!(primary.recorded_requests().len() >= 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn parent_builder_passes_model_fallback_to_a_real_child_runtime() {
+    let approval = Arc::new(FakeModelProvider::new(vec![Err(ModelError::provider(
+        ProviderErrorKind::Unavailable,
+        "approval provider unavailable",
+    ))]));
+    let approval_role = CodingModelRoleConfig::new(
+        RuntimeModelRole::ApprovalReview,
+        approval.clone(),
+        ModelName::new("child-approval-fallback").expect("approval fallback model should be valid"),
+    )
+    .expect("approval role should be valid");
+    let host = CountingAdmission::approving();
+    let primary = run_parent_child_policy(
+        "coding-parent-child-fallback-policy",
+        CodingPermissionPolicy::model_then_host_fallback(Arc::new(host.clone())),
+        vec![approval_role],
+    )
+    .await;
+
+    assert_eq!(approval.recorded_requests().len(), 1);
+    assert_eq!(host.calls(), 1);
+    assert!(primary.recorded_requests().len() >= 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn parent_builder_passes_fully_trusted_to_a_real_child_runtime() {
+    let approval = Arc::new(FakeModelProvider::new(vec![Err(ModelError::provider(
+        ProviderErrorKind::Unavailable,
+        "approval provider must not be called",
+    ))]));
+    let approval_role = CodingModelRoleConfig::new(
+        RuntimeModelRole::ApprovalReview,
+        approval.clone(),
+        ModelName::new("child-approval-trusted").expect("trusted approval model should be valid"),
+    )
+    .expect("approval role should be valid");
+    let primary = run_parent_child_policy(
+        "coding-parent-child-trusted-policy",
+        CodingPermissionPolicy::fully_trusted(),
+        vec![approval_role],
+    )
+    .await;
+
+    assert!(approval.recorded_requests().is_empty());
+    assert!(primary.recorded_requests().len() >= 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn command_generation_builder_is_read_only_even_with_full_policy_inputs() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let provider = completing_provider();
+    let model = ModelName::new("debug-model").expect("model name should be valid");
+    let input = CodingRuntimeInput::new(
+        SessionId::new("coding-command-builder").expect("session id should be valid"),
+        temp.path(),
+        provider.clone(),
+        model,
+        process_backend(),
+    )
+    .with_subagents(CodingSubagentsConfig::enabled(
+        SubagentConfig::new(2, 1).expect("subagent limits should be valid"),
+    ));
+
+    let coding_runtime = CodingRuntimeBuilder::for_command_generation(input)
+        .build()
+        .expect("command generation runtime should build");
+    let tool_names = coding_runtime
+        .profile()
+        .tool_names()
+        .into_iter()
+        .map(ToolName::as_str)
+        .collect::<Vec<_>>();
+    assert!(tool_names.contains(&"workspace_read_file"));
+    for tool in [
+        "run_process",
+        "request_permissions",
+        "workspace_patch",
+        "spawn_subagents",
+        "wait_subagents",
+        "cancel_subagents",
+    ] {
+        assert!(
+            !tool_names.contains(&tool),
+            "read-only runtime exposed {tool}"
+        );
+    }
+
+    let result = coding_runtime
+        .runtime()
+        .run_agent_loop(
+            StepInput::user_text("Describe the workspace.").expect("input should be valid"),
+            StepContext::default(),
+            coding_runtime.loop_config(),
+        )
+        .await
+        .expect("read-only loop should complete");
+    assert!(matches!(
+        result.status(),
+        merry_runtime::AgentLoopStatus::Completed
+    ));
+}
+
+#[test]
+fn full_builder_rejects_missing_process_backend() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let provider = completing_provider();
+    let input = CodingRuntimeInput::read_only(
+        SessionId::new("coding-missing-process").expect("session id should be valid"),
+        temp.path(),
+        provider,
+        ModelName::new("debug-model").expect("model name should be valid"),
+    );
+
+    let error = match CodingRuntimeBuilder::new(input).build() {
+        Ok(_) => panic!("full coding runtime must require a process backend"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        CodingRuntimeBuildError::MissingProcessBackend
+    ));
+}
+
+#[test]
+fn coding_runtime_policy_rejects_duplicate_model_roles_at_its_boundary() {
+    let provider: Arc<dyn ModelProvider> = completing_provider();
+    let model = ModelName::new("debug-model").expect("model name should be valid");
+    let role = CodingModelRoleConfig::new(
+        RuntimeModelRole::ContextCompaction,
+        Arc::clone(&provider),
+        model,
+    )
+    .expect("secondary model role should be valid");
+
+    let error = match CodingRuntimePolicy::try_new(
+        vec![role.clone(), role],
+        CodingPermissionPolicy::default(),
+    ) {
+        Ok(_) => panic!("duplicate model roles must be rejected by the policy owner"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        CodingRuntimeBuildError::DuplicateModelRole {
+            role: RuntimeModelRole::ContextCompaction
+        }
+    ));
+}
+
+#[test]
+fn parent_builder_rejects_ambiguous_model_roles() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let provider = completing_provider();
+    let provider_input: Arc<dyn ModelProvider> = provider.clone();
+    let model = ModelName::new("debug-model").expect("model name should be valid");
+    let role = CodingModelRoleConfig::new(
+        RuntimeModelRole::ContextCompaction,
+        provider_input.clone(),
+        model.clone(),
+    )
+    .expect("secondary model role should be valid");
+    let duplicate_input = CodingRuntimeInput::read_only(
+        SessionId::new("coding-duplicate-role").expect("session id should be valid"),
+        temp.path(),
+        provider_input.clone(),
+        model.clone(),
+    )
+    .with_model_roles([role.clone(), role]);
+    let duplicate_error =
+        match CodingRuntimeBuilder::for_command_generation(duplicate_input).build() {
+            Ok(_) => panic!("duplicate model roles must be rejected"),
+            Err(error) => error,
+        };
+    assert!(matches!(
+        duplicate_error,
+        CodingRuntimeBuildError::DuplicateModelRole {
+            role: RuntimeModelRole::ContextCompaction
+        }
+    ));
+
+    let primary_error = match CodingModelRoleConfig::new(RuntimeModelRole::Primary, provider, model)
+    {
+        Ok(_) => panic!("primary role must be rejected at construction"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        primary_error,
+        CodingModelRoleConfigError::PrimaryRole
+    ));
 }

--- a/crates/merry-process/src/process_runner.rs
+++ b/crates/merry-process/src/process_runner.rs
@@ -1932,11 +1932,11 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "/workspace/merry", "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "cargo test", "cwd": "." }
+            "for_action": { "command": "cargo test", "cwd": "." }
         }));
         let request_with_network = permission_request(json!({
             "requested": { "network": true },
-            "for_action": { "kind": "process", "command": "cargo test", "cwd": "." }
+            "for_action": { "command": "cargo test", "cwd": "." }
         }));
 
         let runner_without_network = factory.build_runner(&request_without_network);
@@ -1971,7 +1971,7 @@ mod tests {
                 )]);
         let request = permission_request(json!({
             "requested": { "network": true },
-            "for_action": { "kind": "process", "command": "cargo test", "cwd": "." }
+            "for_action": { "command": "cargo test", "cwd": "." }
         }));
 
         let runner = factory.build_runner(&request);
@@ -1999,7 +1999,7 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "deps/cache", "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "cargo test", "cwd": "." }
+            "for_action": { "command": "cargo test", "cwd": "." }
         }));
 
         let runner = factory.build_runner(&request);
@@ -2039,17 +2039,17 @@ mod tests {
                     { "path": "/var/lib/merry-demo.txt", "access": "ro" }
                 ]
             },
-            "for_action": { "kind": "process", "command": "touch /var/lib/merry-demo.txt", "cwd": null }
+            "for_action": { "command": "touch /var/lib/merry-demo.txt", "cwd": null }
         }));
         let later_request = permission_request(json!({
             "requested": { "network": true },
-            "for_action": { "kind": "process", "command": "cat /var/lib/merry-demo.txt", "cwd": null }
+            "for_action": { "command": "cat /var/lib/merry-demo.txt", "cwd": null }
         }));
         let narrower_request = permission_request(json!({
             "requested": {
                 "paths": [{ "path": "/tmp", "access": "ro" }]
             },
-            "for_action": { "kind": "process", "command": "ls /tmp", "cwd": null }
+            "for_action": { "command": "ls /tmp", "cwd": null }
         }));
 
         let _ = factory.runner_for(&first_request);
@@ -2087,23 +2087,23 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "/tmp", "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "mkdir -p /tmp/work", "cwd": null }
+            "for_action": { "command": "mkdir -p /tmp/work", "cwd": null }
         }));
         let descendant_read_write_request = permission_request(json!({
             "requested": {
                 "paths": [{ "path": "/tmp/hello_world.txt", "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "cat /tmp/hello_world.txt", "cwd": null }
+            "for_action": { "command": "cat /tmp/hello_world.txt", "cwd": null }
         }));
         let descendant_read_only_request = permission_request(json!({
             "requested": {
                 "paths": [{ "path": "/tmp/hello_world.txt", "access": "ro" }]
             },
-            "for_action": { "kind": "process", "command": "cat /tmp/hello_world.txt", "cwd": null }
+            "for_action": { "command": "cat /tmp/hello_world.txt", "cwd": null }
         }));
         let network_request = permission_request(json!({
             "requested": { "network": true },
-            "for_action": { "kind": "process", "command": "curl https://example.invalid", "cwd": null }
+            "for_action": { "command": "curl https://example.invalid", "cwd": null }
         }));
 
         let _ = factory.runner_for(&parent_request);
@@ -2145,7 +2145,7 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "/tmp", "access": "ro" }]
             },
-            "for_action": { "kind": "process", "command": "cat /tmp/hello_world.txt", "cwd": null }
+            "for_action": { "command": "cat /tmp/hello_world.txt", "cwd": null }
         }));
 
         let _ = read_only_factory.runner_for(&read_only_parent_request);
@@ -2173,7 +2173,7 @@ mod tests {
             .with_session_permissions(session_permissions);
         let network_request = permission_request(json!({
             "requested": { "network": true },
-            "for_action": { "kind": "process", "command": "curl https://example.invalid", "cwd": null }
+            "for_action": { "command": "curl https://example.invalid", "cwd": null }
         }));
 
         let _ = factory.runner_for(&network_request);
@@ -2218,13 +2218,13 @@ mod tests {
             "requested": {
                 "paths": [{ "path": external_root_path.clone(), "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "cp a external/out", "cwd": null }
+            "for_action": { "command": "cp a external/out", "cwd": null }
         }));
         let git_request = permission_request(json!({
             "requested": {
                 "paths": [{ "path": external_git_path.clone(), "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "git checkout -- README.md", "cwd": null }
+            "for_action": { "command": "git checkout -- README.md", "cwd": null }
         }));
 
         let _ = factory.runner_for(&parent_request);
@@ -2393,7 +2393,7 @@ mod tests {
                 .with_session_permissions(session_permissions.clone());
         let request = permission_request(json!({
             "requested": { "host_integrations": ["ssh-agent"] },
-            "for_action": { "kind": "process", "command": "ssh -T git@example.test", "cwd": null }
+            "for_action": { "command": "ssh -T git@example.test", "cwd": null }
         }));
 
         factory
@@ -2407,7 +2407,7 @@ mod tests {
             .with_session_permissions(session_permissions);
         let later_request = permission_request(json!({
             "requested": { "paths": [{ "path": ".", "access": "rw" }] },
-            "for_action": { "kind": "process", "command": "ssh -T git@example.test", "cwd": null }
+            "for_action": { "command": "ssh -T git@example.test", "cwd": null }
         }));
         let plan = base_runner
             .plan_for(request_process_intent(&later_request))
@@ -2437,7 +2437,7 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "deps", "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "cargo test", "cwd": "." }
+            "for_action": { "command": "cargo test", "cwd": "." }
         }));
 
         factory
@@ -2484,7 +2484,7 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "secrets/token", "access": "ro" }]
             },
-            "for_action": { "kind": "process", "command": "cat secrets/token", "cwd": null }
+            "for_action": { "command": "cat secrets/token", "cwd": null }
         }));
 
         let error = factory
@@ -2506,7 +2506,7 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "deps/cache", "access": "rw" }]
             },
-            "for_action": { "kind": "process", "command": "cargo test", "cwd": null }
+            "for_action": { "command": "cargo test", "cwd": null }
         }));
 
         let error = factory
@@ -2529,7 +2529,7 @@ mod tests {
                 "paths": [{ "path": "/var/lib/merry-demo.txt", "access": "rw" }],
                 "host_integrations": ["dbus"]
             },
-            "for_action": { "kind": "process", "command": "gh auth status", "cwd": null }
+            "for_action": { "command": "gh auth status", "cwd": null }
         }));
 
         factory
@@ -2550,7 +2550,7 @@ mod tests {
             "requested": {
                 "paths": [{ "path": "secrets/token", "access": "ro" }]
             },
-            "for_action": { "kind": "process", "command": "cat secrets/token", "cwd": null }
+            "for_action": { "command": "cat secrets/token", "cwd": null }
         }));
 
         let runner = factory.runner_for(&request);
@@ -2827,7 +2827,6 @@ mod tests {
                 "paths": [{ "path": ".git", "access": "rw" }]
             },
             "for_action": {
-                "kind": "process",
                 "command": "git config --local user.name Merry",
                 "cwd": null
             }

--- a/crates/merry-runtime/src/permission.rs
+++ b/crates/merry-runtime/src/permission.rs
@@ -1202,11 +1202,6 @@ fn request_permissions_input_schema() -> Result<ToolInputSchema, PermissionAdmis
                 "additionalProperties": false,
                 "description": "The exact process action that will run after admission. It does not grant access to paths that are not listed in requested.",
                 "properties": {
-                    "kind": {
-                        "type": "string",
-                        "enum": ["process"],
-                        "description": "Kind of exact action to run if the request is approved."
-                    },
                     "command": {
                         "type": "string",
                         "minLength": 1,
@@ -1225,7 +1220,7 @@ fn request_permissions_input_schema() -> Result<ToolInputSchema, PermissionAdmis
                         ]
                     }
                 },
-                "required": ["kind", "command", "cwd"]
+                "required": ["command", "cwd"]
             }
         },
         "required": ["requested", "for_action"]
@@ -1248,7 +1243,7 @@ pub(crate) fn permission_invalid_arguments_outcome(
         },
         "guidance": {
             "kind": "permission_request_invalid_arguments",
-            "message": "Fix the request_permissions arguments before retrying. Include requested and for_action, set for_action.kind to \"process\", provide the exact command string and cwd, and request only minimum network/path/host-integration capability. An unmodeled Linux Unix socket may be requested as its exact filesystem path.",
+            "message": "Fix the request_permissions arguments before retrying. Include requested and for_action, provide the exact command string and cwd, and request only minimum network/path/host-integration capability. An unmodeled Linux Unix socket may be requested as its exact filesystem path.",
         }
     });
     ToolExecutionOutcome::failed_json(
@@ -1267,40 +1262,28 @@ fn permissioned_action(
         });
     };
     for key in object.keys() {
-        if key != "kind" && key != "command" && key != "cwd" {
+        if key != "command" && key != "cwd" {
             return Err(PermissionAdmissionError::InvalidArguments {
                 message: format!("unsupported for_action field {key:?}"),
             });
         }
     }
 
-    let Some(Value::String(kind)) = object.get("kind") else {
-        return Err(PermissionAdmissionError::InvalidArguments {
-            message: "for_action.kind must be a string".to_owned(),
-        });
-    };
-    match kind.as_str() {
-        "process" => {
-            let command = command_from_arguments(object.get("command"))?;
-            let argv = crate::process::shell_command_argv(&command);
-            let cwd = cwd_from_arguments(object.get("cwd"))?;
-            let intent = ProcessActionIntent::new(
-                argv,
-                cwd,
-                ProcessEnvPolicy::empty(),
-                None,
-                DEFAULT_PERMISSION_STDOUT_LIMIT_BYTES,
-                DEFAULT_PERMISSION_STDERR_LIMIT_BYTES,
-            )
-            .map_err(|error| PermissionAdmissionError::InvalidArguments {
-                message: error.to_string(),
-            })?;
-            Ok(PermissionedAction::Process(intent))
-        }
-        actual => Err(PermissionAdmissionError::InvalidArguments {
-            message: format!("unsupported for_action.kind {actual:?}"),
-        }),
-    }
+    let command = command_from_arguments(object.get("command"))?;
+    let argv = crate::process::shell_command_argv(&command);
+    let cwd = cwd_from_arguments(object.get("cwd"))?;
+    let intent = ProcessActionIntent::new(
+        argv,
+        cwd,
+        ProcessEnvPolicy::empty(),
+        None,
+        DEFAULT_PERMISSION_STDOUT_LIMIT_BYTES,
+        DEFAULT_PERMISSION_STDERR_LIMIT_BYTES,
+    )
+    .map_err(|error| PermissionAdmissionError::InvalidArguments {
+        message: error.to_string(),
+    })?;
+    Ok(PermissionedAction::Process(intent))
 }
 
 fn requested_capabilities(
@@ -1848,7 +1831,7 @@ mod tests {
             &call(json!({
                 "reason": "Need to fetch dependency metadata",
                 "requested": { "network": true },
-                "for_action": { "kind": "process", "command": "cargo test", "cwd": "." }
+                "for_action": { "command": "cargo test", "cwd": "." }
             })),
             Vec::new(),
         )
@@ -1871,7 +1854,7 @@ mod tests {
                 "requested": {
                     "host_integrations": ["dbus", "ssh-agent"]
                 },
-                "for_action": { "kind": "process", "command": "gh auth status", "cwd": null }
+                "for_action": { "command": "gh auth status", "cwd": null }
             })),
             Vec::new(),
         )
@@ -1900,7 +1883,7 @@ mod tests {
                     "paths": [{ "path": ".config/gh", "access": "ro" }],
                     "host_integrations": ["dbus"]
                 },
-                "for_action": { "kind": "process", "command": "gh issue list", "cwd": null }
+                "for_action": { "command": "gh issue list", "cwd": null }
             })),
             Vec::new(),
         )
@@ -1986,21 +1969,19 @@ mod tests {
         let valid = json!({
             "reason": "Need dependency metadata",
             "requested": { "paths": [{ "path": "/tmp/cache", "access": "ro" }] },
-                "for_action": {
-                    "kind": "process",
-                    "command": "cargo metadata",
-                    "cwd": "."
-                }
+            "for_action": {
+                "command": "cargo metadata",
+                "cwd": "."
+            }
         });
         assert!(validator.is_valid(&valid));
 
         let host_integration_request = json!({
             "requested": { "host_integrations": ["dbus"] },
-                "for_action": {
-                    "kind": "process",
-                    "command": "gh auth status",
-                    "cwd": null
-                }
+            "for_action": {
+                "command": "gh auth status",
+                "cwd": null
+            }
         });
         assert!(validator.is_valid(&host_integration_request));
 
@@ -2012,6 +1993,10 @@ mod tests {
         let mut empty_requested = valid.clone();
         empty_requested["requested"] = json!({});
         assert!(!validator.is_valid(&empty_requested));
+
+        let mut redundant_kind = valid.clone();
+        redundant_kind["for_action"]["kind"] = json!("process");
+        assert!(!validator.is_valid(&redundant_kind));
 
         let mut oversized_reason = valid.clone();
         oversized_reason["reason"] = json!("x".repeat(MAX_PERMISSION_REASON_BYTES + 1));
@@ -2029,7 +2014,7 @@ mod tests {
             &call(json!({
                 "reason": "Need DNS lookup",
                 "requested": { "network": true },
-                "for_action": { "kind": "process", "command": "ping -c 1 baidu.com", "cwd": "" }
+                "for_action": { "command": "ping -c 1 baidu.com", "cwd": "" }
             })),
             Vec::new(),
         )
@@ -2045,7 +2030,7 @@ mod tests {
         let error = permission_request_from_call(
             &call(json!({
                 "requested": {},
-                "for_action": { "kind": "process", "command": "cargo test", "cwd": null }
+                "for_action": { "command": "cargo test", "cwd": null }
             })),
             Vec::new(),
         )
@@ -2064,7 +2049,7 @@ mod tests {
                         { "path": "deps/./", "access": "ro" }
                     ]
                 },
-                "for_action": { "kind": "process", "command": "cargo metadata", "cwd": null }
+                "for_action": { "command": "cargo metadata", "cwd": null }
             })),
             Vec::new(),
         )
@@ -2082,7 +2067,7 @@ mod tests {
         let traversal = permission_request_from_call(
             &call(json!({
                 "requested": { "paths": [{ "path": "../secrets", "access": "ro" }] },
-                "for_action": { "kind": "process", "command": "cat secrets", "cwd": null }
+                "for_action": { "command": "cat secrets", "cwd": null }
             })),
             Vec::new(),
         )
@@ -2097,7 +2082,7 @@ mod tests {
                         { "path": "./deps", "access": "rw" }
                     ]
                 },
-                "for_action": { "kind": "process", "command": "cargo metadata", "cwd": null }
+                "for_action": { "command": "cargo metadata", "cwd": null }
             })),
             Vec::new(),
         )
@@ -2143,7 +2128,7 @@ mod tests {
         let request = permission_request_from_call(
             &call(json!({
                 "requested": { "network": true },
-                "for_action": { "kind": "process", "command": "cargo test", "cwd": null }
+                "for_action": { "command": "cargo test", "cwd": null }
             })),
             Vec::new(),
         )
@@ -2198,7 +2183,7 @@ mod tests {
         let request = permission_request_from_call(
             &call(json!({
                 "requested": { "network": true },
-                "for_action": { "kind": "process", "command": "cargo test", "cwd": null }
+                "for_action": { "command": "cargo test", "cwd": null }
             })),
             Vec::new(),
         )
@@ -2239,7 +2224,7 @@ mod tests {
         let request = permission_request_from_call(
             &call(json!({
                 "requested": { "network": true },
-                "for_action": { "kind": "process", "command": "cargo test", "cwd": null }
+                "for_action": { "command": "cargo test", "cwd": null }
             })),
             Vec::new(),
         )

--- a/crates/merry-runtime/src/runtime/tests/permission_execution.rs
+++ b/crates/merry-runtime/src/runtime/tests/permission_execution.rs
@@ -68,7 +68,8 @@ async fn request_permissions_invalid_arguments_skip_review_and_runner() {
     let guidance_message = payload["guidance"]["message"]
         .as_str()
         .expect("invalid permission request should include guidance message");
-    assert!(guidance_message.contains("for_action.kind"));
+    assert!(guidance_message.contains("provide the exact command string and cwd"));
+    assert!(!guidance_message.contains("set for_action"));
     assert!(!guidance_message.contains("for_action.payload"));
 }
 

--- a/crates/merry-runtime/src/runtime/tests/support/tool_helpers.rs
+++ b/crates/merry-runtime/src/runtime/tests/support/tool_helpers.rs
@@ -53,7 +53,6 @@
                 "reason": reason,
                 "requested": { "network": true },
                 "for_action": {
-                    "kind": "process",
                     "command": command,
                     "cwd": ".",
                 }
@@ -72,7 +71,6 @@
                     "paths": [{ "path": path, "access": access }]
                 },
                 "for_action": {
-                    "kind": "process",
                     "command": "printf '%s\\n' 'hello' > /tmp/hello-work.txt",
                     "cwd": ".",
                 }
@@ -93,7 +91,6 @@
                     ]
                 },
                 "for_action": {
-                    "kind": "process",
                     "command": "cargo test",
                     "cwd": ".",
                 }

--- a/crates/merry/src/profiles/mod.rs
+++ b/crates/merry/src/profiles/mod.rs
@@ -4,7 +4,9 @@ pub use merry_coding::{
     CODING_AGENT_DYNAMIC_CONTEXT_LAYOUT, CODING_AGENT_POLICY_PROMPT, CODING_AGENT_PROFILE_ID,
     CODING_AGENT_STABLE_PREFIX_LAYOUT, CodingAgentProfile, CodingAgentProfileBuildError,
     CodingAgentProfileBuilder, CodingAgentProfileHash, CodingAgentRunPolicy,
-    CodingAgentRunPolicyError, CodingChildRuntimeFactory, CodingFinalReportPolicy,
+    CodingAgentRunPolicyError, CodingFinalReportPolicy, CodingModelRoleConfig,
+    CodingModelRoleConfigError, CodingPermissionPolicy, CodingRuntime, CodingRuntimeBuildError,
+    CodingRuntimeBuilder, CodingRuntimeInput, CodingSubagentsConfig,
     DEFAULT_CODING_AGENT_MAX_MODEL_TURNS, MAX_ROOT_PROJECT_RULES_BYTES, ProjectRulesLoadError,
     ROOT_PROJECT_RULES_FILE, WorkspaceToolLimits, coding_agent, load_root_project_rules,
 };


### PR DESCRIPTION
## Summary

- Add the typed `CodingRuntimeBuilder` parent composition boundary in `merry-coding`.
- Route coding run, TUI, command generation, facade, and child runtime composition through the shared boundary.
- Keep provider, process, permission, runtime, and CLI ownership boundaries explicit; validate duplicate model roles and semantic permission policies at the composition boundary.
- Remove the redundant `request_permissions.for_action.kind` model input field and update all schema, parser, and process fixtures.
- Mark T5 delivery evidence in `ROADMAP.md`.

The read-only command-generation capability-closure follow-up remains explicitly deferred per the approved scope.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `git diff --check`

Closes #14