### PR TITLE
fix(cli): align permission review and provider selection

### DIFF
--- a/crates/merry-cli/src/coding/mod.rs
+++ b/crates/merry-cli/src/coding/mod.rs
@@ -6,7 +6,7 @@ mod sandbox;
 pub(crate) use error::CodingRuntimeError;
 pub(crate) use merry::profiles::{
     CodingModelRoleConfig as RuntimeRoleProviderConfig, CodingPermissionPolicy,
-    CodingSubagentsConfig,
+    CodingSubagentsConfig, CodingTrustMode,
 };
 #[cfg(test)]
 pub(crate) use process::ActionProcessBackend;
@@ -21,8 +21,8 @@ pub(crate) use runtime::build_headless_coding;
 #[cfg(test)]
 pub(crate) use runtime::{CodingRuntimeOptions, build_coding_runtime, resume_headless_coding};
 pub(crate) use runtime::{
-    HeadlessCodingRuntimeInput, build_headless_coding_composition,
-    build_headless_coding_with_policy_composition, resume_headless_coding_composition_with_policy,
+    HeadlessCodingRuntimeInput, build_headless_coding_with_policy_composition,
+    resume_headless_coding_composition_with_policy,
 };
 pub(crate) use sandbox::{coding_agent_process_admission, coding_agent_requires_sandbox_error};
 

--- a/crates/merry-cli/src/coding/process.rs
+++ b/crates/merry-cli/src/coding/process.rs
@@ -1,4 +1,5 @@
 use super::CodingRuntimeError;
+use merry::profiles::CodingProcessBoundary;
 #[cfg(test)]
 use merry_process::ProcessSession;
 use merry_process::{
@@ -29,6 +30,16 @@ impl ProcessExecutionMode {
         match self {
             Self::Unrestricted => ProcessBackendMode::Host,
             Self::InnerOnly | Self::OuterAndInner => ProcessBackendMode::Isolated,
+        }
+    }
+}
+
+impl From<ProcessExecutionMode> for CodingProcessBoundary {
+    fn from(mode: ProcessExecutionMode) -> Self {
+        match mode {
+            ProcessExecutionMode::Unrestricted => Self::Unrestricted,
+            ProcessExecutionMode::InnerOnly => Self::InnerOnly,
+            ProcessExecutionMode::OuterAndInner => Self::OuterAndInner,
         }
     }
 }

--- a/crates/merry-cli/src/coding/runtime.rs
+++ b/crates/merry-cli/src/coding/runtime.rs
@@ -52,6 +52,7 @@ pub(crate) fn build_headless_coding(
     build_headless_coding_composition(input).map(SharedCodingRuntime::into_runtime)
 }
 
+#[cfg(test)]
 pub(crate) fn build_headless_coding_composition(
     input: HeadlessCodingRuntimeInput<'_>,
 ) -> Result<SharedCodingRuntime, CodingRuntimeError> {

--- a/crates/merry-cli/src/config/managed_provider.rs
+++ b/crates/merry-cli/src/config/managed_provider.rs
@@ -2,7 +2,7 @@ use super::{
     ConfigError, XdgPaths,
     provider::{NamedProviderToml, validate_api_key_text, validate_provider_display_name},
 };
-use merry_llm::ModelName;
+use merry_llm::{ModelName, ReasoningEffort};
 use merry_provider_anthropic::AnthropicProviderConfig;
 use merry_provider_openai::{OpenAiProtocol, OpenAiProviderConfig};
 use serde::{Deserialize, Deserializer, Serialize, de};
@@ -120,9 +120,11 @@ pub(crate) struct ManagedProviderDefinition {
     kind: ManagedProviderKind,
     base_url: String,
     protocol: Option<OpenAiProtocol>,
+    reasoning_effort: Option<ReasoningEffort>,
 }
 
 impl ManagedProviderDefinition {
+    #[cfg(test)]
     pub(crate) fn new(
         alias: ProviderAlias,
         display_name: &str,
@@ -130,6 +132,26 @@ impl ManagedProviderDefinition {
         kind: ManagedProviderKind,
         protocol: Option<OpenAiProtocol>,
         base_url: &str,
+    ) -> Result<Self, ConfigError> {
+        Self::with_reasoning_effort(
+            alias,
+            display_name,
+            default_model,
+            kind,
+            protocol,
+            base_url,
+            None,
+        )
+    }
+
+    pub(crate) fn with_reasoning_effort(
+        alias: ProviderAlias,
+        display_name: &str,
+        default_model: ModelName,
+        kind: ManagedProviderKind,
+        protocol: Option<OpenAiProtocol>,
+        base_url: &str,
+        reasoning_effort: Option<ReasoningEffort>,
     ) -> Result<Self, ConfigError> {
         validate_provider_display_name(display_name)?;
         let protocol = match (kind, protocol) {
@@ -166,6 +188,7 @@ impl ManagedProviderDefinition {
             kind,
             base_url: base_url.to_owned(),
             protocol,
+            reasoning_effort,
         })
     }
 
@@ -173,6 +196,9 @@ impl ManagedProviderDefinition {
         NamedProviderToml {
             display_name: Some(self.display_name),
             default_model: Some(self.default_model.as_str().to_owned()),
+            reasoning_effort: self
+                .reasoning_effort
+                .map(|effort| effort.as_str().to_owned()),
             kind: Some(
                 match self.kind {
                     ManagedProviderKind::OpenAiCompatible => "openai-compatible",

--- a/crates/merry-cli/src/config/mod.rs
+++ b/crates/merry-cli/src/config/mod.rs
@@ -1,3 +1,4 @@
+use merry::profiles::NoSandboxReviewMode;
 use merry_runtime::{HostIntegration, PathAccess, PathAccessRule, PathAccessRuleSource};
 use serde::Deserialize;
 use std::{
@@ -74,6 +75,7 @@ impl XdgPaths {
         xdg_config_home: Option<PathBuf>,
         xdg_state_home: Option<PathBuf>,
     ) -> Self {
+        let home = normalize_path_lexically(&home);
         let config_base = absolute_or_default(xdg_config_home, home.join(".config"));
         let state_base = absolute_or_default(xdg_state_home, home.join(".local/state"));
         let config_dir = config_base.join("merry");
@@ -141,10 +143,11 @@ impl XdgPaths {
 }
 
 fn absolute_or_default(value: Option<PathBuf>, default: PathBuf) -> PathBuf {
-    match value {
+    let path = match value {
         Some(path) if path.is_absolute() && !path.as_os_str().is_empty() => path,
         _ => default,
-    }
+    };
+    normalize_path_lexically(&path)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -242,6 +245,15 @@ impl MerryConfig {
 
     pub fn profile(&self) -> Option<&str> {
         self.raw.global.profile.as_deref()
+    }
+
+    pub(crate) fn no_sandbox_review_mode(&self) -> NoSandboxReviewMode {
+        self.raw
+            .permissions
+            .as_ref()
+            .and_then(|permissions| permissions.no_sandbox_review)
+            .map(Into::into)
+            .unwrap_or_default()
     }
 
     /// Returns user-configured path rules for the outer sandbox ceiling.
@@ -520,6 +532,7 @@ struct GlobalToml {
 struct PermissionsToml {
     ssh_agent: Option<bool>,
     dbus: Option<bool>,
+    no_sandbox_review: Option<NoSandboxReviewToml>,
     #[serde(default)]
     readonly_paths: Vec<String>,
     #[serde(default)]
@@ -530,6 +543,22 @@ struct PermissionsToml {
     paths: Vec<PathRuleToml>,
     #[serde(default)]
     environment: Vec<EnvironmentVariableToml>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum NoSandboxReviewToml {
+    Host,
+    Model,
+}
+
+impl From<NoSandboxReviewToml> for NoSandboxReviewMode {
+    fn from(value: NoSandboxReviewToml) -> Self {
+        match value {
+            NoSandboxReviewToml::Host => Self::Host,
+            NoSandboxReviewToml::Model => Self::Model,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
@@ -745,6 +774,23 @@ mod tests {
         assert_eq!(
             paths.default_log_file(),
             Path::new("/tmp/state/merry/logs/merry.jsonl")
+        );
+    }
+
+    #[test]
+    fn xdg_paths_normalize_absolute_environment_values() {
+        let paths = XdgPaths::from_parts(
+            PathBuf::from("/home/alice/../alice"),
+            Some(PathBuf::from("/tmp/config/../config")),
+            Some(PathBuf::from("/tmp/state/./nested/..")),
+        );
+
+        assert_eq!(paths.home(), Path::new("/home/alice"));
+        assert_eq!(paths.config_base_dir(), Path::new("/tmp/config"));
+        assert_eq!(paths.state_base_dir(), Path::new("/tmp/state"));
+        assert_eq!(
+            paths.managed_config_dir(),
+            Path::new("/tmp/config/merry/managed")
         );
     }
 
@@ -1024,6 +1070,26 @@ access = "ro"
                 .iter()
                 .all(|rule| rule.source() == PathAccessRuleSource::TrustedGlobalConfig)
         );
+    }
+
+    #[test]
+    fn configures_model_review_for_no_sandbox_mode() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let model = MerryConfig::load_optional_from_text(
+            Some("[permissions]\nno_sandbox_review = \"model\"\n"),
+            &paths,
+        )
+        .expect("permission review config should parse")
+        .expect("permission review config should exist");
+        assert_eq!(model.no_sandbox_review_mode(), NoSandboxReviewMode::Model);
+
+        let default = MerryConfig::load_optional_from_text(
+            Some("[permissions]\nno_sandbox_review = \"host\"\n"),
+            &paths,
+        )
+        .expect("host review config should parse")
+        .expect("host review config should exist");
+        assert_eq!(default.no_sandbox_review_mode(), NoSandboxReviewMode::Host);
     }
 
     #[test]

--- a/crates/merry-cli/src/config/provider.rs
+++ b/crates/merry-cli/src/config/provider.rs
@@ -62,6 +62,8 @@ impl MerryConfig {
         } else {
             ProviderConfigSource::User
         };
+        let reasoning_effort =
+            parse_provider_reasoning_effort(alias.as_str(), provider.reasoning_effort.as_deref())?;
         let protocol = match kind {
             ConfiguredProviderKind::OpenAiCompatible => Some(provider.protocol.unwrap_or_default()),
             ConfiguredProviderKind::Anthropic => None,
@@ -73,8 +75,41 @@ impl MerryConfig {
             default_model,
             kind,
             protocol,
+            reasoning_effort,
             source,
         })
+    }
+
+    pub(crate) fn provider_reasoning_effort(
+        &self,
+        alias: &str,
+    ) -> Result<Option<ReasoningEffort>, ConfigError> {
+        Ok(self.provider_profile(alias)?.reasoning_effort().cloned())
+    }
+
+    pub(crate) fn effective_provider_reasoning_effort(
+        &self,
+        alias: &str,
+    ) -> Result<Option<ReasoningEffort>, ConfigError> {
+        let default_reasoning_effort = self
+            .raw
+            .providers
+            .as_ref()
+            .and_then(|providers| providers.default.as_ref())
+            .filter(|default| default.provider == alias)
+            .and_then(|default| default.reasoning_effort.as_deref())
+            .map(ReasoningEffort::new)
+            .transpose()
+            .map_err(|error| {
+                ConfigError::Invalid(format!(
+                    "providers.default.reasoning_effort is invalid: {error}"
+                ))
+            })?;
+
+        match default_reasoning_effort {
+            Some(reasoning_effort) => Ok(Some(reasoning_effort)),
+            None => self.provider_reasoning_effort(alias),
+        }
     }
 
     pub fn validate_provider_settings_if_present(&self) -> Result<(), ConfigError> {
@@ -122,17 +157,8 @@ impl MerryConfig {
             .default
             .as_ref()
             .ok_or_else(|| ConfigError::Invalid("[providers.default] is required".to_owned()))?;
-        let reasoning_effort = default
-            .reasoning_effort
-            .as_deref()
-            .map(ReasoningEffort::new)
-            .transpose()
-            .map_err(|error| {
-                ConfigError::Invalid(format!(
-                    "providers.default.reasoning_effort is invalid: {error}"
-                ))
-            })?;
         let provider = self.provider_by_alias(&default.provider)?;
+        let reasoning_effort = self.effective_provider_reasoning_effort(&default.provider)?;
         Ok(EffectiveDefaultProviderConfig {
             alias: default.provider.clone(),
             model: default.model.clone(),
@@ -168,11 +194,13 @@ impl MerryConfig {
             .ok_or_else(|| ConfigError::Invalid(format!("[providers.{alias}] is required")))?;
         let kind = provider.kind.as_deref().unwrap_or(alias);
         let api_key = resolve_api_key_source(alias, provider, &self.config_dir, &self.home)?;
+        let reasoning_effort =
+            parse_provider_reasoning_effort(alias, provider.reasoning_effort.as_deref())?;
         match kind {
             "openai-compatible" => Ok(EffectiveProviderConfig::OpenAiCompatible(
                 EffectiveOpenAiProviderConfig {
                     model: None,
-                    reasoning_effort: None,
+                    reasoning_effort,
                     alias: alias.to_owned(),
                     protocol: provider.protocol.unwrap_or_default(),
                     base_url: provider.base_url.clone(),
@@ -182,6 +210,7 @@ impl MerryConfig {
             "anthropic" => Ok(EffectiveProviderConfig::Anthropic(
                 EffectiveAnthropicProviderConfig {
                     alias: alias.to_owned(),
+                    reasoning_effort,
                     base_url: provider.base_url.clone(),
                     api_version: provider.api_version.clone(),
                     default_max_output_tokens: provider.default_max_output_tokens,
@@ -254,6 +283,20 @@ fn resolve_api_key_source(
     Ok(api_key)
 }
 
+fn parse_provider_reasoning_effort(
+    alias: &str,
+    value: Option<&str>,
+) -> Result<Option<ReasoningEffort>, ConfigError> {
+    value
+        .map(ReasoningEffort::new)
+        .transpose()
+        .map_err(|error| {
+            ConfigError::Invalid(format!(
+                "providers.{alias}.reasoning_effort is invalid: {error}"
+            ))
+        })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EffectiveDefaultProviderConfig {
     pub alias: String,
@@ -281,6 +324,7 @@ pub(crate) struct ConfiguredProviderProfile {
     default_model: Option<ModelName>,
     kind: ConfiguredProviderKind,
     protocol: Option<OpenAiProtocol>,
+    reasoning_effort: Option<ReasoningEffort>,
     source: ProviderConfigSource,
 }
 
@@ -303,6 +347,10 @@ impl ConfiguredProviderProfile {
 
     pub(crate) fn protocol(&self) -> Option<OpenAiProtocol> {
         self.protocol
+    }
+
+    pub(crate) fn reasoning_effort(&self) -> Option<&ReasoningEffort> {
+        self.reasoning_effort.as_ref()
     }
 
     pub(crate) fn source(&self) -> ProviderConfigSource {
@@ -343,6 +391,7 @@ impl fmt::Debug for EffectiveOpenAiProviderConfig {
 #[derive(Clone, PartialEq, Eq)]
 pub struct EffectiveAnthropicProviderConfig {
     pub alias: String,
+    pub reasoning_effort: Option<ReasoningEffort>,
     pub base_url: Option<String>,
     pub api_version: Option<String>,
     pub default_max_output_tokens: Option<u64>,
@@ -354,6 +403,7 @@ impl fmt::Debug for EffectiveAnthropicProviderConfig {
         formatter
             .debug_struct("EffectiveAnthropicProviderConfig")
             .field("alias", &self.alias)
+            .field("reasoning_effort", &self.reasoning_effort)
             .field("base_url", &self.base_url)
             .field("api_version", &self.api_version)
             .field("default_max_output_tokens", &self.default_max_output_tokens)
@@ -432,6 +482,7 @@ pub(super) struct DefaultProviderToml {
 pub(super) struct NamedProviderToml {
     pub(super) display_name: Option<String>,
     pub(super) default_model: Option<String>,
+    pub(super) reasoning_effort: Option<String>,
     #[serde(rename = "type")]
     pub(super) kind: Option<String>,
     pub(super) protocol: Option<OpenAiProtocol>,
@@ -565,6 +616,7 @@ model = "deepseek-v4-pro"
 [providers.opencode]
 display_name = "OpenCode"
 default_model = "deepseek-v4-pro"
+reasoning_effort = "low"
 type = "openai-compatible"
 api_key = "sk-test"
 "#,
@@ -586,6 +638,18 @@ api_key = "sk-test"
         );
         assert_eq!(profile.source(), ProviderConfigSource::User);
         assert_eq!(profile.protocol(), Some(OpenAiProtocol::Responses));
+        assert_eq!(
+            profile.reasoning_effort().map(ReasoningEffort::as_str),
+            Some("low")
+        );
+        let provider = config
+            .provider_by_alias("opencode")
+            .expect("provider should resolve");
+        assert!(matches!(
+            provider,
+            EffectiveProviderConfig::OpenAiCompatible(provider)
+                if provider.reasoning_effort.as_ref().map(ReasoningEffort::as_str) == Some("low")
+        ));
     }
 
     #[test]

--- a/crates/merry-cli/src/headless_review.rs
+++ b/crates/merry-cli/src/headless_review.rs
@@ -1,0 +1,276 @@
+use merry_runtime::{
+    ChannelPermissionAdmissionSource, PermissionReviewRequest, RequestedCapability,
+};
+use std::{io, sync::Arc};
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter},
+    sync::mpsc,
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+pub(crate) struct HeadlessPermissionReviewer {
+    source: Arc<ChannelPermissionAdmissionSource>,
+    requests: mpsc::Receiver<PermissionReviewRequest>,
+    cancellation: CancellationToken,
+}
+
+pub(crate) struct HeadlessPermissionReviewTask {
+    cancellation: CancellationToken,
+    handle: JoinHandle<io::Result<()>>,
+}
+
+impl HeadlessPermissionReviewer {
+    pub(crate) fn new() -> Self {
+        let (source, requests) = ChannelPermissionAdmissionSource::channel(8);
+        Self {
+            source: Arc::new(source),
+            requests,
+            cancellation: CancellationToken::new(),
+        }
+    }
+
+    pub(crate) fn source(&self) -> Arc<ChannelPermissionAdmissionSource> {
+        Arc::clone(&self.source)
+    }
+
+    pub(crate) fn start(self) -> HeadlessPermissionReviewTask {
+        let Self {
+            requests,
+            cancellation,
+            ..
+        } = self;
+        let task_cancellation = cancellation.clone();
+        let handle = tokio::spawn(async move {
+            run_headless_permission_review(requests, task_cancellation).await
+        });
+        HeadlessPermissionReviewTask {
+            cancellation,
+            handle,
+        }
+    }
+}
+
+impl HeadlessPermissionReviewTask {
+    pub(crate) async fn finish(self) -> io::Result<()> {
+        self.cancellation.cancel();
+        match self.handle.await {
+            Ok(result) => result,
+            Err(error) => Err(io::Error::other(format!(
+                "headless permission review task failed: {error}"
+            ))),
+        }
+    }
+}
+
+async fn run_headless_permission_review(
+    mut requests: mpsc::Receiver<PermissionReviewRequest>,
+    cancellation: CancellationToken,
+) -> io::Result<()> {
+    let mut input = BufReader::new(tokio::io::stdin());
+    let mut output = BufWriter::new(tokio::io::stderr());
+
+    loop {
+        let Some(request) = (tokio::select! {
+            biased;
+            () = cancellation.cancelled() => None,
+            request = requests.recv() => request,
+        }) else {
+            return Ok(());
+        };
+
+        if request.is_cancelled() {
+            continue;
+        }
+        review_request(request, &mut input, &mut output, &cancellation).await?;
+    }
+}
+
+async fn review_request<R, W>(
+    request: PermissionReviewRequest,
+    input: &mut R,
+    output: &mut W,
+    cancellation: &CancellationToken,
+) -> io::Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    output
+        .write_all(format_permission_prompt(&request).as_bytes())
+        .await?;
+    output.flush().await?;
+
+    match read_headless_decision(input, output, cancellation).await? {
+        HeadlessDecision::Approve => request
+            .approve("approved by headless command-line review")
+            .map_err(|error| {
+                io::Error::other(format!(
+                    "failed to approve headless permission review: {error}"
+                ))
+            }),
+        HeadlessDecision::Deny => request
+            .deny("denied by headless command-line review")
+            .map_err(|error| {
+                io::Error::other(format!(
+                    "failed to deny headless permission review: {error}"
+                ))
+            }),
+        HeadlessDecision::InputEnded => request
+            .deny("headless permission review input ended; defaulting to deny")
+            .map_err(|error| {
+                io::Error::other(format!(
+                    "failed to deny headless permission review at input EOF: {error}"
+                ))
+            }),
+        HeadlessDecision::Cancelled => {
+            let _ = request.deny("headless permission review was cancelled");
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeadlessDecision {
+    Approve,
+    Deny,
+    InputEnded,
+    Cancelled,
+}
+
+async fn read_headless_decision<R, W>(
+    input: &mut R,
+    output: &mut W,
+    cancellation: &CancellationToken,
+) -> io::Result<HeadlessDecision>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes_read = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => return Ok(HeadlessDecision::Cancelled),
+            result = input.read_line(&mut line) => result?,
+        };
+
+        if bytes_read == 0 {
+            return Ok(HeadlessDecision::InputEnded);
+        }
+
+        match parse_decision(&line) {
+            Some(true) => return Ok(HeadlessDecision::Approve),
+            Some(false) => return Ok(HeadlessDecision::Deny),
+            None => {
+                output.write_all(b"Please answer yes or no [y/N]: ").await?;
+                output.flush().await?;
+            }
+        }
+    }
+}
+
+fn parse_decision(value: &str) -> Option<bool> {
+    let value = value.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("n") || value.eq_ignore_ascii_case("no") {
+        Some(false)
+    } else if value.eq_ignore_ascii_case("y") || value.eq_ignore_ascii_case("yes") {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+fn format_permission_prompt(request: &PermissionReviewRequest) -> String {
+    let permission_request = request.request();
+    let mut lines = vec![format!(
+        "Permission review required ({})",
+        request.approval_id()
+    )];
+    if let Some(failure) = request.review_failure() {
+        lines.push(format!("AI review unavailable: {failure}"));
+    }
+    if let Some(reason) = permission_request.reason() {
+        lines.push(format!("reason: {reason}"));
+    }
+    if permission_request.is_action_review() {
+        lines.push("review: high-risk process action".to_owned());
+    }
+    lines.push(format!("action: {}", permission_request.action().summary()));
+    for capability in permission_request.requested() {
+        let line = match capability {
+            RequestedCapability::Network => "requested: network".to_owned(),
+            RequestedCapability::Path(path) => {
+                format!(
+                    "requested: path {} ({})",
+                    path.path(),
+                    path.access().as_str()
+                )
+            }
+            RequestedCapability::HostIntegration(integration) => {
+                format!("requested: host integration {}", integration.as_str())
+            }
+        };
+        lines.push(line);
+    }
+    lines.push("Allow? [y/N] ".to_owned());
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HeadlessDecision, parse_decision, read_headless_decision};
+    use std::io::Cursor;
+    use tokio::io::BufReader;
+    use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn command_line_decision_defaults_to_deny() {
+        assert_eq!(parse_decision(""), Some(false));
+        assert_eq!(parse_decision("n"), Some(false));
+        assert_eq!(parse_decision("NO"), Some(false));
+        assert_eq!(parse_decision("y"), Some(true));
+        assert_eq!(parse_decision("Yes"), Some(true));
+        assert_eq!(parse_decision("maybe"), None);
+    }
+
+    #[tokio::test]
+    async fn command_line_review_reprompts_invalid_input_then_accepts() {
+        let cancellation = CancellationToken::new();
+        let mut input = BufReader::new(Cursor::new(b"maybe\nyes\n".to_vec()));
+        let mut output = Vec::new();
+
+        let decision = read_headless_decision(&mut input, &mut output, &cancellation)
+            .await
+            .expect("headless input should be readable");
+
+        assert_eq!(decision, HeadlessDecision::Approve);
+        assert_eq!(
+            String::from_utf8(output).expect("prompt output should be UTF-8"),
+            "Please answer yes or no [y/N]: "
+        );
+    }
+
+    #[tokio::test]
+    async fn command_line_review_defaults_to_deny_at_eof_and_honors_cancellation() {
+        let cancellation = CancellationToken::new();
+        let mut input = BufReader::new(Cursor::new(Vec::<u8>::new()));
+        let mut output = Vec::new();
+        assert_eq!(
+            read_headless_decision(&mut input, &mut output, &cancellation)
+                .await
+                .expect("EOF should be handled"),
+            HeadlessDecision::InputEnded
+        );
+
+        cancellation.cancel();
+        let mut input = BufReader::new(Cursor::new(b"yes\n".to_vec()));
+        assert_eq!(
+            read_headless_decision(&mut input, &mut output, &cancellation)
+                .await
+                .expect("cancellation should be handled"),
+            HeadlessDecision::Cancelled
+        );
+    }
+}

--- a/crates/merry-cli/src/main.rs
+++ b/crates/merry-cli/src/main.rs
@@ -8,6 +8,7 @@ mod cmd;
 mod coding;
 mod config;
 mod debug;
+mod headless_review;
 mod mcp_tools;
 mod observability;
 mod provider_config;

--- a/crates/merry-cli/src/provider_management.rs
+++ b/crates/merry-cli/src/provider_management.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use merry_llm::{
     ModelCatalog, ModelCatalogEntry, ModelCatalogError, ModelCatalogProvider, ModelName,
+    ReasoningEffort,
 };
 use merry_provider_anthropic::{AnthropicProvider, AnthropicProviderConfig};
 use merry_provider_openai::{OpenAiProvider, OpenAiProviderConfig};
@@ -37,6 +38,7 @@ pub(crate) struct ProviderDraft {
     protocol: Option<merry_provider_openai::OpenAiProtocol>,
     base_url: String,
     api_key: Option<SecretString>,
+    reasoning_effort: Option<ReasoningEffort>,
     default_model: ModelName,
 }
 
@@ -136,13 +138,14 @@ impl ProviderDraft {
         api_key: &str,
         default_model: ModelName,
     ) -> Result<Self, ProviderManagementError> {
-        let _ = ManagedProviderDefinition::new(
+        let _ = ManagedProviderDefinition::with_reasoning_effort(
             alias.clone(),
             display_name,
             default_model.clone(),
             kind,
             protocol,
             base_url,
+            None,
         )?;
         Ok(Self {
             display_name: display_name.to_owned(),
@@ -151,6 +154,7 @@ impl ProviderDraft {
             protocol,
             base_url: base_url.to_owned(),
             api_key: Some(SecretString::new(api_key)?),
+            reasoning_effort: None,
             default_model,
         })
     }
@@ -164,13 +168,14 @@ impl ProviderDraft {
         api_key: Option<&str>,
         default_model: ModelName,
     ) -> Result<Self, ProviderManagementError> {
-        let _ = ManagedProviderDefinition::new(
+        let _ = ManagedProviderDefinition::with_reasoning_effort(
             alias.clone(),
             display_name,
             default_model.clone(),
             kind,
             protocol,
             base_url,
+            None,
         )?;
         Ok(Self {
             display_name: display_name.to_owned(),
@@ -179,12 +184,43 @@ impl ProviderDraft {
             protocol,
             base_url: base_url.to_owned(),
             api_key: api_key.map(SecretString::new).transpose()?,
+            reasoning_effort: None,
             default_model,
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_reasoning_effort(
+        mut self,
+        reasoning_effort: Option<ReasoningEffort>,
+    ) -> Self {
+        self.reasoning_effort = reasoning_effort;
+        self
+    }
+
+    pub(crate) fn with_reasoning_effort_text(
+        mut self,
+        value: &str,
+    ) -> Result<Self, ProviderManagementError> {
+        let value = value.trim();
+        self.reasoning_effort = if value.is_empty() {
+            None
+        } else {
+            Some(ReasoningEffort::new(value).map_err(|error| {
+                ProviderManagementError::Invalid(format!(
+                    "provider reasoning effort is invalid: {error}"
+                ))
+            })?)
+        };
+        Ok(self)
+    }
+
     pub(crate) fn alias(&self) -> &ProviderAlias {
         &self.alias
+    }
+
+    pub(crate) fn reasoning_effort(&self) -> Option<&ReasoningEffort> {
+        self.reasoning_effort.as_ref()
     }
 }
 
@@ -206,6 +242,7 @@ impl fmt::Debug for ProviderDraft {
                 },
             )
             .field("default_model", &self.default_model)
+            .field("reasoning_effort", &self.reasoning_effort)
             .finish()
     }
 }
@@ -241,6 +278,7 @@ pub(crate) struct EditableProviderProfile {
     pub(crate) kind: ManagedProviderKind,
     pub(crate) protocol: Option<merry_provider_openai::OpenAiProtocol>,
     pub(crate) base_url: String,
+    pub(crate) reasoning_effort: Option<ReasoningEffort>,
     pub(crate) default_model: ModelName,
 }
 
@@ -320,6 +358,7 @@ impl ProviderManagementService {
             kind,
             protocol,
             base_url,
+            reasoning_effort: profile.reasoning_effort().cloned(),
             default_model,
         })
     }
@@ -347,18 +386,20 @@ impl ProviderManagementService {
             protocol,
             base_url,
             api_key,
+            reasoning_effort,
             default_model,
         } = draft;
         let api_key = api_key.ok_or_else(|| {
             ProviderManagementError::Invalid("new managed providers require an API key".to_owned())
         })?;
-        let definition = ManagedProviderDefinition::new(
+        let definition = ManagedProviderDefinition::with_reasoning_effort(
             alias,
             &display_name,
             default_model,
             kind,
             protocol,
             &base_url,
+            reasoning_effort,
         )?;
         self.managed_store
             .upsert(definition, api_key.expose())
@@ -396,15 +437,17 @@ impl ProviderManagementService {
             protocol,
             base_url,
             api_key,
+            reasoning_effort,
             default_model,
         } = draft;
-        let definition = ManagedProviderDefinition::new(
+        let definition = ManagedProviderDefinition::with_reasoning_effort(
             alias,
             &display_name,
             default_model,
             kind,
             protocol,
             &base_url,
+            reasoning_effort,
         )?;
         self.managed_store
             .update(
@@ -995,7 +1038,8 @@ api_key = "sk-user"
                     "sk-retained",
                     ModelName::new("model-a").expect("model"),
                 )
-                .expect("draft"),
+                .expect("draft")
+                .with_reasoning_effort(Some(ReasoningEffort::new("medium").expect("valid effort"))),
             )
             .await
             .expect("provider save");
@@ -1003,6 +1047,13 @@ api_key = "sk-user"
         let editable = service.editable_provider(&alias).expect("editable profile");
         assert_eq!(editable.display_name, "OpenCode");
         assert_eq!(editable.protocol, Some(OpenAiProtocol::ChatCompletions));
+        assert_eq!(
+            editable
+                .reasoning_effort
+                .as_ref()
+                .map(ReasoningEffort::as_str),
+            Some("medium")
+        );
         service
             .update_provider(
                 &alias,
@@ -1015,7 +1066,9 @@ api_key = "sk-user"
                     None,
                     ModelName::new("model-b").expect("model"),
                 )
-                .expect("update draft"),
+                .expect("update draft")
+                .with_reasoning_effort_text("max ultra")
+                .expect("valid custom effort"),
             )
             .await
             .expect("provider update");
@@ -1025,6 +1078,13 @@ api_key = "sk-user"
         assert_eq!(updated.protocol, Some(OpenAiProtocol::Responses));
         assert_eq!(updated.base_url, "https://new.example.test/v1");
         assert_eq!(updated.default_model.as_str(), "model-b");
+        assert_eq!(
+            updated
+                .reasoning_effort
+                .as_ref()
+                .map(ReasoningEffort::as_str),
+            Some("max ultra")
+        );
         assert_eq!(secret_file_count(&paths).await, 1);
         let mut secrets = tokio::fs::read_dir(paths.managed_secrets_dir())
             .await

--- a/crates/merry-cli/src/run.rs
+++ b/crates/merry-cli/src/run.rs
@@ -1,11 +1,11 @@
 use crate::cli_error::{CliError, debug_openai_usage_error, stdout_error, unexpected};
 use crate::coding::{
-    CodingPermissionPolicy, HeadlessCodingRuntimeInput, ProcessExecutionMode,
-    action_process_runner_for_mode, build_headless_coding_composition,
-    build_headless_coding_with_policy_composition, coding_agent_process_admission,
-    coding_agent_requires_sandbox_error,
+    CodingPermissionPolicy, CodingTrustMode, HeadlessCodingRuntimeInput, ProcessExecutionMode,
+    action_process_runner_for_mode, build_headless_coding_with_policy_composition,
+    coding_agent_process_admission, coding_agent_requires_sandbox_error,
 };
 use crate::config::MerryConfig;
+use crate::headless_review::HeadlessPermissionReviewer;
 use crate::mcp_tools::discover_configured_mcp_tools;
 use crate::provider_config::{
     RuntimePrimaryProviderConfig, RuntimeProviderBundle, runtime_provider_bundle_from_config,
@@ -100,25 +100,38 @@ pub(crate) async fn run(
         subagents: subagents_config(merry_config).map_err(unexpected)?.into(),
         workspace_tool_limits: None,
     };
-    let coding_runtime = if fully_trusted {
-        build_headless_coding_with_policy_composition(
-            runtime_input,
-            CodingPermissionPolicy::fully_trusted(),
-        )?
-    } else {
-        build_headless_coding_composition(runtime_input)?
-    };
+    let headless_reviewer = HeadlessPermissionReviewer::new();
+    let permission_policy = CodingPermissionPolicy::for_process_boundary(
+        process_execution_mode.into(),
+        if fully_trusted {
+            CodingTrustMode::FullyTrusted
+        } else {
+            CodingTrustMode::Reviewed
+        },
+        merry_config
+            .map(MerryConfig::no_sandbox_review_mode)
+            .unwrap_or_default(),
+        Some(headless_reviewer.source()),
+    )
+    .map_err(unexpected)?;
+    let coding_runtime =
+        build_headless_coding_with_policy_composition(runtime_input, permission_policy)?;
     let loop_config = coding_runtime.loop_config();
     let runtime = coding_runtime.into_runtime();
     let input = StepInput::user_text(&args.task).map_err(unexpected)?;
     let context = StepContext::default()
         .with_generation_config(generation_config(merry_config).map_err(unexpected)?);
-    if args.events_jsonl {
+    let review_task = headless_reviewer.start();
+    let run_result = if args.events_jsonl {
         write_agent_loop_jsonl_output(&runtime, input, loop_config, context, tokio::io::stdout())
             .await
     } else {
         write_agent_loop_output(&runtime, input, loop_config, context, tokio::io::stdout()).await
-    }
+    };
+    let review_result = review_task.finish().await.map_err(unexpected);
+    let status = run_result?;
+    review_result?;
+    Ok(status)
 }
 
 fn default_run_session_id() -> merry_core::SessionId {

--- a/crates/merry-cli/src/runtime_config.rs
+++ b/crates/merry-cli/src/runtime_config.rs
@@ -230,9 +230,10 @@ api_key_file = "managed/secrets/opencode.key"
 [providers.default]
 provider = "openai-compatible"
 model = "gpt-test"
-reasoning_effort = "low"
+reasoning_effort = "high"
 
 [providers.openai-compatible]
+reasoning_effort = "low"
 api_key = "sk-test"
 "#,
             ),
@@ -245,7 +246,7 @@ api_key = "sk-test"
 
         assert_eq!(
             generation.reasoning_effort().map(|effort| effort.as_str()),
-            Some("low")
+            Some("high")
         );
     }
 

--- a/crates/merry-cli/src/sandbox.rs
+++ b/crates/merry-cli/src/sandbox.rs
@@ -316,11 +316,7 @@ pub(crate) fn maybe_reexec(
     let host = Host::from_env(args)?;
     match plan_bootstrap(with_sandbox, clipboard_access, &host)? {
         Bootstrap::Disabled | Bootstrap::AlreadyInside => Ok(()),
-        Bootstrap::Reexec(plan) => {
-            ensure_host_managed_provider_directories(&host)?;
-            ensure_host_state_directory(&host)?;
-            exec(plan)
-        }
+        Bootstrap::Reexec(plan) => exec(plan),
     }
 }
 
@@ -345,7 +341,13 @@ pub(crate) fn plan_bootstrap(
     clipboard_access: ClipboardAccess,
     host: &Host,
 ) -> Result<Bootstrap, Error> {
-    plan_bootstrap_with_probe(with_sandbox, clipboard_access, host, &FilesystemHostProbe)
+    plan_bootstrap_with_probe_inner(
+        with_sandbox,
+        clipboard_access,
+        host,
+        &FilesystemHostProbe,
+        true,
+    )
 }
 
 #[cfg(test)]
@@ -369,19 +371,31 @@ pub(crate) fn plan_bootstrap_with_file_exists(
         }
     }
 
-    plan_bootstrap_with_probe(
+    plan_bootstrap_with_probe_inner(
         with_sandbox,
         ClipboardAccess::Disabled,
         host,
         &FileExistsProbe(file_exists),
+        false,
     )
 }
 
+#[cfg(test)]
 pub(crate) fn plan_bootstrap_with_probe(
     with_sandbox: bool,
     clipboard_access: ClipboardAccess,
     host: &Host,
     probe: &impl HostPathProbe,
+) -> Result<Bootstrap, Error> {
+    plan_bootstrap_with_probe_inner(with_sandbox, clipboard_access, host, probe, false)
+}
+
+fn plan_bootstrap_with_probe_inner(
+    with_sandbox: bool,
+    clipboard_access: ClipboardAccess,
+    host: &Host,
+    probe: &impl HostPathProbe,
+    prepare_host_writable_dirs: bool,
 ) -> Result<Bootstrap, Error> {
     if !with_sandbox {
         return Ok(Bootstrap::Disabled);
@@ -396,7 +410,16 @@ pub(crate) fn plan_bootstrap_with_probe(
     let path = sandbox_path(host);
     let bwrap = find_bwrap_in_path(&path, |candidate| probe.file_exists(candidate))
         .ok_or(Error::MissingBubblewrap)?;
-    ensure_host_log_directory(host)?;
+    SandboxPathPlan::new(host)?;
+    if prepare_host_writable_dirs {
+        ensure_host_managed_provider_directories(host)?;
+        ensure_host_state_directory(host)?;
+    } else {
+        ensure_host_log_directory(host)?;
+    }
+    // Directory preparation may materialize previously missing components.
+    // Re-check the filesystem identity immediately before producing mounts.
+    let path_plan = SandboxPathPlan::new(host)?;
 
     Ok(Bootstrap::Reexec(build_plan(
         host,
@@ -404,7 +427,134 @@ pub(crate) fn plan_bootstrap_with_probe(
         bwrap,
         clipboard_access,
         probe,
+        &path_plan,
     )))
+}
+
+#[derive(Debug, Clone)]
+struct SandboxPathPlan {
+    development_rules: Vec<PathAccessRule>,
+    trusted_rules: Vec<PathAccessRule>,
+    trusted_product_rules: Vec<PathAccessRule>,
+}
+
+impl SandboxPathPlan {
+    fn new(host: &Host) -> Result<Self, Error> {
+        let product_paths = [
+            host.xdg_paths.state_dir().to_path_buf(),
+            host.xdg_paths.managed_config_dir(),
+        ];
+        for product_path in &product_paths {
+            validate_product_path_identity(product_path)?;
+        }
+
+        validate_trusted_rule_conflicts(&host.trusted_path_rules)?;
+        for rule in &host.trusted_path_rules {
+            if rule.access() == PathAccess::Deny
+                && let Some(product_path) = product_paths
+                    .iter()
+                    .find(|product_path| paths_overlap(product_path, rule.path()))
+            {
+                return Err(Error::ProductPathConflictsWithTrustedRule {
+                    product_path: product_path.clone(),
+                    rule_path: rule.path().to_path_buf(),
+                    access: rule.access(),
+                });
+            }
+        }
+
+        let (trusted_rules, trusted_product_rules) = host
+            .trusted_path_rules
+            .iter()
+            .cloned()
+            .partition::<Vec<_>, _>(|rule| !path_is_inside_product(rule.path(), &product_paths));
+
+        Ok(Self {
+            development_rules: order_path_rules(default_development_path_rules(
+                host.xdg_paths.home(),
+            )),
+            trusted_rules: order_path_rules(trusted_rules),
+            trusted_product_rules: order_path_rules(trusted_product_rules),
+        })
+    }
+}
+
+fn validate_product_path_identity(path: &Path) -> Result<(), Error> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => current.push(prefix.as_os_str()),
+            Component::RootDir => current.push(component.as_os_str()),
+            Component::CurDir => continue,
+            Component::ParentDir => {
+                current.pop();
+                continue;
+            }
+            Component::Normal(part) => current.push(part),
+        }
+
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(Error::ProductPathContainsSymlink {
+                    product_path: path.to_path_buf(),
+                    symlink_path: current,
+                });
+            }
+            Ok(_) => {}
+            Err(source) if source.kind() == io::ErrorKind::NotFound => break,
+            Err(source) => {
+                return Err(Error::ProductPathMetadata {
+                    path: current,
+                    source,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_trusted_rule_conflicts(rules: &[PathAccessRule]) -> Result<(), Error> {
+    for (index, rule) in rules.iter().enumerate() {
+        if let Some(conflicting) = rules[index + 1..]
+            .iter()
+            .find(|other| other.path() == rule.path() && other.access() != rule.access())
+        {
+            return Err(Error::ConflictingTrustedPathRules {
+                path: rule.path().to_path_buf(),
+                first_access: rule.access(),
+                second_access: conflicting.access(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn order_path_rules(mut rules: Vec<PathAccessRule>) -> Vec<PathAccessRule> {
+    rules.sort_by(|left, right| {
+        path_depth(left.path())
+            .cmp(&path_depth(right.path()))
+            .then_with(|| {
+                left.path()
+                    .to_string_lossy()
+                    .cmp(&right.path().to_string_lossy())
+            })
+    });
+    rules.dedup_by(|left, right| left.path() == right.path() && left.access() == right.access());
+    rules
+}
+
+fn path_depth(path: &Path) -> usize {
+    path.components().count()
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left.starts_with(right) || right.starts_with(left)
+}
+
+fn path_is_inside_product(path: &Path, product_paths: &[PathBuf]) -> bool {
+    product_paths
+        .iter()
+        .any(|product_path| path.starts_with(product_path))
 }
 
 fn ensure_host_log_directory(host: &Host) -> Result<(), Error> {
@@ -677,6 +827,7 @@ fn build_plan(
     bwrap: PathBuf,
     clipboard_access: ClipboardAccess,
     probe: &impl HostPathProbe,
+    path_plan: &SandboxPathPlan,
 ) -> Plan {
     let cwd = host.cwd.as_os_str().to_owned();
     let current_exe = host.current_exe.as_os_str().to_owned();
@@ -717,7 +868,6 @@ fn build_plan(
     }
     args.extend([os("--perms"), os("0700"), os("--dir"), home.clone()]);
     append_bind_dir_try_args(&mut args, &config_dir, &config_dir);
-    append_bind_dir_rw_args(&mut args, &managed_config_dir, &managed_config_dir);
     args.extend([
         os("--ro-bind"),
         os("/usr"),
@@ -752,7 +902,6 @@ fn build_plan(
         os("--chdir"),
         cwd.clone(),
     ]);
-    append_bind_dir_rw_args(&mut args, &state_dir, &state_dir);
     if let Some(log_settings) = host.log_settings.as_ref()
         && let Some(host_log_dir) = log_settings.path.parent()
     {
@@ -762,10 +911,18 @@ fn build_plan(
             host_log_dir.as_os_str().to_owned(),
         ]);
     }
-    for rule in default_development_path_rules(host.xdg_paths.home()) {
-        append_path_rule_args(&mut args, &rule);
+    for rule in &path_plan.development_rules {
+        append_path_rule_args(&mut args, rule);
     }
-    for rule in &host.trusted_path_rules {
+    for rule in &path_plan.trusted_rules {
+        append_path_rule_args(&mut args, rule);
+    }
+    // A trusted read-only parent may be overridden by a narrower product-owned
+    // write mount. Trusted read-only children are appended below to retain the
+    // user's narrower restriction.
+    append_bind_dir_rw_args(&mut args, &state_dir, &state_dir);
+    append_bind_dir_rw_args(&mut args, &managed_config_dir, &managed_config_dir);
+    for rule in &path_plan.trusted_product_rules {
         append_path_rule_args(&mut args, rule);
     }
     for mount in &graphical_plan.mounts {
@@ -1112,6 +1269,24 @@ pub(crate) enum Error {
     MissingBubblewrap,
     InvalidWorkspacePath(&'static str),
     InvalidHomeLayout(&'static str),
+    ProductPathConflictsWithTrustedRule {
+        product_path: PathBuf,
+        rule_path: PathBuf,
+        access: PathAccess,
+    },
+    ProductPathContainsSymlink {
+        product_path: PathBuf,
+        symlink_path: PathBuf,
+    },
+    ProductPathMetadata {
+        path: PathBuf,
+        source: io::Error,
+    },
+    ConflictingTrustedPathRules {
+        path: PathBuf,
+        first_access: PathAccess,
+        second_access: PathAccess,
+    },
     Exec(io::Error),
 }
 
@@ -1164,6 +1339,42 @@ impl fmt::Display for Error {
             Error::InvalidHomeLayout(reason) => {
                 write!(formatter, "sandbox HOME layout is invalid: {reason}")
             }
+            Error::ProductPathConflictsWithTrustedRule {
+                product_path,
+                rule_path,
+                access,
+            } => write!(
+                formatter,
+                "sandbox product path {} conflicts with trusted global {} rule {}",
+                product_path.display(),
+                access.as_str(),
+                rule_path.display()
+            ),
+            Error::ProductPathContainsSymlink {
+                product_path,
+                symlink_path,
+            } => write!(
+                formatter,
+                "sandbox product path {} contains symlink component {}; refusing writable mount",
+                product_path.display(),
+                symlink_path.display()
+            ),
+            Error::ProductPathMetadata { path, source } => write!(
+                formatter,
+                "failed to inspect sandbox product path component {}: {source}",
+                path.display()
+            ),
+            Error::ConflictingTrustedPathRules {
+                path,
+                first_access,
+                second_access,
+            } => write!(
+                formatter,
+                "trusted sandbox path {} has conflicting {} and {} rules",
+                path.display(),
+                first_access.as_str(),
+                second_access.as_str()
+            ),
             Error::Exec(error) => {
                 write!(
                     formatter,

--- a/crates/merry-cli/src/sandbox/tests.rs
+++ b/crates/merry-cli/src/sandbox/tests.rs
@@ -8,6 +8,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(target_os = "linux")]
+use std::process::Command;
+
 #[derive(Default)]
 struct FakeHostProbe {
     metadata: BTreeMap<PathBuf, HostPathMetadata>,
@@ -483,6 +486,267 @@ fn plan_mounts_only_managed_provider_config_read_write() {
         &args,
         &["--bind-try", "/host/config/merry", SANDBOX_MERRY_CONFIG_DIR,]
     ));
+    let config_mount = sequence_position(
+        &args,
+        &[
+            "--ro-bind-try",
+            "/host/config/merry",
+            SANDBOX_MERRY_CONFIG_DIR,
+        ],
+    )
+    .expect("read-only provider config mount");
+    let managed_mount = sequence_position(
+        &args,
+        &[
+            "--bind",
+            "/host/config/merry/managed",
+            SANDBOX_MERRY_MANAGED_CONFIG_DIR,
+        ],
+    )
+    .expect("managed provider write mount");
+    assert!(
+        config_mount < managed_mount,
+        "managed provider mount must override only its read-only parent"
+    );
+}
+
+#[test]
+fn sandbox_allows_product_write_roots_under_trusted_readonly_parent_rules() {
+    let mut host = sandbox_host();
+    host.trusted_path_rules = vec![
+        PathAccessRule::new(
+            PathBuf::from("/host/config"),
+            PathAccess::ReadOnly,
+            PathAccessRuleSource::TrustedGlobalConfig,
+        ),
+        PathAccessRule::new(
+            PathBuf::from("/host/state"),
+            PathAccess::ReadOnly,
+            PathAccessRuleSource::TrustedGlobalConfig,
+        ),
+    ];
+    let Bootstrap::Reexec(plan) =
+        plan_sandbox(true, &host).expect("read-only parents should allow product child writes")
+    else {
+        panic!("expected sandbox reexec plan");
+    };
+    let args = plan_args(&plan);
+    let config_parent =
+        sequence_position(&args, &["--ro-bind-try", "/host/config", "/host/config"])
+            .expect("trusted config parent mount");
+    let managed_write = sequence_position(
+        &args,
+        &[
+            "--bind",
+            "/host/config/merry/managed",
+            SANDBOX_MERRY_MANAGED_CONFIG_DIR,
+        ],
+    )
+    .expect("managed provider write mount");
+    assert!(config_parent < managed_write);
+}
+
+#[test]
+fn sandbox_retains_trusted_readonly_product_child_rules() {
+    let mut host = sandbox_host();
+    host.trusted_path_rules = vec![PathAccessRule::new(
+        PathBuf::from("/host/config/merry/managed/secrets"),
+        PathAccess::ReadOnly,
+        PathAccessRuleSource::TrustedGlobalConfig,
+    )];
+
+    let Bootstrap::Reexec(plan) =
+        plan_sandbox(true, &host).expect("nested read-only rule should be representable")
+    else {
+        panic!("expected sandbox reexec plan");
+    };
+    let args = plan_args(&plan);
+    let managed_write = sequence_position(
+        &args,
+        &[
+            "--bind",
+            "/host/config/merry/managed",
+            SANDBOX_MERRY_MANAGED_CONFIG_DIR,
+        ],
+    )
+    .expect("managed provider write mount");
+    let secrets_readonly = sequence_position(
+        &args,
+        &[
+            "--ro-bind-try",
+            "/host/config/merry/managed/secrets",
+            "/host/config/merry/managed/secrets",
+        ],
+    )
+    .expect("trusted secrets read-only mount");
+    assert!(managed_write < secrets_readonly);
+}
+
+#[test]
+fn sandbox_orders_nested_trusted_rules_from_parent_to_child() {
+    let mut host = sandbox_host();
+    host.trusted_path_rules = vec![
+        PathAccessRule::new(
+            PathBuf::from("/workspace/shared/cache"),
+            PathAccess::ReadWrite,
+            PathAccessRuleSource::TrustedGlobalConfig,
+        ),
+        PathAccessRule::new(
+            PathBuf::from("/workspace/shared"),
+            PathAccess::ReadOnly,
+            PathAccessRuleSource::TrustedGlobalConfig,
+        ),
+    ];
+
+    let Bootstrap::Reexec(plan) =
+        plan_sandbox(true, &host).expect("nested trusted rules should be representable")
+    else {
+        panic!("expected sandbox reexec plan");
+    };
+    let args = plan_args(&plan);
+    let parent = sequence_position(
+        &args,
+        &["--ro-bind-try", "/workspace/shared", "/workspace/shared"],
+    )
+    .expect("trusted parent rule");
+    let child = sequence_position(
+        &args,
+        &[
+            "--bind-try",
+            "/workspace/shared/cache",
+            "/workspace/shared/cache",
+        ],
+    )
+    .expect("trusted child rule");
+    assert!(
+        parent < child,
+        "narrower trusted rules must be applied last"
+    );
+}
+
+#[test]
+fn sandbox_rejects_conflicting_rules_for_the_same_path() {
+    let mut host = sandbox_host();
+    host.trusted_path_rules = vec![
+        PathAccessRule::new(
+            PathBuf::from("/workspace/shared"),
+            PathAccess::ReadOnly,
+            PathAccessRuleSource::TrustedGlobalConfig,
+        ),
+        PathAccessRule::new(
+            PathBuf::from("/workspace/shared"),
+            PathAccess::ReadWrite,
+            PathAccessRuleSource::TrustedGlobalConfig,
+        ),
+    ];
+
+    let error = plan_sandbox(true, &host).expect_err("same-path conflicts must fail closed");
+    assert!(matches!(error, Error::ConflictingTrustedPathRules { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn sandbox_rejects_symlinked_product_write_roots() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("temporary sandbox paths");
+    let real_config = temp.path().join("real-config");
+    let linked_config = temp.path().join("config-link");
+    std::fs::create_dir_all(&real_config).expect("real config directory");
+    symlink(&real_config, &linked_config).expect("config symlink");
+
+    let mut host = sandbox_host();
+    host.xdg_paths = XdgPaths::from_parts(
+        PathBuf::from("/home/alice"),
+        Some(linked_config),
+        Some(temp.path().join("state")),
+    );
+
+    let error = plan_sandbox(true, &host).expect_err("symlinked write root must fail closed");
+    assert!(matches!(error, Error::ProductPathContainsSymlink { .. }));
+}
+
+#[test]
+fn sandbox_rejects_merry_owned_write_roots_under_trusted_deny_rules() {
+    let mut host = sandbox_host();
+    host.trusted_path_rules = vec![PathAccessRule::new(
+        PathBuf::from("/host/config/merry/managed/secrets"),
+        PathAccess::Deny,
+        PathAccessRuleSource::TrustedGlobalConfig,
+    )];
+
+    let error = plan_sandbox(true, &host).expect_err("conflicting outer rule must fail closed");
+    assert!(matches!(
+        error,
+        Error::ProductPathConflictsWithTrustedRule {
+            access: PathAccess::Deny,
+            ..
+        }
+    ));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bubblewrap_keeps_child_write_bind_after_readonly_parent_mount() {
+    let temp = tempfile::tempdir().expect("temporary bubblewrap paths");
+    let parent = temp.path().join("config");
+    let managed = parent.join("managed");
+    std::fs::create_dir_all(&managed).expect("managed directory");
+
+    let output = match Command::new("bwrap")
+        .args(["--unshare-user", "--die-with-parent", "--ro-bind", "/", "/"])
+        .arg("--ro-bind")
+        .arg(&parent)
+        .arg(&parent)
+        .arg("--bind")
+        .arg(&managed)
+        .arg(&managed)
+        .arg("--")
+        .arg("/usr/bin/touch")
+        .arg(managed.join("probe"))
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => panic!("bubblewrap test could not start: {error}"),
+    };
+
+    assert!(
+        output.status.success(),
+        "bubblewrap mount-order probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(managed.join("probe").is_file());
+}
+
+#[test]
+fn sandbox_prepares_provider_and_state_write_roots_before_building_mounts() {
+    let temp = tempfile::tempdir().expect("temporary sandbox paths");
+    let mut host = sandbox_host();
+    host.xdg_paths = XdgPaths::from_parts(
+        PathBuf::from("/home/alice"),
+        Some(temp.path().join("config")),
+        Some(temp.path().join("state")),
+    );
+
+    let probe = FakeHostProbe::default();
+    let bootstrap = super::plan_bootstrap_with_probe_inner(
+        true,
+        ClipboardAccess::Disabled,
+        &host,
+        &probe,
+        true,
+    )
+    .expect("sandbox plan should prepare writable roots");
+    assert!(matches!(bootstrap, Bootstrap::Reexec(_)));
+    assert!(
+        host.xdg_paths
+            .managed_providers_file()
+            .parent()
+            .is_some_and(Path::exists)
+    );
+    assert!(host.xdg_paths.managed_secrets_dir().is_dir());
+    assert!(host.xdg_paths.state_dir().is_dir());
 }
 
 #[test]
@@ -1111,7 +1375,11 @@ fn args_without_sandbox_bootstrap_flags_preserves_shell_trailing_argv() {
 }
 
 fn contains_sequence(args: &[String], expected: &[&str]) -> bool {
-    args.windows(expected.len()).any(|window| {
+    sequence_position(args, expected).is_some()
+}
+
+fn sequence_position(args: &[String], expected: &[&str]) -> Option<usize> {
+    args.windows(expected.len()).position(|window| {
         window
             .iter()
             .map(String::as_str)

--- a/crates/merry-cli/src/tui/controller.rs
+++ b/crates/merry-cli/src/tui/controller.rs
@@ -7,8 +7,8 @@ use super::{
     preferences::{TuiPreferences, TuiPreferencesStore, TuiSettingsDefaults},
     projector::TuiProjector,
     provider_overlay::{
-        ModelListItem, ModelPickerTarget, ProviderFormSeed, ProviderFormValues, ProviderListItem,
-        ProviderOverlayAction,
+        ModelListItem, ModelPickerTarget, ProviderDraftMode, ProviderFormSeed, ProviderFormValues,
+        ProviderListItem, ProviderOverlayAction,
     },
     render,
     runtime::TuiRuntimeSession,
@@ -19,7 +19,7 @@ use crate::{
     cli_error::{CliError, unexpected},
     config::{ProviderAlias, derive_provider_alias},
     provider_management::{
-        ProviderDiscoveryDraft, ProviderDraft, ProviderManagementError, ProviderManagementService,
+        ProviderDiscoveryDraft, ProviderManagementError, ProviderManagementService,
     },
 };
 use crossterm::event::{KeyCode, KeyEvent};
@@ -85,11 +85,20 @@ pub(crate) enum ControllerEffect {
     RefreshModels(String),
     RefreshFormModels,
     DeleteProvider(String),
-    SelectProviderModel {
+    SelectProvider {
+        alias: String,
+    },
+    OpenReasoningPicker {
         alias: String,
         model: String,
+        target: ModelPickerTarget,
     },
-    SelectProviderFormModel(String),
+    ApplyProviderModel {
+        alias: String,
+        model: String,
+        reasoning_effort: merry_llm::ReasoningEffort,
+        target: ModelPickerTarget,
+    },
     EnterPlanMode,
     ApprovePlan(merry_runtime::PlanApprovalInput),
     ApprovePermission(String),
@@ -247,7 +256,25 @@ pub(crate) fn handle_key_event(key: KeyEvent, state: &mut TuiState) -> Controlle
                 ControllerEffect::None
             }
             OverlayKeyResult::CommitModel(value) => {
-                if state.commit_settings_model(value) {
+                let clears_model = value.trim().is_empty();
+                match state.commit_settings_model(value) {
+                    Some((alias, model)) => ControllerEffect::OpenReasoningPicker {
+                        alias,
+                        model,
+                        target: ModelPickerTarget::ActiveProvider,
+                    },
+                    None if clears_model => {
+                        ControllerEffect::ApplyRuntimePreferences(state.preferences().clone())
+                    }
+                    None => ControllerEffect::None,
+                }
+            }
+            OverlayKeyResult::BeginReasoningEdit => {
+                state.begin_settings_reasoning_edit();
+                ControllerEffect::None
+            }
+            OverlayKeyResult::CommitReasoning(value) => {
+                if state.commit_settings_reasoning(value) {
                     ControllerEffect::ApplyRuntimePreferences(state.preferences().clone())
                 } else {
                     ControllerEffect::None
@@ -373,16 +400,27 @@ fn provider_overlay_effect(action: ProviderOverlayAction) -> ControllerEffect {
         ProviderOverlayAction::RefreshModels(alias) => ControllerEffect::RefreshModels(alias),
         ProviderOverlayAction::RefreshFormModels => ControllerEffect::RefreshFormModels,
         ProviderOverlayAction::DeleteProvider(alias) => ControllerEffect::DeleteProvider(alias),
+        ProviderOverlayAction::SelectProvider(alias) => ControllerEffect::SelectProvider { alias },
         ProviderOverlayAction::SelectModel {
             alias,
             model,
-            target: ModelPickerTarget::ActiveProvider,
-        } => ControllerEffect::SelectProviderModel { alias, model },
-        ProviderOverlayAction::SelectModel {
+            target,
+        } => ControllerEffect::OpenReasoningPicker {
+            alias,
             model,
-            target: ModelPickerTarget::ProviderForm,
-            ..
-        } => ControllerEffect::SelectProviderFormModel(model),
+            target,
+        },
+        ProviderOverlayAction::SelectReasoning {
+            alias,
+            model,
+            reasoning_effort,
+            target,
+        } => ControllerEffect::ApplyProviderModel {
+            alias,
+            model,
+            reasoning_effort,
+            target,
+        },
     }
 }
 
@@ -799,6 +837,7 @@ async fn dispatch_effect(
                     protocol: editable.protocol,
                     base_url: editable.base_url,
                     model: editable.default_model.as_str().to_owned(),
+                    reasoning_effort: editable.reasoning_effort,
                 },
                 used,
             );
@@ -901,7 +940,7 @@ async fn dispatch_effect(
             }
             let mut preferences = state.preferences().clone();
             preferences
-                .set_model_for_provider(alias.as_str(), None)
+                .clear_provider_state(alias.as_str())
                 .map_err(unexpected)?;
             let preference_cleanup_error = preferences_store.save(&preferences).await.err();
             state.replace_preferences(preferences);
@@ -921,35 +960,14 @@ async fn dispatch_effect(
             Ok(false)
         }
         ControllerEffect::SaveProvider(values) => {
-            let alias = match ProviderAlias::new(values.alias.trim()) {
-                Ok(alias) => alias,
+            let (alias, model, draft) = match values.to_draft(ProviderDraftMode::Create) {
+                Ok(values) => values,
                 Err(error) => {
                     state.set_provider_overlay_error(error.to_string());
                     return Ok(false);
                 }
             };
-            let model = match merry_llm::ModelName::new(values.model.trim()) {
-                Ok(model) => model,
-                Err(error) => {
-                    state.set_provider_overlay_error(error.to_string());
-                    return Ok(false);
-                }
-            };
-            let draft = match ProviderDraft::new(
-                values.display_name.trim(),
-                alias.clone(),
-                values.kind,
-                values.protocol,
-                values.base_url.trim(),
-                &values.api_key,
-                model.clone(),
-            ) {
-                Ok(draft) => draft,
-                Err(error) => {
-                    state.set_provider_overlay_error(error.to_string());
-                    return Ok(false);
-                }
-            };
+            let reasoning_effort = draft.reasoning_effort().cloned();
             if let Err(error) = providers.management.save_provider(draft).await {
                 state.set_provider_overlay_error(error.to_string());
                 return Ok(false);
@@ -967,6 +985,9 @@ async fn dispatch_effect(
             preferences.provider = Some(alias.as_str().to_owned());
             preferences
                 .set_model_for_provider(alias.as_str(), Some(model.as_str()))
+                .map_err(unexpected)?;
+            preferences
+                .set_reasoning_effort_for_provider(alias.as_str(), reasoning_effort)
                 .map_err(unexpected)?;
             if let Err(error) = session.apply_preferences(&preferences).await {
                 state.set_provider_overlay_error(format!(
@@ -990,31 +1011,8 @@ async fn dispatch_effect(
             values,
         } => {
             let original_alias = ProviderAlias::new(&original_alias).map_err(unexpected)?;
-            let alias = match ProviderAlias::new(values.alias.trim()) {
-                Ok(alias) => alias,
-                Err(error) => {
-                    state.set_provider_overlay_error(error.to_string());
-                    return Ok(false);
-                }
-            };
-            let model = match merry_llm::ModelName::new(values.model.trim()) {
-                Ok(model) => model,
-                Err(error) => {
-                    state.set_provider_overlay_error(error.to_string());
-                    return Ok(false);
-                }
-            };
-            let api_key = (!values.api_key.trim().is_empty()).then(|| values.api_key.trim());
-            let draft = match ProviderDraft::for_update(
-                values.display_name.trim(),
-                alias.clone(),
-                values.kind,
-                values.protocol,
-                values.base_url.trim(),
-                api_key,
-                model.clone(),
-            ) {
-                Ok(draft) => draft,
+            let (_, _, draft) = match values.to_draft(ProviderDraftMode::Update) {
+                Ok(values) => values,
                 Err(error) => {
                     state.set_provider_overlay_error(error.to_string());
                     return Ok(false);
@@ -1037,35 +1035,28 @@ async fn dispatch_effect(
             state.replace_settings_defaults(
                 TuiSettingsDefaults::from_config(Some(&config)).map_err(unexpected)?,
             );
-            let mut preferences = state.preferences().clone();
-            preferences
-                .set_model_for_provider(alias.as_str(), Some(model.as_str()))
-                .map_err(unexpected)?;
+            // Provider configuration and the TUI's per-provider selection are
+            // separate stores. Editing a URL, key, or provider default must
+            // not replace the model/thinking pair selected for this provider.
+            // Model changes go through the model picker, which atomically
+            // updates the selection preferences.
+            let preferences = state.preferences().clone();
             if let Err(error) = session.apply_preferences(&preferences).await {
                 state.set_provider_overlay_error(format!(
                     "provider updated; runtime refresh failed: {error:?}"
                 ));
                 return Ok(false);
             }
-            preferences_store
-                .save(&preferences)
-                .await
-                .map_err(unexpected)?;
-            state.replace_preferences(preferences);
             state.set_model_label(session.model_label.clone());
             state.set_reasoning_effort_label(session.reasoning_effort_label.clone());
             let items = provider_list_items(providers.management, state)?;
             state.open_provider_manager(items);
             Ok(false)
         }
-        ControllerEffect::SelectProviderModel { alias, model } => {
+        ControllerEffect::SelectProvider { alias } => {
             let alias = ProviderAlias::new(&alias).map_err(unexpected)?;
-            let model = merry_llm::ModelName::new(&model).map_err(unexpected)?;
             let mut preferences = state.preferences().clone();
             preferences.provider = Some(alias.as_str().to_owned());
-            preferences
-                .set_model_for_provider(alias.as_str(), Some(model.as_str()))
-                .map_err(unexpected)?;
             if let Err(error) = session.apply_preferences(&preferences).await {
                 state.set_provider_overlay_error(format!("switch failed: {error:?}"));
                 return Ok(false);
@@ -1082,15 +1073,62 @@ async fn dispatch_effect(
             state.open_provider_manager(items);
             Ok(false)
         }
-        ControllerEffect::SelectProviderFormModel(model) => {
-            cancel_model_discovery(providers.discovery_token);
-            if !state.select_provider_form_model(&model) {
+        ControllerEffect::OpenReasoningPicker {
+            alias,
+            model,
+            target,
+        } => {
+            if !state.open_reasoning_picker(alias, model, target) {
                 state.set_provider_overlay_error(
-                    "provider form is no longer available for the selected model".to_owned(),
+                    "model selection is no longer available for reasoning mode selection"
+                        .to_owned(),
                 );
             }
             Ok(false)
         }
+        ControllerEffect::ApplyProviderModel {
+            alias,
+            model,
+            reasoning_effort,
+            target,
+        } => match target {
+            ModelPickerTarget::ActiveProvider => {
+                let alias = ProviderAlias::new(&alias).map_err(unexpected)?;
+                let mut preferences = state.preferences().clone();
+                preferences.provider = Some(alias.as_str().to_owned());
+                preferences
+                    .set_model_and_reasoning_for_provider(alias.as_str(), &model, reasoning_effort)
+                    .map_err(unexpected)?;
+                if let Err(error) = session.apply_preferences(&preferences).await {
+                    state.set_provider_overlay_error(format!("switch failed: {error:?}"));
+                    return Ok(false);
+                }
+                preferences_store
+                    .save(&preferences)
+                    .await
+                    .map_err(unexpected)?;
+                state.replace_preferences(preferences);
+                state.set_model_label(session.model_label.clone());
+                state.set_reasoning_effort_label(session.reasoning_effort_label.clone());
+                if !state.restore_settings_after_reasoning_picker() {
+                    cancel_model_discovery(providers.discovery_token);
+                    let items = provider_list_items(providers.management, state)?;
+                    state.open_provider_manager(items);
+                }
+                Ok(false)
+            }
+            ModelPickerTarget::ProviderForm => {
+                cancel_model_discovery(providers.discovery_token);
+                if !state
+                    .select_provider_form_model_with_reasoning(&model, reasoning_effort.as_str())
+                {
+                    state.set_provider_overlay_error(
+                        "provider form is no longer available for the selected model".to_owned(),
+                    );
+                }
+                Ok(false)
+            }
+        },
         ControllerEffect::EnterPlanMode
         | ControllerEffect::ApprovePlan(_)
         | ControllerEffect::RevisePlan
@@ -1306,7 +1344,9 @@ pub(super) fn project_local_effect(effect: &ControllerEffect, state: &mut TuiSta
         | ControllerEffect::UpdateProvider { .. }
         | ControllerEffect::RefreshModels(_)
         | ControllerEffect::DeleteProvider(_)
-        | ControllerEffect::SelectProviderModel { .. } => {}
+        | ControllerEffect::SelectProvider { .. }
+        | ControllerEffect::OpenReasoningPicker { .. }
+        | ControllerEffect::ApplyProviderModel { .. } => {}
         _ => {}
     }
 }

--- a/crates/merry-cli/src/tui/mod.rs
+++ b/crates/merry-cli/src/tui/mod.rs
@@ -1,21 +1,19 @@
 use crate::cli_error::CliError;
 use crate::coding::ProcessExecutionMode;
 use crate::config::{MerryConfig, XdgPaths};
+use crate::config::{ProviderAlias, derive_provider_alias};
 use crate::provider_management::{
     ProviderDiscoveryDraft, ProviderManagementError, ProviderManagementService,
 };
 use crate::sandbox::ChildHandoff as SandboxChildHandoff;
-use crate::{
-    config::{ProviderAlias, derive_provider_alias},
-    provider_management::ProviderDraft,
-};
 use crossterm::event::KeyCode;
 use input_history_store::InputHistoryStore;
 use keymap::Keymap;
 use preferences::{TuiPreferences, TuiPreferencesStore, TuiSettingsDefaults};
 use projector::TuiProjector;
 use provider_overlay::{
-    ModelListItem, ModelPickerTarget, ProviderFormSeed, ProviderListItem, ProviderOverlayAction,
+    ModelListItem, ModelPickerTarget, ProviderDraftMode, ProviderFormSeed, ProviderListItem,
+    ProviderOverlayAction,
 };
 use session_list::TuiSessionStore;
 use session_picker::SessionPickerSelection;
@@ -49,6 +47,8 @@ mod preferences;
 mod projector;
 mod provider_overlay;
 mod provider_render;
+mod provider_selection;
+mod reasoning_picker;
 mod render;
 mod runtime;
 mod session_list;
@@ -277,6 +277,15 @@ async fn run_provider_setup(
                                 state.back_overlay();
                                 continue;
                             }
+                            overlay::OverlayKeyResult::Back
+                                if matches!(
+                                    state.overlay(),
+                                    Some(overlay::Overlay::ReasoningPicker(_))
+                                ) =>
+                            {
+                                state.back_overlay();
+                                continue;
+                            }
                             overlay::OverlayKeyResult::Back => return Ok(None),
                             overlay::OverlayKeyResult::Provider(action) => action,
                             _ => ProviderOverlayAction::Consumed,
@@ -335,6 +344,7 @@ async fn run_provider_setup(
                                         protocol: editable.protocol,
                                         base_url: editable.base_url,
                                         model: editable.default_model.as_str().to_owned(),
+                                        reasoning_effort: editable.reasoning_effort,
                                     },
                                     used,
                                 );
@@ -429,40 +439,25 @@ async fn run_provider_setup(
                                     continue;
                                 }
                                 preferences
-                                    .set_model_for_provider(alias.as_str(), None)
+                                    .clear_provider_state(alias.as_str())
                                     .map_err(crate::cli_error::unexpected)?;
+                                preferences_store
+                                    .save(&preferences)
+                                    .await
+                                    .map_err(crate::cli_error::unexpected)?;
+                                state.replace_preferences(preferences.clone());
                                 open_setup_provider_manager(state, provider_management)?;
                             }
                             ProviderOverlayAction::SaveProvider(values) => {
-                                let alias = match ProviderAlias::new(values.alias.trim()) {
-                                    Ok(alias) => alias,
+                                let (alias, model, draft) =
+                                    match values.to_draft(ProviderDraftMode::Create) {
+                                    Ok(values) => values,
                                     Err(error) => {
                                         state.set_provider_overlay_error(error.to_string());
                                         continue;
                                     }
                                 };
-                                let model = match merry_llm::ModelName::new(values.model.trim()) {
-                                    Ok(model) => model,
-                                    Err(error) => {
-                                        state.set_provider_overlay_error(error.to_string());
-                                        continue;
-                                    }
-                                };
-                                let draft = match ProviderDraft::new(
-                                    values.display_name.trim(),
-                                    alias.clone(),
-                                    values.kind,
-                                    values.protocol,
-                                    values.base_url.trim(),
-                                    &values.api_key,
-                                    model.clone(),
-                                ) {
-                                    Ok(draft) => draft,
-                                    Err(error) => {
-                                        state.set_provider_overlay_error(error.to_string());
-                                        continue;
-                                    }
-                                };
+                                let reasoning_effort = draft.reasoning_effort().cloned();
                                 if let Err(error) = provider_management.save_provider(draft).await {
                                     state.set_provider_overlay_error(error.to_string());
                                     continue;
@@ -470,6 +465,12 @@ async fn run_provider_setup(
                                 preferences.provider = Some(alias.as_str().to_owned());
                                 preferences
                                     .set_model_for_provider(alias.as_str(), Some(model.as_str()))
+                                    .map_err(crate::cli_error::unexpected)?;
+                                preferences
+                                    .set_reasoning_effort_for_provider(
+                                        alias.as_str(),
+                                        reasoning_effort,
+                                    )
                                     .map_err(crate::cli_error::unexpected)?;
                                 preferences_store
                                     .save(&preferences)
@@ -483,32 +484,9 @@ async fn run_provider_setup(
                             } => {
                                 let original_alias = ProviderAlias::new(&original_alias)
                                     .map_err(crate::cli_error::unexpected)?;
-                                let alias = match ProviderAlias::new(values.alias.trim()) {
-                                    Ok(alias) => alias,
-                                    Err(error) => {
-                                        state.set_provider_overlay_error(error.to_string());
-                                        continue;
-                                    }
-                                };
-                                let model = match merry_llm::ModelName::new(values.model.trim()) {
-                                    Ok(model) => model,
-                                    Err(error) => {
-                                        state.set_provider_overlay_error(error.to_string());
-                                        continue;
-                                    }
-                                };
-                                let api_key = (!values.api_key.trim().is_empty())
-                                    .then(|| values.api_key.trim());
-                                let draft = match ProviderDraft::for_update(
-                                    values.display_name.trim(),
-                                    alias.clone(),
-                                    values.kind,
-                                    values.protocol,
-                                    values.base_url.trim(),
-                                    api_key,
-                                    model.clone(),
-                                ) {
-                                    Ok(draft) => draft,
+                                let (_, _, draft) =
+                                    match values.to_draft(ProviderDraftMode::Update) {
+                                    Ok(values) => values,
                                     Err(error) => {
                                         state.set_provider_overlay_error(error.to_string());
                                         continue;
@@ -521,31 +499,16 @@ async fn run_provider_setup(
                                     state.set_provider_overlay_error(error.to_string());
                                     continue;
                                 }
-                                preferences
-                                    .set_model_for_provider(
-                                        alias.as_str(),
-                                        Some(model.as_str()),
-                                    )
-                                    .map_err(crate::cli_error::unexpected)?;
-                                preferences_store
-                                    .save(&preferences)
-                                    .await
-                                    .map_err(crate::cli_error::unexpected)?;
+                                // Provider defaults belong to the config store. The
+                                // per-provider TUI model/thinking selection is a
+                                // separate preference and must survive edits to the
+                                // URL, credentials, or config defaults.
                                 open_setup_provider_manager(state, provider_management)?;
                             }
-                            ProviderOverlayAction::SelectModel {
-                                alias,
-                                model,
-                                target: ModelPickerTarget::ActiveProvider,
-                            } => {
+                            ProviderOverlayAction::SelectProvider(alias) => {
                                 let alias = ProviderAlias::new(&alias)
                                     .map_err(crate::cli_error::unexpected)?;
-                                let model = merry_llm::ModelName::new(&model)
-                                    .map_err(crate::cli_error::unexpected)?;
                                 preferences.provider = Some(alias.as_str().to_owned());
-                                preferences
-                                    .set_model_for_provider(alias.as_str(), Some(model.as_str()))
-                                    .map_err(crate::cli_error::unexpected)?;
                                 preferences_store
                                     .save(&preferences)
                                     .await
@@ -554,12 +517,51 @@ async fn run_provider_setup(
                                 return Ok(Some(preferences));
                             }
                             ProviderOverlayAction::SelectModel {
+                                alias,
                                 model,
+                                target,
+                            } => {
+                                if !state.open_reasoning_picker(alias, model, target) {
+                                    state.set_provider_overlay_error(
+                                        "model selection is no longer available for reasoning mode selection"
+                                            .to_owned(),
+                                    );
+                                }
+                            }
+                            ProviderOverlayAction::SelectReasoning {
+                                alias,
+                                model,
+                                reasoning_effort,
+                                target: ModelPickerTarget::ActiveProvider,
+                            } => {
+                                let alias = ProviderAlias::new(&alias)
+                                    .map_err(crate::cli_error::unexpected)?;
+                                preferences.provider = Some(alias.as_str().to_owned());
+                                preferences
+                                    .set_model_and_reasoning_for_provider(
+                                        alias.as_str(),
+                                        &model,
+                                        reasoning_effort,
+                                    )
+                                    .map_err(crate::cli_error::unexpected)?;
+                                preferences_store
+                                    .save(&preferences)
+                                    .await
+                                    .map_err(crate::cli_error::unexpected)?;
+                                cancel_setup_discovery(&mut discovery_token);
+                                return Ok(Some(preferences));
+                            }
+                            ProviderOverlayAction::SelectReasoning {
+                                model,
+                                reasoning_effort,
                                 target: ModelPickerTarget::ProviderForm,
                                 ..
                             } => {
                                 cancel_setup_discovery(&mut discovery_token);
-                                if !state.select_provider_form_model(&model) {
+                                if !state.select_provider_form_model_with_reasoning(
+                                    &model,
+                                    reasoning_effort.as_str(),
+                                ) {
                                     state.set_provider_overlay_error(
                                         "provider form is no longer available for the selected model"
                                             .to_owned(),
@@ -591,18 +593,22 @@ fn open_setup_provider_manager(
     state: &mut TuiState,
     provider_management: &ProviderManagementService,
 ) -> Result<(), CliError> {
+    let preferences = state.preferences().clone();
     let items = provider_management
         .profiles()
         .map_err(crate::cli_error::unexpected)?
         .into_iter()
         .map(|profile| {
+            let model = preferences
+                .model_for_provider(profile.alias().as_str())
+                .or_else(|| profile.default_model().map(merry_llm::ModelName::as_str));
             ProviderListItem::new(
                 profile.alias().as_str(),
                 profile.display_name(),
                 profile.kind(),
                 profile.source(),
                 profile.protocol(),
-                profile.default_model().map(merry_llm::ModelName::as_str),
+                model,
             )
         })
         .collect::<Vec<_>>();

--- a/crates/merry-cli/src/tui/overlay.rs
+++ b/crates/merry-cli/src/tui/overlay.rs
@@ -4,6 +4,7 @@ use super::{
     provider_overlay::{
         ModelPickerOverlay, ProviderFormOverlay, ProviderManagerOverlay, ProviderOverlayAction,
     },
+    reasoning_picker::{ReasoningPickerAction, ReasoningPickerOverlay},
 };
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use merry_core::{PlanAttemptOutcome, PlanNodeId, PlanPhase, PlanSnapshot};
@@ -61,6 +62,7 @@ pub(crate) enum Overlay {
     ProviderManager(ProviderManagerOverlay),
     ProviderForm(ProviderFormOverlay),
     ModelPicker(ModelPickerOverlay),
+    ReasoningPicker(ReasoningPickerOverlay),
     PlanApproval(PlanApprovalOverlay),
     PermissionReview(PermissionReviewOverlay),
     Dialog(MessageDialogOverlay),
@@ -187,6 +189,7 @@ pub(crate) enum SettingDirection {
 pub(crate) struct SettingsOverlay {
     selected: usize,
     model_editor: Option<TextInput>,
+    reasoning_editor: Option<TextInput>,
     context_window_editor: Option<TextInput>,
     notice: Option<String>,
 }
@@ -208,6 +211,8 @@ pub(crate) enum OverlayKeyResult {
     ResetSetting(SettingItem),
     BeginModelEdit,
     CommitModel(String),
+    BeginReasoningEdit,
+    CommitReasoning(String),
     BeginContextWindowEdit,
     CommitContextWindow(String),
     OpenShortcuts,
@@ -295,6 +300,10 @@ impl SettingsOverlay {
         self.context_window_editor.as_ref()
     }
 
+    pub(crate) fn reasoning_editor(&self) -> Option<&TextInput> {
+        self.reasoning_editor.as_ref()
+    }
+
     pub(crate) fn notice(&self) -> Option<&str> {
         self.notice.as_deref()
     }
@@ -313,12 +322,21 @@ impl SettingsOverlay {
         self.notice = None;
     }
 
+    pub(crate) fn begin_reasoning_edit(&mut self, value: String) {
+        let mut input = TextInput::default();
+        input.replace_text(value);
+        self.reasoning_editor = Some(input);
+        self.notice = None;
+    }
+
     pub(crate) fn set_notice(&mut self, notice: Option<String>) {
         self.notice = notice;
     }
 
     fn insert_paste(&mut self, text: &str) {
         if let Some(editor) = self.model_editor.as_mut() {
+            editor.insert_str(text);
+        } else if let Some(editor) = self.reasoning_editor.as_mut() {
             editor.insert_str(text);
         } else if let Some(editor) = self.context_window_editor.as_mut() {
             editor.insert_str(text);
@@ -362,6 +380,24 @@ impl SettingsOverlay {
             };
         }
 
+        if let Some(editor) = self.reasoning_editor.as_mut() {
+            return match key.code {
+                KeyCode::Esc => {
+                    self.reasoning_editor = None;
+                    OverlayKeyResult::Consumed
+                }
+                KeyCode::Enter => {
+                    let value = editor.text().to_owned();
+                    self.reasoning_editor = None;
+                    OverlayKeyResult::CommitReasoning(value)
+                }
+                _ => {
+                    editor.handle_key(key);
+                    OverlayKeyResult::Consumed
+                }
+            };
+        }
+
         match key.code {
             KeyCode::Esc => OverlayKeyResult::Back,
             KeyCode::Down => {
@@ -396,6 +432,7 @@ impl SettingsOverlay {
             }
             KeyCode::Enter => match self.selected_item() {
                 SettingItem::DefaultModel => OverlayKeyResult::BeginModelEdit,
+                SettingItem::ReasoningEffort => OverlayKeyResult::BeginReasoningEdit,
                 SettingItem::ContextWindow => OverlayKeyResult::BeginContextWindowEdit,
                 SettingItem::DefaultProvider => {
                     OverlayKeyResult::Provider(ProviderOverlayAction::OpenProviderManager)
@@ -461,6 +498,21 @@ impl Overlay {
                 }
                 action => OverlayKeyResult::Provider(action),
             },
+            Self::ReasoningPicker(picker) => match picker.handle_key(key) {
+                ReasoningPickerAction::Back => OverlayKeyResult::Back,
+                ReasoningPickerAction::Consumed => OverlayKeyResult::Consumed,
+                ReasoningPickerAction::SelectReasoning {
+                    alias,
+                    model,
+                    reasoning_effort,
+                    target,
+                } => OverlayKeyResult::Provider(ProviderOverlayAction::SelectReasoning {
+                    alias,
+                    model,
+                    reasoning_effort,
+                    target,
+                }),
+            },
             Self::PlanApproval(_) => match key.code {
                 KeyCode::Enter => OverlayKeyResult::ConfirmPlanApproval,
                 KeyCode::Esc => OverlayKeyResult::Back,
@@ -496,6 +548,7 @@ impl Overlay {
             | Self::PlanApproval(_)
             | Self::PermissionReview(_)
             | Self::Dialog(_) => {}
+            Self::ReasoningPicker(picker) => picker.insert_paste(text),
             Self::Shortcuts(_) => {}
         }
     }

--- a/crates/merry-cli/src/tui/overlay_render.rs
+++ b/crates/merry-cli/src/tui/overlay_render.rs
@@ -116,6 +116,9 @@ pub(crate) fn render_overlay(frame: &mut Frame<'_>, state: &TuiState) {
         Overlay::ModelPicker(picker) => {
             super::provider_render::render_model_picker(frame, state, picker)
         }
+        Overlay::ReasoningPicker(picker) => {
+            super::provider_render::render_reasoning_picker(frame, state, picker)
+        }
         Overlay::PlanApproval(approval) => render_plan_approval(frame, state, approval),
         Overlay::PermissionReview(review) => render_permission_review(frame, state, review),
         Overlay::Dialog(dialog) => render_message_dialog(frame, state, dialog),
@@ -236,6 +239,13 @@ fn render_settings(frame: &mut Frame<'_>, state: &TuiState) {
         .as_ref()
         .map(|viewport| format!("{}  editing", viewport.text))
         .unwrap_or_else(|| state.setting_value(SettingItem::DefaultModel));
+    let reasoning_editor_viewport = state
+        .settings_reasoning_editor()
+        .map(|input| input.viewport(inner.width.saturating_sub(36).max(1).into()));
+    let reasoning_value = reasoning_editor_viewport
+        .as_ref()
+        .map(|viewport| format!("{}  editing", viewport.text))
+        .unwrap_or_else(|| state.setting_value(SettingItem::ReasoningEffort));
     let context_window_editor_viewport = state
         .settings_context_window_editor()
         .map(|input| input.viewport(inner.width.saturating_sub(36).max(1).into()));
@@ -268,7 +278,7 @@ fn render_settings(frame: &mut Frame<'_>, state: &TuiState) {
         setting_line(
             state,
             "Reasoning effort",
-            &state.setting_value(SettingItem::ReasoningEffort),
+            &reasoning_value,
             selected == Some(SettingItem::ReasoningEffort),
         ),
         Line::default(),
@@ -344,6 +354,20 @@ fn render_settings(frame: &mut Frame<'_>, state: &TuiState) {
         let value_x = inner.x.saturating_add(26);
         let context_window_row = setting_line_index(SettingItem::ContextWindow);
         if let Some(visible_row) = context_window_row.checked_sub(scroll_offset)
+            && visible_row < visible_height
+        {
+            frame.set_cursor_position(Position::new(
+                value_x
+                    .saturating_add(viewport.cursor_column as u16)
+                    .min(inner.right().saturating_sub(1)),
+                inner.y.saturating_add(visible_row as u16),
+            ));
+        }
+    }
+    if let Some(viewport) = reasoning_editor_viewport {
+        let value_x = inner.x.saturating_add(26);
+        let reasoning_row = setting_line_index(SettingItem::ReasoningEffort);
+        if let Some(visible_row) = reasoning_row.checked_sub(scroll_offset)
             && visible_row < visible_height
         {
             frame.set_cursor_position(Position::new(

--- a/crates/merry-cli/src/tui/preferences.rs
+++ b/crates/merry-cli/src/tui/preferences.rs
@@ -10,8 +10,34 @@ use std::{
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 
-const PREFERENCES_VERSION: u32 = 2;
+const PREFERENCES_VERSION: u32 = 3;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) const REASONING_EFFORT_PRESETS: [&str; 7] =
+    ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TuiProviderState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<ReasoningEffort>,
+}
+
+impl TuiProviderState {
+    pub(crate) fn model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
+    pub(crate) fn reasoning_effort(&self) -> Option<&ReasoningEffort> {
+        self.reasoning_effort.as_ref()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.model.is_none() && self.reasoning_effort.is_none()
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -76,9 +102,7 @@ pub(crate) struct TuiPreferences {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) provider: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    models: BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) reasoning_effort: Option<ReasoningEffort>,
+    provider_states: BTreeMap<String, TuiProviderState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) context_window_tokens: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -97,8 +121,7 @@ impl Default for TuiPreferences {
             version: PREFERENCES_VERSION,
             code_theme: CodeTheme::default(),
             provider: None,
-            models: BTreeMap::new(),
-            reasoning_effort: None,
+            provider_states: BTreeMap::new(),
             context_window_tokens: None,
             auto_compaction_enabled: None,
             compaction_strategy: None,
@@ -109,12 +132,21 @@ impl Default for TuiPreferences {
 }
 
 impl TuiPreferences {
-    pub(crate) fn reasoning_label(&self) -> Option<&str> {
-        self.reasoning_effort.as_ref().map(ReasoningEffort::as_str)
+    pub(crate) fn reasoning_effort_for_provider(&self, provider: &str) -> Option<&ReasoningEffort> {
+        self.provider_states
+            .get(provider)
+            .and_then(TuiProviderState::reasoning_effort)
+    }
+
+    pub(crate) fn reasoning_label_for_provider(&self, provider: &str) -> Option<&str> {
+        self.reasoning_effort_for_provider(provider)
+            .map(ReasoningEffort::as_str)
     }
 
     pub(crate) fn model_for_provider(&self, provider: &str) -> Option<&str> {
-        self.models.get(provider).map(String::as_str)
+        self.provider_states
+            .get(provider)
+            .and_then(TuiProviderState::model)
     }
 
     pub(crate) fn set_model_for_provider(
@@ -128,13 +160,68 @@ impl TuiPreferences {
             Some(model) => {
                 let model = ModelName::new(model)
                     .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
-                self.models
-                    .insert(provider.to_owned(), model.as_str().to_owned());
+                self.provider_states
+                    .entry(provider.to_owned())
+                    .or_default()
+                    .model = Some(model.as_str().to_owned());
             }
             None => {
-                self.models.remove(provider);
+                let should_remove = if let Some(state) = self.provider_states.get_mut(provider) {
+                    state.model = None;
+                    state.is_empty()
+                } else {
+                    false
+                };
+                if should_remove {
+                    self.provider_states.remove(provider);
+                }
             }
         }
+        Ok(())
+    }
+
+    pub(crate) fn set_reasoning_effort_for_provider(
+        &mut self,
+        provider: &str,
+        reasoning_effort: Option<ReasoningEffort>,
+    ) -> Result<(), PreferencesError> {
+        ProviderAlias::new(provider)
+            .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
+        let should_remove = {
+            let state = self.provider_states.entry(provider.to_owned()).or_default();
+            state.reasoning_effort = reasoning_effort;
+            state.is_empty()
+        };
+        if should_remove {
+            self.provider_states.remove(provider);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clear_provider_state(&mut self, provider: &str) -> Result<(), PreferencesError> {
+        ProviderAlias::new(provider)
+            .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
+        self.provider_states.remove(provider);
+        Ok(())
+    }
+
+    pub(crate) fn set_model_and_reasoning_for_provider(
+        &mut self,
+        provider: &str,
+        model: &str,
+        reasoning_effort: ReasoningEffort,
+    ) -> Result<(), PreferencesError> {
+        let model =
+            ModelName::new(model).map_err(|error| PreferencesError::Invalid(error.to_string()))?;
+        ProviderAlias::new(provider)
+            .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
+        self.provider_states.insert(
+            provider.to_owned(),
+            TuiProviderState {
+                model: Some(model.as_str().to_owned()),
+                reasoning_effort: Some(reasoning_effort),
+            },
+        );
         Ok(())
     }
 }
@@ -144,7 +231,7 @@ pub(crate) struct TuiSettingsDefaults {
     pub(crate) provider_aliases: Vec<String>,
     pub(crate) provider: Option<String>,
     pub(crate) model: Option<String>,
-    pub(crate) reasoning_effort: Option<ReasoningEffort>,
+    pub(crate) reasoning_efforts: BTreeMap<String, ReasoningEffort>,
     pub(crate) context_window_tokens: u64,
     pub(crate) subagents_enabled: bool,
     pub(crate) subagent_max_threads: usize,
@@ -159,7 +246,7 @@ impl Default for TuiSettingsDefaults {
             provider_aliases: Vec::new(),
             provider: None,
             model: None,
-            reasoning_effort: None,
+            reasoning_efforts: BTreeMap::new(),
             context_window_tokens: merry_runtime::DEFAULT_CONTEXT_WINDOW_FALLBACK_TOKENS,
             subagents_enabled: false,
             subagent_max_threads: limits.max_threads(),
@@ -177,23 +264,38 @@ impl TuiSettingsDefaults {
             return Ok(Self::default());
         };
         let default_provider = config.configured_default_provider()?;
+        let provider_aliases = config.provider_aliases();
+        let mut reasoning_efforts = BTreeMap::new();
+        for alias in &provider_aliases {
+            if let Some(reasoning_effort) = config.effective_provider_reasoning_effort(alias)? {
+                reasoning_efforts.insert(alias.clone(), reasoning_effort);
+            }
+        }
         let subagents = config.subagents_config()?;
         let auto_compaction = config.automatic_compaction_config()?;
         Ok(Self {
-            provider_aliases: config.provider_aliases(),
+            provider_aliases,
             provider: default_provider
                 .as_ref()
                 .map(|provider| provider.alias.clone()),
             model: default_provider
                 .as_ref()
                 .map(|provider| provider.model.clone()),
-            reasoning_effort: default_provider.and_then(|provider| provider.reasoning_effort),
+            reasoning_efforts,
             context_window_tokens: merry_runtime::DEFAULT_CONTEXT_WINDOW_FALLBACK_TOKENS,
             subagents_enabled: subagents.is_enabled(),
             subagent_max_threads: subagents.limits().max_threads(),
             auto_compaction_enabled: auto_compaction.is_enabled(),
             compaction_strategy: "Config".to_owned(),
         })
+    }
+
+    pub(crate) fn reasoning_effort_for_provider(
+        &self,
+        provider: Option<&str>,
+    ) -> Option<&ReasoningEffort> {
+        let provider = provider.or(self.provider.as_deref())?;
+        self.reasoning_efforts.get(provider)
     }
 }
 
@@ -240,6 +342,12 @@ impl TuiPreferencesStore {
             .version;
         let preferences = match version {
             1 => toml::from_str::<LegacyTuiPreferences>(&text)
+                .map_err(|source| PreferencesError::Parse {
+                    path: self.path.clone(),
+                    source,
+                })?
+                .migrate(default_provider)?,
+            2 => toml::from_str::<StoredTuiPreferencesV2>(&text)
                 .map_err(|source| PreferencesError::Parse {
                     path: self.path.clone(),
                     source,
@@ -309,10 +417,13 @@ impl TuiPreferences {
             ProviderAlias::new(provider)
                 .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
         }
-        for (provider, model) in &self.models {
+        for (provider, state) in &self.provider_states {
             ProviderAlias::new(provider)
                 .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
-            ModelName::new(model).map_err(|error| PreferencesError::Invalid(error.to_string()))?;
+            if let Some(model) = state.model() {
+                ModelName::new(model)
+                    .map_err(|error| PreferencesError::Invalid(error.to_string()))?;
+            }
         }
         if self.subagent_max_threads == Some(0) {
             return Err(PreferencesError::Invalid(
@@ -332,6 +443,54 @@ impl TuiPreferences {
 struct PreferencesVersion {
     #[serde(default = "legacy_preferences_version")]
     version: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredTuiPreferencesV2 {
+    #[serde(default = "legacy_preferences_version")]
+    version: u32,
+    #[serde(default)]
+    code_theme: CodeTheme,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    models: BTreeMap<String, String>,
+    #[serde(default)]
+    reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default)]
+    context_window_tokens: Option<u64>,
+    #[serde(default)]
+    auto_compaction_enabled: Option<bool>,
+    #[serde(default)]
+    compaction_strategy: Option<CompactionStrategy>,
+    #[serde(default)]
+    subagents_enabled: Option<bool>,
+    #[serde(default)]
+    subagent_max_threads: Option<usize>,
+}
+
+impl StoredTuiPreferencesV2 {
+    fn migrate(self, default_provider: Option<&str>) -> Result<TuiPreferences, PreferencesError> {
+        if self.version != 2 {
+            return Err(PreferencesError::UnsupportedVersion {
+                path_version: self.version,
+                supported_version: PREFERENCES_VERSION,
+            });
+        }
+        migrate_provider_states(
+            self.provider,
+            self.models,
+            self.reasoning_effort,
+            self.code_theme,
+            self.context_window_tokens,
+            self.auto_compaction_enabled,
+            self.compaction_strategy,
+            self.subagents_enabled,
+            self.subagent_max_threads,
+            default_provider,
+        )
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -361,20 +520,9 @@ impl LegacyTuiPreferences {
                 supported_version: PREFERENCES_VERSION,
             });
         }
-        let mut preferences = TuiPreferences {
-            version: PREFERENCES_VERSION,
-            code_theme: self.code_theme,
-            provider: self.provider,
-            models: BTreeMap::new(),
-            reasoning_effort: self.reasoning_effort,
-            context_window_tokens: None,
-            auto_compaction_enabled: None,
-            compaction_strategy: None,
-            subagents_enabled: self.subagents_enabled,
-            subagent_max_threads: self.subagent_max_threads,
-        };
-        if let Some(model) = self.model.as_deref() {
-            let provider = preferences
+        let mut models = BTreeMap::new();
+        if let Some(model) = self.model {
+            let provider = self
                 .provider
                 .as_deref()
                 .or(default_provider)
@@ -382,12 +530,70 @@ impl LegacyTuiPreferences {
                     PreferencesError::Invalid(
                         "version 1 model preference cannot migrate without a provider".to_owned(),
                     )
-                })?
-                .to_owned();
-            preferences.set_model_for_provider(&provider, Some(model))?;
+                })?;
+            models.insert(provider.to_owned(), model);
         }
-        Ok(preferences)
+        migrate_provider_states(
+            self.provider,
+            models,
+            self.reasoning_effort,
+            self.code_theme,
+            None,
+            None,
+            None,
+            self.subagents_enabled,
+            self.subagent_max_threads,
+            default_provider,
+        )
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn migrate_provider_states(
+    provider: Option<String>,
+    models: BTreeMap<String, String>,
+    reasoning_effort: Option<ReasoningEffort>,
+    code_theme: CodeTheme,
+    context_window_tokens: Option<u64>,
+    auto_compaction_enabled: Option<bool>,
+    compaction_strategy: Option<CompactionStrategy>,
+    subagents_enabled: Option<bool>,
+    subagent_max_threads: Option<usize>,
+    default_provider: Option<&str>,
+) -> Result<TuiPreferences, PreferencesError> {
+    let mut provider_states = models
+        .into_iter()
+        .map(|(provider, model)| {
+            (
+                provider,
+                TuiProviderState {
+                    model: Some(model),
+                    reasoning_effort: None,
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if let Some(reasoning_effort) = reasoning_effort
+        && let Some(provider) = provider.as_deref().or(default_provider)
+    {
+        provider_states
+            .entry(provider.to_owned())
+            .or_default()
+            .reasoning_effort = Some(reasoning_effort);
+    }
+    let preferences = TuiPreferences {
+        version: PREFERENCES_VERSION,
+        code_theme,
+        provider,
+        provider_states,
+        context_window_tokens,
+        auto_compaction_enabled,
+        compaction_strategy,
+        subagents_enabled,
+        subagent_max_threads,
+    };
+    preferences.validate()?;
+    Ok(preferences)
 }
 
 fn legacy_preferences_version() -> u32 {
@@ -434,23 +640,71 @@ pub(crate) enum PreferencesError {
 mod tests {
     use super::*;
 
+    #[test]
+    fn settings_defaults_keep_reasoning_effort_per_provider() {
+        let paths = crate::config::XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = crate::config::MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "compat"
+model = "gpt-test"
+reasoning_effort = "high"
+
+[providers.compat]
+type = "openai-compatible"
+reasoning_effort = "low"
+api_key = "sk-compat-test"
+
+[providers.alt]
+type = "openai-compatible"
+reasoning_effort = "max ultra"
+api_key = "sk-alt-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should exist");
+
+        let defaults =
+            TuiSettingsDefaults::from_config(Some(&config)).expect("settings defaults should load");
+
+        assert_eq!(
+            defaults
+                .reasoning_effort_for_provider(Some("compat"))
+                .map(ReasoningEffort::as_str),
+            Some("high")
+        );
+        assert_eq!(
+            defaults
+                .reasoning_effort_for_provider(Some("alt"))
+                .map(ReasoningEffort::as_str),
+            Some("max ultra")
+        );
+    }
+
     #[tokio::test]
     async fn preferences_store_round_trips_safe_tui_defaults() {
         let temp = tempfile::tempdir().expect("tempdir should be created");
         let store = TuiPreferencesStore::new(temp.path().join("merry/tui-preferences.toml"));
-        let preferences = TuiPreferences {
+        let mut preferences = TuiPreferences {
             code_theme: CodeTheme::CatppuccinMocha,
             provider: Some("anthropic".to_owned()),
-            reasoning_effort: Some(ReasoningEffort::new("high").unwrap()),
             context_window_tokens: Some(272_000),
             subagents_enabled: Some(true),
             subagent_max_threads: Some(6),
             ..TuiPreferences::default()
         };
-        let mut preferences = preferences;
         preferences
             .set_model_for_provider("anthropic", Some("claude-test"))
             .expect("valid model preference");
+        preferences
+            .set_reasoning_effort_for_provider(
+                "anthropic",
+                Some(ReasoningEffort::new("high").unwrap()),
+            )
+            .expect("valid reasoning preference");
 
         store.save(&preferences).await.expect("preferences save");
         let loaded = store.load().await.expect("preferences load");
@@ -489,6 +743,69 @@ model = "deepseek-v4-pro"
             Some("deepseek-v4-pro")
         );
         assert_eq!(migrated.model_for_provider("anthropic"), None);
+    }
+
+    #[tokio::test]
+    async fn migrates_version_two_reasoning_only_to_its_selected_provider() {
+        let temp = tempfile::tempdir().expect("tempdir should be created");
+        let path = temp.path().join("merry/tui-preferences.toml");
+        tokio::fs::create_dir_all(path.parent().expect("preferences parent"))
+            .await
+            .expect("preferences parent");
+        tokio::fs::write(
+            &path,
+            r#"
+version = 2
+provider = "opencode"
+models = { opencode = "model-a", anthropic = "model-b" }
+reasoning_effort = "max ultra"
+"#,
+        )
+        .await
+        .expect("v2 preferences");
+        let store = TuiPreferencesStore::new(path);
+
+        let migrated = store
+            .load_with_default_provider(Some("anthropic"))
+            .await
+            .expect("v2 preferences should migrate");
+
+        assert_eq!(migrated.model_for_provider("opencode"), Some("model-a"));
+        assert_eq!(migrated.model_for_provider("anthropic"), Some("model-b"));
+        assert_eq!(
+            migrated
+                .reasoning_effort_for_provider("opencode")
+                .map(ReasoningEffort::as_str),
+            Some("max ultra")
+        );
+        assert_eq!(migrated.reasoning_effort_for_provider("anthropic"), None);
+    }
+
+    #[test]
+    fn provider_state_keeps_one_model_and_reasoning_pair() {
+        let mut preferences = TuiPreferences::default();
+        preferences
+            .set_model_and_reasoning_for_provider(
+                "opencode",
+                "model-a",
+                ReasoningEffort::new("high").expect("valid effort"),
+            )
+            .expect("valid provider state");
+        preferences
+            .set_model_and_reasoning_for_provider(
+                "opencode",
+                "model-b",
+                ReasoningEffort::new("max ultra").expect("valid effort"),
+            )
+            .expect("valid provider state");
+
+        assert_eq!(preferences.model_for_provider("opencode"), Some("model-b"));
+        assert_eq!(
+            preferences
+                .reasoning_effort_for_provider("opencode")
+                .map(ReasoningEffort::as_str),
+            Some("max ultra")
+        );
     }
 
     #[tokio::test]

--- a/crates/merry-cli/src/tui/provider_overlay.rs
+++ b/crates/merry-cli/src/tui/provider_overlay.rs
@@ -1,10 +1,16 @@
 use super::input::{TextInput, TextInputViewport};
+use super::preferences::REASONING_EFFORT_PRESETS;
 use crate::config::{
-    ConfiguredProviderKind, ManagedProviderKind, ProviderConfigSource, derive_provider_alias,
+    ConfiguredProviderKind, ManagedProviderKind, ProviderAlias, ProviderConfigSource,
+    derive_provider_alias,
 };
+use crate::provider_management::{ProviderDraft, ProviderManagementError};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use merry_llm::ReasoningEffort;
 use merry_provider_openai::OpenAiProtocol;
 use std::{collections::BTreeSet, fmt};
+
+pub(crate) use super::provider_selection::ModelPickerTarget;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProviderListItem {
@@ -119,11 +125,7 @@ impl ProviderManagerOverlay {
             KeyCode::Enter => self.items.get(self.selected).map_or(
                 ProviderOverlayAction::OpenProviderForm,
                 |item| match item.model() {
-                    Some(model) => ProviderOverlayAction::SelectModel {
-                        alias: item.alias().to_owned(),
-                        model: model.to_owned(),
-                        target: ModelPickerTarget::ActiveProvider,
-                    },
+                    Some(_) => ProviderOverlayAction::SelectProvider(item.alias().to_owned()),
                     None => ProviderOverlayAction::OpenModelPicker(item.alias().to_owned()),
                 },
             ),
@@ -175,11 +177,12 @@ pub(crate) enum ProviderFormField {
     BaseUrl,
     ApiKey,
     Model,
+    ReasoningEffort,
     Save,
 }
 
 impl ProviderFormField {
-    pub(crate) const ALL: [Self; 8] = [
+    pub(crate) const ALL: [Self; 9] = [
         Self::DisplayName,
         Self::Alias,
         Self::Kind,
@@ -187,6 +190,7 @@ impl ProviderFormField {
         Self::BaseUrl,
         Self::ApiKey,
         Self::Model,
+        Self::ReasoningEffort,
         Self::Save,
     ];
 }
@@ -200,6 +204,13 @@ pub(crate) struct ProviderFormValues {
     pub(crate) base_url: String,
     pub(crate) api_key: String,
     pub(crate) model: String,
+    pub(crate) reasoning_effort: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderDraftMode {
+    Create,
+    Update,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +222,7 @@ pub(crate) struct ProviderFormSeed {
     pub(crate) protocol: Option<OpenAiProtocol>,
     pub(crate) base_url: String,
     pub(crate) model: String,
+    pub(crate) reasoning_effort: Option<ReasoningEffort>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -230,13 +242,51 @@ impl fmt::Debug for ProviderFormValues {
             .field("base_url", &self.base_url)
             .field("api_key", &"<redacted>")
             .field("model", &self.model)
+            .field("reasoning_effort", &self.reasoning_effort)
             .finish()
+    }
+}
+
+impl ProviderFormValues {
+    pub(crate) fn to_draft(
+        &self,
+        mode: ProviderDraftMode,
+    ) -> Result<(ProviderAlias, merry_llm::ModelName, ProviderDraft), ProviderManagementError> {
+        let alias = ProviderAlias::new(self.alias.trim())
+            .map_err(|error| ProviderManagementError::Invalid(error.to_string()))?;
+        let model = merry_llm::ModelName::new(self.model.trim())
+            .map_err(|error| ProviderManagementError::Invalid(error.to_string()))?;
+        let draft = match mode {
+            ProviderDraftMode::Update => ProviderDraft::for_update(
+                self.display_name.trim(),
+                alias.clone(),
+                self.kind,
+                self.protocol,
+                self.base_url.trim(),
+                (!self.api_key.trim().is_empty()).then_some(self.api_key.trim()),
+                model.clone(),
+            )?,
+            ProviderDraftMode::Create => ProviderDraft::new(
+                self.display_name.trim(),
+                alias.clone(),
+                self.kind,
+                self.protocol,
+                self.base_url.trim(),
+                &self.api_key,
+                model.clone(),
+            )?,
+        };
+        Ok((
+            alias,
+            model,
+            draft.with_reasoning_effort_text(&self.reasoning_effort)?,
+        ))
     }
 }
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ProviderFormOverlay {
-    fields: [TextInput; 5],
+    fields: [TextInput; 6],
     used_aliases: BTreeSet<String>,
     mode: ProviderFormMode,
     kind: ManagedProviderKind,
@@ -256,6 +306,7 @@ impl fmt::Debug for ProviderFormOverlay {
             .field("base_url", &self.field(ProviderFormField::BaseUrl))
             .field("api_key", &"<redacted>")
             .field("model", &self.field(ProviderFormField::Model))
+            .field("reasoning_effort", &self.reasoning_effort_text())
             .field("selected", &self.selected)
             .field("notice", &self.notice)
             .finish()
@@ -285,6 +336,9 @@ impl ProviderFormOverlay {
         fields[1].replace_text(seed.alias);
         fields[2].replace_text(seed.base_url);
         fields[4].replace_text(seed.model);
+        if let Some(reasoning_effort) = seed.reasoning_effort {
+            fields[5].replace_text(reasoning_effort.as_str().to_owned());
+        }
         Self {
             fields,
             used_aliases,
@@ -325,6 +379,18 @@ impl ProviderFormOverlay {
         }
     }
 
+    pub(crate) fn reasoning_effort_text(&self) -> &str {
+        self.field(ProviderFormField::ReasoningEffort)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+        let value = self.reasoning_effort_text().trim();
+        (!value.is_empty())
+            .then(|| ReasoningEffort::new(value).ok())
+            .flatten()
+    }
+
     pub(crate) fn field(&self, field: ProviderFormField) -> &str {
         match field_input_index(field) {
             Some(index) => self.fields[index].text(),
@@ -353,12 +419,13 @@ impl ProviderFormOverlay {
         self.notice.as_deref()
     }
 
-    pub(crate) fn set_model(&mut self, model: &str) {
+    pub(crate) fn set_model_and_reasoning(&mut self, model: &str, reasoning_effort: &str) {
         self.fields[4].replace_text(model.to_owned());
+        self.fields[5].replace_text(reasoning_effort.to_owned());
         self.selected = ProviderFormField::ALL
             .iter()
-            .position(|field| *field == ProviderFormField::Model)
-            .expect("model field is present");
+            .position(|field| *field == ProviderFormField::ReasoningEffort)
+            .expect("reasoning effort field is present");
     }
 
     pub(crate) fn discovery_request(&self) -> (Option<String>, ProviderFormValues) {
@@ -405,6 +472,13 @@ impl ProviderFormOverlay {
                 if self.selected_field() == ProviderFormField::Protocol =>
             {
                 self.toggle_protocol();
+                ProviderOverlayAction::Consumed
+            }
+            KeyCode::Char(' ')
+                if self.selected_field() == ProviderFormField::ReasoningEffort
+                    && key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.cycle_reasoning();
                 ProviderOverlayAction::Consumed
             }
             KeyCode::Enter if self.selected_field() == ProviderFormField::Model => {
@@ -466,6 +540,15 @@ impl ProviderFormOverlay {
         };
     }
 
+    fn cycle_reasoning(&mut self) {
+        let current = self.reasoning_effort_text().trim();
+        let next = REASONING_EFFORT_PRESETS
+            .iter()
+            .position(|value| *value == current)
+            .map_or(0, |index| (index + 1) % REASONING_EFFORT_PRESETS.len());
+        self.fields[5].replace_text(REASONING_EFFORT_PRESETS[next].to_owned());
+    }
+
     fn save_action(&self) -> ProviderOverlayAction {
         match &self.mode {
             ProviderFormMode::Add => ProviderOverlayAction::SaveProvider(self.values()),
@@ -485,6 +568,7 @@ impl ProviderFormOverlay {
             base_url: self.field(ProviderFormField::BaseUrl).to_owned(),
             api_key: self.field(ProviderFormField::ApiKey).to_owned(),
             model: self.field(ProviderFormField::Model).to_owned(),
+            reasoning_effort: self.reasoning_effort_text().trim().to_owned(),
         }
     }
 
@@ -504,6 +588,7 @@ fn field_input_index(field: ProviderFormField) -> Option<usize> {
         ProviderFormField::BaseUrl => Some(2),
         ProviderFormField::ApiKey => Some(3),
         ProviderFormField::Model => Some(4),
+        ProviderFormField::ReasoningEffort => Some(5),
         ProviderFormField::Save => None,
     }
 }
@@ -512,12 +597,6 @@ fn field_input_index(field: ProviderFormField) -> Option<usize> {
 pub(crate) struct ModelListItem {
     id: String,
     owner: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ModelPickerTarget {
-    ActiveProvider,
-    ProviderForm,
 }
 
 impl ModelListItem {
@@ -732,9 +811,16 @@ pub(crate) enum ProviderOverlayAction {
     RefreshModels(String),
     RefreshFormModels,
     DeleteProvider(String),
+    SelectProvider(String),
     SelectModel {
         alias: String,
         model: String,
+        target: ModelPickerTarget,
+    },
+    SelectReasoning {
+        alias: String,
+        model: String,
+        reasoning_effort: ReasoningEffort,
         target: ModelPickerTarget,
     },
 }
@@ -817,11 +903,7 @@ mod tests {
 
         assert_eq!(
             switch_manager.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
-            ProviderOverlayAction::SelectModel {
-                alias: "opencode".to_owned(),
-                model: "model-a".to_owned(),
-                target: ModelPickerTarget::ActiveProvider,
-            }
+            ProviderOverlayAction::SelectProvider("opencode".to_owned())
         );
         assert_eq!(
             edit_manager.handle_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE)),
@@ -947,6 +1029,52 @@ mod tests {
     }
 
     #[test]
+    fn provider_form_exposes_reasoning_effort_selection() {
+        let mut form = ProviderFormOverlay::new("provider".to_owned(), BTreeSet::new());
+        for _ in 0..7 {
+            let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+        assert_eq!(form.selected_field(), ProviderFormField::ReasoningEffort);
+        assert_eq!(form.reasoning_effort(), None);
+
+        let _ = form.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::CONTROL));
+        assert_eq!(
+            form.reasoning_effort()
+                .as_ref()
+                .map(ReasoningEffort::as_str),
+            Some("minimal")
+        );
+        let _ = form.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::CONTROL));
+        assert_eq!(
+            form.reasoning_effort()
+                .as_ref()
+                .map(ReasoningEffort::as_str),
+            Some("low")
+        );
+    }
+
+    #[test]
+    fn provider_form_supports_builtin_and_custom_reasoning_efforts() {
+        let mut form = ProviderFormOverlay::new("provider".to_owned(), BTreeSet::new());
+        for _ in 0..7 {
+            let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+
+        for expected in ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"] {
+            let _ = form.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::CONTROL));
+            assert_eq!(form.reasoning_effort_text(), expected);
+        }
+
+        form.set_field_for_test(ProviderFormField::ReasoningEffort, "max ultra");
+        assert_eq!(
+            form.reasoning_effort()
+                .as_ref()
+                .map(ReasoningEffort::as_str),
+            Some("max ultra")
+        );
+    }
+
+    #[test]
     fn provider_edit_form_prefills_values_retains_secret_and_emits_update() {
         let mut form = ProviderFormOverlay::edit(
             ProviderFormSeed {
@@ -957,6 +1085,7 @@ mod tests {
                 protocol: Some(OpenAiProtocol::Responses),
                 base_url: "https://api.openai.com/v1".to_owned(),
                 model: "model-a".to_owned(),
+                reasoning_effort: None,
             },
             BTreeSet::from(["opencode".to_owned()]),
         );
@@ -974,7 +1103,7 @@ mod tests {
         let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let _ = form.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
-        for _ in 0..4 {
+        for _ in 0..5 {
             let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         }
 
@@ -1000,6 +1129,7 @@ mod tests {
                 protocol: Some(OpenAiProtocol::ChatCompletions),
                 base_url: "https://opencode.example.test/v1".to_owned(),
                 model: "model-a".to_owned(),
+                reasoning_effort: None,
             },
             BTreeSet::from(["opencode".to_owned()]),
         );
@@ -1017,7 +1147,9 @@ mod tests {
             } if original_alias == "opencode" && values.model == "model-a"
         ));
 
-        let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        for _ in 0..2 {
+            let _ = form.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
         assert_eq!(form.selected_field(), ProviderFormField::Save);
         assert!(matches!(
             form.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
@@ -1033,16 +1165,6 @@ mod tests {
         let action = form.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
 
         assert!(matches!(action, ProviderOverlayAction::SaveProvider(_)));
-    }
-
-    #[test]
-    fn provider_form_selected_model_replaces_initial_model() {
-        let mut form = ProviderFormOverlay::new("provider".to_owned(), BTreeSet::new());
-
-        form.set_model("discovered-model");
-
-        assert_eq!(form.field(ProviderFormField::Model), "discovered-model");
-        assert_eq!(form.selected_field(), ProviderFormField::Model);
     }
 
     #[test]

--- a/crates/merry-cli/src/tui/provider_render.rs
+++ b/crates/merry-cli/src/tui/provider_render.rs
@@ -3,6 +3,7 @@ use super::{
     provider_overlay::{
         ModelPickerOverlay, ProviderFormField, ProviderFormOverlay, ProviderManagerOverlay,
     },
+    reasoning_picker::ReasoningPickerOverlay,
     state::TuiState,
     theme::SemanticColor,
 };
@@ -136,7 +137,7 @@ pub(super) fn render_provider_form(
     state: &TuiState,
     form: &ProviderFormOverlay,
 ) {
-    let region = centered_rect(frame.area(), PROVIDER_OVERLAY_WIDTH, 19);
+    let region = centered_rect(frame.area(), PROVIDER_OVERLAY_WIDTH, 20);
     render_surface(frame, state, region, form.title());
     let inner = inset(region, 2, 1);
     let value_width = inner.width.saturating_sub(24).max(1) as usize;
@@ -166,6 +167,11 @@ pub(super) fn render_provider_form(
                     None => "Messages".to_owned(),
                 },
                 ProviderFormField::ApiKey => form.masked_api_key(),
+                ProviderFormField::ReasoningEffort => form
+                    .field_viewport(*field, value_width)
+                    .map(|viewport| viewport.text)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_default(),
                 _ => form
                     .field_viewport(*field, value_width)
                     .map(|viewport| viewport.text)
@@ -196,6 +202,11 @@ pub(super) fn render_provider_form(
                     ProviderFormField::Model => {
                         &[("Enter", "Models"), ("Ctrl+S", "Save"), ("Esc", "Back")]
                     }
+                    ProviderFormField::ReasoningEffort => &[
+                        ("Ctrl+Space", "Presets"),
+                        ("Ctrl+S", "Save"),
+                        ("Esc", "Back"),
+                    ],
                     ProviderFormField::Save => &[("Enter", "Save"), ("Esc", "Back")],
                     _ => &[
                         ("Tab", "Next"),
@@ -352,6 +363,105 @@ pub(super) fn render_model_picker(
     ));
 }
 
+pub(super) fn render_reasoning_picker(
+    frame: &mut Frame<'_>,
+    state: &TuiState,
+    picker: &ReasoningPickerOverlay,
+) {
+    let region = centered_rect(frame.area(), PROVIDER_OVERLAY_WIDTH, 20);
+    render_surface(frame, state, region, " M  Thinking mode ");
+    let inner = inset(region, 2, 1);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(3),
+        ])
+        .split(inner);
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled(
+                    picker.model().to_owned(),
+                    semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  {}", picker.alias()),
+                    semantic_style(state, SemanticColor::Muted),
+                ),
+            ]),
+            Line::from(Span::styled(
+                "Choose a thinking mode for this model",
+                semantic_style(state, SemanticColor::Muted),
+            )),
+        ]),
+        rows[0],
+    );
+
+    if let Some(editor) = picker.custom_editor() {
+        let viewport = editor.viewport(rows[1].width.saturating_sub(10) as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Custom ", semantic_style(state, SemanticColor::Focus)),
+                Span::styled(
+                    viewport.text.clone(),
+                    semantic_style(state, SemanticColor::Assistant),
+                ),
+            ])),
+            rows[1],
+        );
+        let status = picker
+            .error()
+            .unwrap_or("Enter a provider-supported reasoning identifier");
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    status,
+                    if picker.error().is_some() {
+                        semantic_style(state, SemanticColor::Error)
+                    } else {
+                        semantic_style(state, SemanticColor::Muted)
+                    },
+                )),
+                action_hint_line(state, &[("Enter", "Use"), ("Esc", "Back")]),
+            ]),
+            rows[2],
+        );
+        frame.set_cursor_position(Position::new(
+            rows[1]
+                .x
+                .saturating_add(7)
+                .saturating_add(viewport.cursor_column as u16)
+                .min(rows[1].right().saturating_sub(1)),
+            rows[1].y,
+        ));
+        return;
+    }
+
+    let lines = (0..picker.option_count())
+        .map(|index| {
+            let selected = index == picker.selected();
+            let base = selection_style(state, selected);
+            Line::from(vec![
+                Span::styled(if selected { "▌ " } else { "  " }, base),
+                Span::styled(
+                    picker.option_label(index),
+                    base.add_modifier(Modifier::BOLD),
+                ),
+            ])
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(lines), rows[1]);
+    frame.render_widget(
+        Paragraph::new(action_hint_line(
+            state,
+            &[("Enter", "Use"), ("Esc", "Back")],
+        )),
+        rows[2],
+    );
+}
+
 fn form_field_label(field: ProviderFormField) -> &'static str {
     match field {
         ProviderFormField::DisplayName => "Provider name",
@@ -361,6 +471,7 @@ fn form_field_label(field: ProviderFormField) -> &'static str {
         ProviderFormField::BaseUrl => "Base URL",
         ProviderFormField::ApiKey => "API key",
         ProviderFormField::Model => "Initial model",
+        ProviderFormField::ReasoningEffort => "Thinking mode",
         ProviderFormField::Save => "Save provider",
     }
 }

--- a/crates/merry-cli/src/tui/provider_selection.rs
+++ b/crates/merry-cli/src/tui/provider_selection.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelPickerTarget {
+    ActiveProvider,
+    ProviderForm,
+}

--- a/crates/merry-cli/src/tui/reasoning_picker.rs
+++ b/crates/merry-cli/src/tui/reasoning_picker.rs
@@ -1,0 +1,201 @@
+use super::{
+    input::TextInput, preferences::REASONING_EFFORT_PRESETS, provider_selection::ModelPickerTarget,
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use merry_llm::ReasoningEffort;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReasoningPickerOverlay {
+    alias: String,
+    model: String,
+    target: ModelPickerTarget,
+    selected: usize,
+    custom_editor: Option<TextInput>,
+    error: Option<String>,
+}
+
+impl ReasoningPickerOverlay {
+    pub(crate) fn new(alias: String, model: String, target: ModelPickerTarget) -> Self {
+        Self {
+            alias,
+            model,
+            target,
+            selected: 0,
+            custom_editor: None,
+            error: None,
+        }
+    }
+
+    pub(crate) fn alias(&self) -> &str {
+        &self.alias
+    }
+
+    pub(crate) fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub(crate) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub(crate) fn custom_editor(&self) -> Option<&TextInput> {
+        self.custom_editor.as_ref()
+    }
+
+    pub(crate) fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    pub(crate) fn insert_paste(&mut self, text: &str) {
+        if let Some(editor) = self.custom_editor.as_mut() {
+            editor.insert_str(text);
+            self.error = None;
+        }
+    }
+
+    pub(crate) fn option_count(&self) -> usize {
+        REASONING_EFFORT_PRESETS.len() + 1
+    }
+
+    pub(crate) fn option_label(&self, index: usize) -> &str {
+        REASONING_EFFORT_PRESETS
+            .get(index)
+            .copied()
+            .unwrap_or("Custom")
+    }
+
+    pub(crate) fn handle_key(&mut self, key: KeyEvent) -> ReasoningPickerAction {
+        if let Some(editor) = self.custom_editor.as_mut() {
+            return match key.code {
+                KeyCode::Esc => {
+                    self.custom_editor = None;
+                    self.error = None;
+                    ReasoningPickerAction::Consumed
+                }
+                KeyCode::Enter => match ReasoningEffort::new(editor.text().trim()) {
+                    Ok(reasoning_effort) => ReasoningPickerAction::SelectReasoning {
+                        alias: self.alias.clone(),
+                        model: self.model.clone(),
+                        reasoning_effort,
+                        target: self.target,
+                    },
+                    Err(error) => {
+                        self.error = Some(error.to_string());
+                        ReasoningPickerAction::Consumed
+                    }
+                },
+                _ => {
+                    editor.handle_key(key);
+                    self.error = None;
+                    ReasoningPickerAction::Consumed
+                }
+            };
+        }
+
+        match key.code {
+            KeyCode::Esc => ReasoningPickerAction::Back,
+            KeyCode::Down => {
+                self.selected = (self.selected + 1).min(self.option_count() - 1);
+                ReasoningPickerAction::Consumed
+            }
+            KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+                ReasoningPickerAction::Consumed
+            }
+            KeyCode::Enter => {
+                if let Some(value) = REASONING_EFFORT_PRESETS.get(self.selected) {
+                    let reasoning_effort = ReasoningEffort::new(value)
+                        .expect("built-in reasoning effort should validate");
+                    ReasoningPickerAction::SelectReasoning {
+                        alias: self.alias.clone(),
+                        model: self.model.clone(),
+                        reasoning_effort,
+                        target: self.target,
+                    }
+                } else {
+                    self.custom_editor = Some(TextInput::default());
+                    self.error = None;
+                    ReasoningPickerAction::Consumed
+                }
+            }
+            _ => ReasoningPickerAction::Consumed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReasoningPickerAction {
+    Consumed,
+    Back,
+    SelectReasoning {
+        alias: String,
+        model: String,
+        reasoning_effort: ReasoningEffort,
+        target: ModelPickerTarget,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reasoning_picker_has_no_empty_default_and_accepts_custom_values() {
+        let mut picker = ReasoningPickerOverlay::new(
+            "opencode".to_owned(),
+            "model-a".to_owned(),
+            ModelPickerTarget::ActiveProvider,
+        );
+        assert_eq!(picker.option_count(), REASONING_EFFORT_PRESETS.len() + 1);
+        assert!((0..picker.option_count()).all(|index| picker.option_label(index) != "Default"));
+
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(
+                KeyCode::Enter,
+                crossterm::event::KeyModifiers::NONE
+            )),
+            ReasoningPickerAction::SelectReasoning {
+                alias: "opencode".to_owned(),
+                model: "model-a".to_owned(),
+                reasoning_effort: ReasoningEffort::new("minimal").expect("preset is valid"),
+                target: ModelPickerTarget::ActiveProvider,
+            }
+        );
+
+        let mut custom = ReasoningPickerOverlay::new(
+            "opencode".to_owned(),
+            "model-b".to_owned(),
+            ModelPickerTarget::ActiveProvider,
+        );
+        for _ in 0..REASONING_EFFORT_PRESETS.len() {
+            let _ = custom.handle_key(KeyEvent::new(
+                KeyCode::Down,
+                crossterm::event::KeyModifiers::NONE,
+            ));
+        }
+        assert_eq!(
+            custom.handle_key(KeyEvent::new(
+                KeyCode::Enter,
+                crossterm::event::KeyModifiers::NONE,
+            )),
+            ReasoningPickerAction::Consumed
+        );
+        custom
+            .custom_editor
+            .as_mut()
+            .expect("custom editor should open")
+            .replace_text("max ultra".to_owned());
+        assert_eq!(
+            custom.handle_key(KeyEvent::new(
+                KeyCode::Enter,
+                crossterm::event::KeyModifiers::NONE,
+            )),
+            ReasoningPickerAction::SelectReasoning {
+                alias: "opencode".to_owned(),
+                model: "model-b".to_owned(),
+                reasoning_effort: ReasoningEffort::new("max ultra").expect("custom is valid"),
+                target: ModelPickerTarget::ActiveProvider,
+            }
+        );
+    }
+}

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -1,6 +1,6 @@
 use crate::cli_error::{CliError, debug_openai_usage_error, unexpected};
 use crate::coding::{
-    CodingPermissionPolicy, HeadlessCodingRuntimeInput, ProcessExecutionMode,
+    CodingPermissionPolicy, CodingTrustMode, HeadlessCodingRuntimeInput, ProcessExecutionMode,
     action_process_runner_for_mode, build_headless_coding_with_policy_composition,
     coding_agent_process_admission, resume_headless_coding_composition_with_policy,
 };
@@ -131,11 +131,17 @@ pub(crate) async fn start_tui_runtime_session(
         ),
         workspace_tool_limits: None,
     };
-    let permission_policy = if fully_trusted {
-        CodingPermissionPolicy::fully_trusted()
-    } else {
-        CodingPermissionPolicy::model_then_host_fallback(permission_source)
-    };
+    let permission_policy = CodingPermissionPolicy::for_process_boundary(
+        process_execution_mode.into(),
+        if fully_trusted {
+            CodingTrustMode::FullyTrusted
+        } else {
+            CodingTrustMode::Reviewed
+        },
+        owned_config.no_sandbox_review_mode(),
+        Some(permission_source),
+    )
+    .map_err(unexpected)?;
     let coding_runtime = if should_resume {
         resume_headless_coding_composition_with_policy(
             runtime_input,
@@ -423,9 +429,25 @@ fn generation_config_with_preferences(
     merry_config: Option<&MerryConfig>,
     preferences: &TuiPreferences,
 ) -> Result<GenerationConfig, crate::config::ConfigError> {
-    let reasoning_effort = preferences
-        .reasoning_effort
-        .clone()
+    let selected_provider = match preferences.provider.as_deref() {
+        Some(provider) => Some(provider.to_owned()),
+        None => merry_config
+            .map(MerryConfig::configured_default_provider)
+            .transpose()?
+            .flatten()
+            .map(|provider| provider.alias),
+    };
+    let preference_reasoning_effort = selected_provider
+        .as_deref()
+        .and_then(|provider| preferences.reasoning_effort_for_provider(provider))
+        .cloned();
+    let provider_reasoning_effort = merry_config
+        .zip(selected_provider.as_deref())
+        .map(|(config, provider)| config.effective_provider_reasoning_effort(provider))
+        .transpose()?
+        .flatten();
+    let reasoning_effort = preference_reasoning_effort
+        .or(provider_reasoning_effort)
         .or(main_reasoning_effort(merry_config)?);
     Ok(GenerationConfig::default().with_reasoning_effort(reasoning_effort))
 }
@@ -507,7 +529,49 @@ api_key = "sk-test"
         .expect("config should parse")
         .expect("config should exist");
         let mut preferences = TuiPreferences::default();
-        preferences.reasoning_effort = Some(merry_llm::ReasoningEffort::new("high").unwrap());
+        preferences
+            .set_reasoning_effort_for_provider(
+                "compat",
+                Some(merry_llm::ReasoningEffort::new("high").unwrap()),
+            )
+            .expect("reasoning preference should be valid");
+
+        let generation = generation_config_with_preferences(Some(&config), &preferences)
+            .expect("generation config should build");
+
+        assert_eq!(
+            generation.reasoning_effort().map(|effort| effort.as_str()),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn selected_provider_reasoning_effort_is_used_when_preference_is_inherited() {
+        let paths = XdgPaths::from_parts(std::path::PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "compat"
+model = "gpt-test"
+
+[providers.compat]
+type = "openai-compatible"
+api_key = "sk-test"
+
+[providers.alt]
+type = "openai-compatible"
+default_model = "alt-model"
+reasoning_effort = "high"
+api_key = "sk-alt-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should exist");
+        let mut preferences = TuiPreferences::default();
+        preferences.provider = Some("alt".to_owned());
 
         let generation = generation_config_with_preferences(Some(&config), &preferences)
             .expect("generation config should build");

--- a/crates/merry-cli/src/tui/state.rs
+++ b/crates/merry-cli/src/tui/state.rs
@@ -12,6 +12,7 @@ use super::{
         ModelListItem, ModelPickerOverlay, ProviderFormOverlay, ProviderFormSeed,
         ProviderFormValues, ProviderListItem, ProviderManagerOverlay,
     },
+    reasoning_picker::ReasoningPickerOverlay,
     status::{format_header_status_parts, format_session_usage_full},
     theme::TuiTheme,
 };
@@ -215,6 +216,7 @@ pub(crate) struct TuiState {
     dialog_back: Option<Box<Overlay>>,
     provider_overlay_back: Option<ProviderOverlayBack>,
     provider_form_back: Option<ProviderFormOverlay>,
+    reasoning_picker_back: Option<Box<Overlay>>,
     preferences: TuiPreferences,
     settings_defaults: TuiSettingsDefaults,
     plan: PlanUiState,
@@ -279,6 +281,7 @@ impl TuiState {
             dialog_back: None,
             provider_overlay_back: None,
             provider_form_back: None,
+            reasoning_picker_back: None,
             preferences: TuiPreferences::default(),
             settings_defaults: TuiSettingsDefaults::default(),
             plan: PlanUiState::default(),
@@ -499,6 +502,7 @@ impl TuiState {
 
     pub(crate) fn open_provider_manager(&mut self, items: Vec<ProviderListItem>) {
         self.provider_form_back = None;
+        self.reasoning_picker_back = None;
         match self.overlay.take() {
             Some(Overlay::CommandPalette(_)) => {
                 self.provider_overlay_back = Some(ProviderOverlayBack::CommandPalette);
@@ -507,7 +511,10 @@ impl TuiState {
                 self.provider_overlay_back = Some(ProviderOverlayBack::Settings(settings));
             }
             Some(
-                Overlay::ProviderManager(_) | Overlay::ProviderForm(_) | Overlay::ModelPicker(_),
+                Overlay::ProviderManager(_)
+                | Overlay::ProviderForm(_)
+                | Overlay::ModelPicker(_)
+                | Overlay::ReasoningPicker(_),
             ) => {}
             Some(
                 Overlay::PlanApproval(_)
@@ -554,6 +561,7 @@ impl TuiState {
         models: Vec<ModelListItem>,
     ) {
         self.provider_form_back = None;
+        self.reasoning_picker_back = None;
         self.overlay = Some(Overlay::ModelPicker(ModelPickerOverlay::new(
             alias,
             display_name,
@@ -583,6 +591,22 @@ impl TuiState {
         true
     }
 
+    pub(crate) fn open_reasoning_picker(
+        &mut self,
+        alias: String,
+        model: String,
+        target: super::provider_overlay::ModelPickerTarget,
+    ) -> bool {
+        let Some(previous) = self.overlay.take() else {
+            return false;
+        };
+        self.reasoning_picker_back = Some(Box::new(previous));
+        self.overlay = Some(Overlay::ReasoningPicker(ReasoningPickerOverlay::new(
+            alias, model, target,
+        )));
+        true
+    }
+
     pub(crate) fn provider_form_discovery_request(
         &self,
     ) -> Option<(Option<String>, ProviderFormValues)> {
@@ -591,13 +615,34 @@ impl TuiState {
             .map(ProviderFormOverlay::discovery_request)
     }
 
-    pub(crate) fn select_provider_form_model(&mut self, model: &str) -> bool {
+    pub(crate) fn select_provider_form_model_with_reasoning(
+        &mut self,
+        model: &str,
+        reasoning_effort: &str,
+    ) -> bool {
         let Some(mut form) = self.provider_form_back.take() else {
             return false;
         };
-        form.set_model(model);
+        form.set_model_and_reasoning(model, reasoning_effort);
         self.overlay = Some(Overlay::ProviderForm(form));
+        self.reasoning_picker_back = None;
         true
+    }
+
+    pub(crate) fn restore_settings_after_reasoning_picker(&mut self) -> bool {
+        let Some(back) = self.reasoning_picker_back.take() else {
+            return false;
+        };
+        match *back {
+            Overlay::Settings(settings) => {
+                self.overlay = Some(Overlay::Settings(settings));
+                true
+            }
+            overlay => {
+                self.reasoning_picker_back = Some(Box::new(overlay));
+                false
+            }
+        }
     }
 
     pub(crate) fn update_model_picker(
@@ -708,6 +753,7 @@ impl TuiState {
         self.dialog_back = None;
         self.provider_overlay_back = None;
         self.provider_form_back = None;
+        self.reasoning_picker_back = None;
     }
 
     pub(crate) fn back_overlay(&mut self) {
@@ -727,6 +773,9 @@ impl TuiState {
             }
             Some(Overlay::ModelPicker(_)) => {
                 self.provider_form_back.take().map(Overlay::ProviderForm)
+            }
+            Some(Overlay::ReasoningPicker(_)) => {
+                self.reasoning_picker_back.take().map(|overlay| *overlay)
             }
             _ => None,
         };

--- a/crates/merry-cli/src/tui/state/settings.rs
+++ b/crates/merry-cli/src/tui/state/settings.rs
@@ -2,7 +2,10 @@ use super::TuiState;
 use crate::tui::{
     input::TextInput,
     overlay::{Overlay, SettingDirection, SettingItem},
-    preferences::{CodeTheme, CompactionStrategy, TuiPreferences, TuiSettingsDefaults},
+    preferences::{
+        CodeTheme, CompactionStrategy, REASONING_EFFORT_PRESETS, TuiPreferences,
+        TuiSettingsDefaults,
+    },
 };
 
 impl TuiState {
@@ -44,6 +47,13 @@ impl TuiState {
         }
     }
 
+    pub(crate) fn settings_reasoning_editor(&self) -> Option<&TextInput> {
+        match self.overlay.as_ref() {
+            Some(Overlay::Settings(settings)) => settings.reasoning_editor(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn settings_notice(&self) -> Option<&str> {
         match self.overlay.as_ref() {
             Some(Overlay::Settings(settings)) => settings.notice(),
@@ -67,28 +77,25 @@ impl TuiState {
         }
     }
 
-    pub(crate) fn commit_settings_model(&mut self, value: String) -> bool {
+    pub(crate) fn commit_settings_model(&mut self, value: String) -> Option<(String, String)> {
         let Some(provider) = self.effective_provider_alias().map(str::to_owned) else {
             self.set_settings_notice(Some("Select a provider first".to_owned()));
-            return false;
+            return None;
         };
         let value = value.trim();
-        let result = if value.is_empty() {
-            self.preferences.set_model_for_provider(&provider, None)
-        } else {
-            self.preferences
-                .set_model_for_provider(&provider, Some(value))
-        };
-        match result {
-            Ok(()) => {
-                self.set_settings_notice(Some("Applied".to_owned()));
-                true
+        if value.is_empty() {
+            match self.preferences.set_model_for_provider(&provider, None) {
+                Ok(()) => self.set_settings_notice(Some("Applied".to_owned())),
+                Err(error) => self.set_settings_notice(Some(error.to_string())),
             }
-            Err(error) => {
-                self.set_settings_notice(Some(error.to_string()));
-                false
-            }
+            return None;
         }
+        if let Err(error) = merry_llm::ModelName::new(value) {
+            self.set_settings_notice(Some(error.to_string()));
+            return None;
+        }
+        self.set_settings_notice(Some("Choose a thinking mode".to_owned()));
+        Some((provider, value.to_owned()))
     }
 
     pub(crate) fn begin_settings_context_window_edit(&mut self) {
@@ -100,6 +107,55 @@ impl TuiState {
         if let Some(Overlay::Settings(settings)) = self.overlay.as_mut() {
             settings.begin_context_window_edit(value);
         }
+    }
+
+    pub(crate) fn begin_settings_reasoning_edit(&mut self) {
+        let provider = self.effective_provider_alias().map(str::to_owned);
+        let value = provider
+            .as_deref()
+            .and_then(|provider| {
+                self.preferences
+                    .reasoning_label_for_provider(provider)
+                    .map(str::to_owned)
+            })
+            .or_else(|| {
+                self.settings_defaults
+                    .reasoning_effort_for_provider(provider.as_deref())
+                    .map(merry_llm::ReasoningEffort::as_str)
+                    .map(str::to_owned)
+            })
+            .unwrap_or_default();
+        if let Some(Overlay::Settings(settings)) = self.overlay.as_mut() {
+            settings.begin_reasoning_edit(value);
+        }
+    }
+
+    pub(crate) fn commit_settings_reasoning(&mut self, value: String) -> bool {
+        let value = value.trim();
+        let reasoning_effort = if value.is_empty() {
+            None
+        } else {
+            match merry_llm::ReasoningEffort::new(value) {
+                Ok(effort) => Some(effort),
+                Err(error) => {
+                    self.set_settings_notice(Some(error.to_string()));
+                    return false;
+                }
+            }
+        };
+        let Some(provider) = self.effective_provider_alias().map(str::to_owned) else {
+            self.set_settings_notice(Some("Select a provider first".to_owned()));
+            return false;
+        };
+        if let Err(error) = self
+            .preferences
+            .set_reasoning_effort_for_provider(&provider, reasoning_effort)
+        {
+            self.set_settings_notice(Some(error.to_string()));
+            return false;
+        }
+        self.set_settings_notice(Some("Applied".to_owned()));
+        true
     }
 
     pub(crate) fn commit_settings_context_window(&mut self, value: String) -> bool {
@@ -150,7 +206,13 @@ impl TuiState {
                     let _ = self.preferences.set_model_for_provider(&provider, None);
                 }
             }
-            SettingItem::ReasoningEffort => self.preferences.reasoning_effort = None,
+            SettingItem::ReasoningEffort => {
+                if let Some(provider) = self.effective_provider_alias().map(str::to_owned) {
+                    let _ = self
+                        .preferences
+                        .set_reasoning_effort_for_provider(&provider, None);
+                }
+            }
             SettingItem::ContextWindow => self.preferences.context_window_tokens = None,
             SettingItem::AutoCompaction => self.preferences.auto_compaction_enabled = None,
             SettingItem::ContextStrategy => self.preferences.compaction_strategy = None,
@@ -177,10 +239,10 @@ impl TuiState {
                 )
             }
             SettingItem::ReasoningEffort => inherited_value(
-                self.preferences.reasoning_label(),
+                self.effective_provider_alias()
+                    .and_then(|provider| self.preferences.reasoning_label_for_provider(provider)),
                 self.settings_defaults
-                    .reasoning_effort
-                    .as_ref()
+                    .reasoning_effort_for_provider(self.effective_provider_alias())
                     .map(merry_llm::ReasoningEffort::as_str),
             ),
             SettingItem::ContextWindow => self
@@ -268,22 +330,31 @@ impl TuiState {
     }
 
     fn adjust_reasoning(&mut self, direction: SettingDirection) {
-        const VALUES: [&str; 5] = ["minimal", "low", "medium", "high", "xhigh"];
+        let Some(provider) = self.effective_provider_alias().map(str::to_owned) else {
+            return;
+        };
         let current = self
             .preferences
-            .reasoning_label()
-            .and_then(|effort| VALUES.iter().position(|value| *value == effort))
+            .reasoning_label_for_provider(&provider)
+            .and_then(|effort| {
+                REASONING_EFFORT_PRESETS
+                    .iter()
+                    .position(|value| *value == effort)
+            })
             .map(|index| index + 1)
             .unwrap_or(0);
-        let count = VALUES.len() + 1;
+        let count = REASONING_EFFORT_PRESETS.len() + 1;
         let next = match direction {
             SettingDirection::Previous => (current + count - 1) % count,
             SettingDirection::Next => (current + 1) % count,
         };
-        self.preferences.reasoning_effort = (next > 0).then(|| {
-            merry_llm::ReasoningEffort::new(VALUES[next - 1])
+        let reasoning_effort = (next > 0).then(|| {
+            merry_llm::ReasoningEffort::new(REASONING_EFFORT_PRESETS[next - 1])
                 .expect("static reasoning effort should validate")
         });
+        let _ = self
+            .preferences
+            .set_reasoning_effort_for_provider(&provider, reasoning_effort);
     }
 
     fn adjust_auto_compaction(&mut self, direction: SettingDirection) {

--- a/crates/merry-cli/src/tui/tests.rs
+++ b/crates/merry-cli/src/tui/tests.rs
@@ -5,9 +5,9 @@ use super::controller::{
 };
 use super::input::{DraftImage, TextInput, TuiSubmission};
 use super::keymap::{KeyAction, KeyBinding, Keymap};
-use super::overlay::{Overlay, PaletteCommand};
+use super::overlay::{Overlay, PaletteCommand, SettingItem};
 use super::panels::{FocusPanelBody, FocusPanelTone, focus_panel_view};
-use super::preferences::CodeTheme;
+use super::preferences::{CodeTheme, TuiPreferences, TuiSettingsDefaults};
 use super::projector::TuiProjector;
 use super::provider_overlay::{ModelListItem, ProviderListItem};
 use super::render::{render_to_buffer, render_to_buffer_and_cursor, render_to_text};
@@ -28,9 +28,9 @@ use ratatui::{
     style::{Color, Modifier},
 };
 use serde_json::json;
-use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
+use std::{collections::BTreeMap, fs};
 
 fn text_submission(text: &str) -> TuiSubmission {
     TuiSubmission {
@@ -1233,6 +1233,51 @@ fn model_discovery_error_dialog_returns_to_model_picker() {
 }
 
 #[test]
+fn model_selection_requires_reasoning_before_it_emits_a_runtime_change() {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    state.open_model_picker(
+        "opencode".to_owned(),
+        "OpenCode".to_owned(),
+        vec![ModelListItem::new("model-a", None)],
+    );
+
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut state,
+        ),
+        ControllerEffect::OpenReasoningPicker {
+            alias: "opencode".to_owned(),
+            model: "model-a".to_owned(),
+            target: super::provider_overlay::ModelPickerTarget::ActiveProvider,
+        }
+    );
+    assert!(state.open_reasoning_picker(
+        "opencode".to_owned(),
+        "model-a".to_owned(),
+        super::provider_overlay::ModelPickerTarget::ActiveProvider,
+    ));
+
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut state,
+        ),
+        ControllerEffect::ApplyProviderModel {
+            alias: "opencode".to_owned(),
+            model: "model-a".to_owned(),
+            reasoning_effort: merry_llm::ReasoningEffort::new("minimal").expect("preset is valid"),
+            target: super::provider_overlay::ModelPickerTarget::ActiveProvider,
+        }
+    );
+}
+
+#[test]
 fn command_palette_uses_a_magenta_selection_surface() {
     let mut state = TuiState::new(
         "/repo".into(),
@@ -1419,6 +1464,8 @@ fn provider_surfaces_fit_supported_terminal_sizes_without_secret_exposure() {
     let form = render_to_text(&state, 100, 30);
     assert!(form.contains("API protocol"));
     assert!(form.contains("Responses"));
+    assert!(form.contains("Thinking mode"));
+    assert!(!form.contains("Default"));
     assert!(form.contains("Save provider"));
     assert!(form.contains("Ctrl+S Save"));
     for (width, height) in [(100, 30), (80, 24), (40, 16)] {
@@ -1439,6 +1486,7 @@ fn provider_surfaces_fit_supported_terminal_sizes_without_secret_exposure() {
             protocol: Some(merry_provider_openai::OpenAiProtocol::ChatCompletions),
             base_url: "https://gateway.example.test/v1".to_owned(),
             model: "deepseek-v4-pro".to_owned(),
+            reasoning_effort: None,
         },
         Default::default(),
     );
@@ -1482,12 +1530,42 @@ fn provider_form_model_picker_returns_selection_to_the_form() {
             protocol: Some(merry_provider_openai::OpenAiProtocol::ChatCompletions),
             base_url: "https://opencode.example.test/v1".to_owned(),
             model: "model-a".to_owned(),
+            reasoning_effort: None,
         },
         Default::default(),
     );
 
     assert!(state.open_provider_form_model_picker("opencode".to_owned(), "OpenCode".to_owned(),));
-    assert!(state.select_provider_form_model("model-b"));
+    state.update_model_picker("opencode", Ok(vec![ModelListItem::new("model-b", None)]));
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut state,
+        ),
+        ControllerEffect::OpenReasoningPicker {
+            alias: "opencode".to_owned(),
+            model: "model-b".to_owned(),
+            target: super::provider_overlay::ModelPickerTarget::ProviderForm,
+        }
+    );
+    assert!(state.open_reasoning_picker(
+        "opencode".to_owned(),
+        "model-b".to_owned(),
+        super::provider_overlay::ModelPickerTarget::ProviderForm,
+    ));
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut state,
+        ),
+        ControllerEffect::ApplyProviderModel {
+            alias: "opencode".to_owned(),
+            model: "model-b".to_owned(),
+            reasoning_effort: merry_llm::ReasoningEffort::new("minimal").expect("preset is valid"),
+            target: super::provider_overlay::ModelPickerTarget::ProviderForm,
+        }
+    );
+    assert!(state.select_provider_form_model_with_reasoning("model-b", "minimal"));
 
     let Some(Overlay::ProviderForm(form)) = state.overlay() else {
         panic!("provider form should be restored");
@@ -1498,8 +1576,9 @@ fn provider_form_model_picker_returns_selection_to_the_form() {
     );
     assert_eq!(
         form.selected_field(),
-        super::provider_overlay::ProviderFormField::Model
+        super::provider_overlay::ProviderFormField::ReasoningEffort
     );
+    assert_eq!(form.reasoning_effort_text(), "minimal");
 }
 
 #[test]
@@ -1621,6 +1700,13 @@ fn settings_reasoning_change_applies_to_the_current_runtime() {
         Keymap::default(),
         TuiTheme::default(),
     );
+    state.configure_preferences(
+        TuiPreferences::default(),
+        TuiSettingsDefaults {
+            provider: Some("compat".to_owned()),
+            ..TuiSettingsDefaults::default()
+        },
+    );
     handle_key_event(
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
         &mut state,
@@ -1647,9 +1733,109 @@ fn settings_reasoning_change_applies_to_the_current_runtime() {
     assert!(matches!(
         effect,
         ControllerEffect::ApplyRuntimePreferences(preferences)
-            if preferences.reasoning_effort.is_some()
+            if preferences
+                .reasoning_effort_for_provider("compat")
+                .map(|effort| effort.as_str())
+                == Some("minimal")
     ));
     assert_eq!(state.settings_notice(), Some("Applied"));
+
+    for expected in ["low", "medium", "high", "xhigh", "max", "ultra"] {
+        let effect = handle_key_event(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::NONE),
+            &mut state,
+        );
+        assert!(matches!(
+            effect,
+            ControllerEffect::ApplyRuntimePreferences(preferences)
+                if preferences
+                    .reasoning_effort_for_provider("compat")
+                    .map(|effort| effort.as_str())
+                    == Some(expected)
+        ));
+    }
+}
+
+#[test]
+fn settings_reasoning_editor_accepts_custom_provider_value() {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    state.configure_preferences(
+        TuiPreferences::default(),
+        TuiSettingsDefaults {
+            provider: Some("compat".to_owned()),
+            ..TuiSettingsDefaults::default()
+        },
+    );
+    state.open_settings();
+    for _ in 0..3 {
+        handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE), &mut state);
+    }
+
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut state,
+        ),
+        ControllerEffect::None
+    );
+    assert!(state.settings_reasoning_editor().is_some());
+    handle_paste_event("model-specific", &mut state);
+
+    let effect = handle_key_event(
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        &mut state,
+    );
+
+    assert!(matches!(
+        effect,
+        ControllerEffect::ApplyRuntimePreferences(preferences)
+            if preferences
+                .reasoning_effort_for_provider("compat")
+                .map(|effort| effort.as_str())
+                == Some("model-specific")
+    ));
+    assert_eq!(state.settings_notice(), Some("Applied"));
+}
+
+#[test]
+fn settings_reasoning_display_and_editor_follow_the_selected_provider() {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    let mut preferences = TuiPreferences::default();
+    preferences.provider = Some("alt".to_owned());
+    let defaults = TuiSettingsDefaults {
+        provider_aliases: vec!["compat".to_owned(), "alt".to_owned()],
+        provider: Some("compat".to_owned()),
+        reasoning_efforts: BTreeMap::from([(
+            "alt".to_owned(),
+            merry_llm::ReasoningEffort::new("max ultra").expect("custom effort should validate"),
+        )]),
+        ..TuiSettingsDefaults::default()
+    };
+    state.configure_preferences(preferences, defaults);
+
+    assert_eq!(
+        state.setting_value(SettingItem::ReasoningEffort),
+        "Inherit (max ultra)"
+    );
+    state.open_settings();
+    state.begin_settings_reasoning_edit();
+    assert_eq!(
+        state
+            .settings_reasoning_editor()
+            .expect("reasoning editor should open")
+            .text(),
+        "max ultra"
+    );
 }
 
 #[test]

--- a/crates/merry-coding/src/lib.rs
+++ b/crates/merry-coding/src/lib.rs
@@ -19,8 +19,10 @@ pub use project_rules::{
     load_root_project_rules,
 };
 pub use runtime::{
-    CodingModelRoleConfig, CodingModelRoleConfigError, CodingPermissionPolicy, CodingRuntime,
-    CodingRuntimeBuildError, CodingRuntimeBuilder, CodingRuntimeInput, CodingSubagentsConfig,
+    CodingModelRoleConfig, CodingModelRoleConfigError, CodingPermissionPolicy,
+    CodingPermissionPolicyError, CodingProcessBoundary, CodingRuntime, CodingRuntimeBuildError,
+    CodingRuntimeBuilder, CodingRuntimeInput, CodingSubagentsConfig, CodingTrustMode,
+    NoSandboxReviewMode,
 };
 
 use merry_core::{CoreError, ToolName};

--- a/crates/merry-coding/src/runtime.rs
+++ b/crates/merry-coding/src/runtime.rs
@@ -79,6 +79,45 @@ pub enum CodingModelRoleConfigError {
     PrimaryRole,
 }
 
+/// Product process boundary used to select coding permission policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodingProcessBoundary {
+    /// Process actions run directly in the host environment.
+    Unrestricted,
+    /// Process actions use only the per-action inner sandbox.
+    InnerOnly,
+    /// Process actions use the outer Merry sandbox and the inner sandbox.
+    OuterAndInner,
+}
+
+/// Host/model preference for permission review when the outer sandbox is off.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum NoSandboxReviewMode {
+    /// Use the host admission source directly when one is available.
+    #[default]
+    Host,
+    /// Try model review first and fall back to the host when one is available.
+    Model,
+}
+
+/// Trust mode selected by the product surface for a coding runtime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CodingTrustMode {
+    /// Permission requests must go through the configured review policy.
+    #[default]
+    Reviewed,
+    /// Explicitly skip model and host permission review for configured actions.
+    FullyTrusted,
+}
+
+/// Failure to construct a process-boundary permission policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum CodingPermissionPolicyError {
+    /// A selected policy needs a host admission source, but the surface did not provide one.
+    #[error("{boundary:?} permission review requires a host admission source")]
+    HostAdmissionUnavailable { boundary: CodingProcessBoundary },
+}
+
 /// Permission configuration shared by parent and child coding runtimes.
 ///
 /// This is the only coding-layer representation of permission mode and host
@@ -89,7 +128,10 @@ pub enum CodingPermissionPolicy {
     /// Use the runtime's trust-level default.
     #[default]
     Default,
-    /// Always route permission requests through model-backed review.
+    /// Route permission requests through model-backed review without a host fallback.
+    ///
+    /// The variant name is retained for public API compatibility; use
+    /// [`CodingPermissionPolicy::model_only`] in new code.
     Required,
     /// Route permission requests through the supplied host admission source.
     HostDecisionOnly {
@@ -106,10 +148,16 @@ pub enum CodingPermissionPolicy {
 }
 
 impl CodingPermissionPolicy {
-    /// Always route permission requests through model-backed review.
+    /// Route permission requests through model-backed review without a host fallback.
+    #[must_use]
+    pub const fn model_only() -> Self {
+        Self::Required
+    }
+
+    /// Route permission requests through model-backed review without a host fallback.
     #[must_use]
     pub const fn required() -> Self {
-        Self::Required
+        Self::model_only()
     }
 
     /// Route permission requests through the supplied host admission source.
@@ -128,6 +176,37 @@ impl CodingPermissionPolicy {
     #[must_use]
     pub const fn fully_trusted() -> Self {
         Self::FullyTrusted
+    }
+
+    /// Selects the product policy for one process boundary.
+    ///
+    /// A host fallback is only constructed when the caller supplies a host
+    /// admission source. Callers that need host review must handle the typed
+    /// error instead of silently degrading to another policy.
+    pub fn for_process_boundary(
+        boundary: CodingProcessBoundary,
+        trust: CodingTrustMode,
+        no_sandbox_review: NoSandboxReviewMode,
+        host_source: Option<Arc<dyn PermissionAdmissionSource>>,
+    ) -> Result<Self, CodingPermissionPolicyError> {
+        if trust == CodingTrustMode::FullyTrusted {
+            return Ok(Self::fully_trusted());
+        }
+
+        match boundary {
+            CodingProcessBoundary::OuterAndInner => Ok(Self::model_only()),
+            CodingProcessBoundary::InnerOnly => host_source
+                .map(Self::model_then_host_fallback)
+                .ok_or(CodingPermissionPolicyError::HostAdmissionUnavailable { boundary }),
+            CodingProcessBoundary::Unrestricted => match no_sandbox_review {
+                NoSandboxReviewMode::Host => host_source
+                    .map(Self::host_decision_only)
+                    .ok_or(CodingPermissionPolicyError::HostAdmissionUnavailable { boundary }),
+                NoSandboxReviewMode::Model => host_source
+                    .map(Self::model_then_host_fallback)
+                    .ok_or(CodingPermissionPolicyError::HostAdmissionUnavailable { boundary }),
+            },
+        }
     }
 
     fn apply_to(&self, mut builder: RuntimeBuilder) -> RuntimeBuilder {

--- a/crates/merry-coding/src/tests.rs
+++ b/crates/merry-coding/src/tests.rs
@@ -649,7 +649,7 @@ async fn parent_builder_passes_policy_to_a_real_child_runtime() {
     .expect("approval role should be valid");
     let primary = run_parent_child_policy(
         "coding-parent-child-policy",
-        CodingPermissionPolicy::required(),
+        CodingPermissionPolicy::model_only(),
         vec![approval_role],
     )
     .await;
@@ -659,6 +659,100 @@ async fn parent_builder_passes_policy_to_a_real_child_runtime() {
         "child-approval"
     );
     assert!(primary.recorded_requests().len() >= 3);
+}
+
+#[test]
+fn process_boundary_policy_rejects_missing_host_admission() {
+    let error = match CodingPermissionPolicy::for_process_boundary(
+        CodingProcessBoundary::Unrestricted,
+        CodingTrustMode::Reviewed,
+        NoSandboxReviewMode::Model,
+        None,
+    ) {
+        Ok(_) => panic!("headless host fallback must be explicit"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        CodingPermissionPolicyError::HostAdmissionUnavailable {
+            boundary: CodingProcessBoundary::Unrestricted
+        }
+    ));
+}
+
+#[test]
+fn process_boundary_policy_uses_model_then_host_only_for_interactive_no_sandbox() {
+    let host = CountingAdmission::approving();
+    let policy = CodingPermissionPolicy::for_process_boundary(
+        CodingProcessBoundary::Unrestricted,
+        CodingTrustMode::Reviewed,
+        NoSandboxReviewMode::Model,
+        Some(Arc::new(host)),
+    )
+    .expect("host fallback policy should build");
+
+    assert!(matches!(
+        policy,
+        CodingPermissionPolicy::ModelThenHostFallback { .. }
+    ));
+}
+
+#[test]
+fn process_boundary_policy_defaults_to_host_review_for_interactive_no_sandbox() {
+    let host = CountingAdmission::approving();
+    let policy = CodingPermissionPolicy::for_process_boundary(
+        CodingProcessBoundary::Unrestricted,
+        CodingTrustMode::Reviewed,
+        NoSandboxReviewMode::Host,
+        Some(Arc::new(host)),
+    )
+    .expect("host review policy should build");
+
+    assert!(matches!(
+        policy,
+        CodingPermissionPolicy::HostDecisionOnly { .. }
+    ));
+}
+
+#[test]
+fn process_boundary_policy_keeps_outer_and_inner_model_only() {
+    let host = CountingAdmission::approving();
+    let policy = CodingPermissionPolicy::for_process_boundary(
+        CodingProcessBoundary::OuterAndInner,
+        CodingTrustMode::Reviewed,
+        NoSandboxReviewMode::Model,
+        Some(Arc::new(host)),
+    )
+    .expect("outer and inner model-only policy should build");
+
+    assert!(matches!(policy, CodingPermissionPolicy::Required));
+}
+
+#[test]
+fn outer_and_inner_model_only_does_not_need_a_host_admission_source() {
+    let policy = CodingPermissionPolicy::for_process_boundary(
+        CodingProcessBoundary::OuterAndInner,
+        CodingTrustMode::Reviewed,
+        NoSandboxReviewMode::Model,
+        None,
+    )
+    .expect("outer and inner should remain model-only without host fallback");
+
+    assert!(matches!(policy, CodingPermissionPolicy::Required));
+}
+
+#[test]
+fn fully_trusted_process_policy_does_not_need_a_host_admission_source() {
+    let policy = CodingPermissionPolicy::for_process_boundary(
+        CodingProcessBoundary::Unrestricted,
+        CodingTrustMode::FullyTrusted,
+        NoSandboxReviewMode::Host,
+        None,
+    )
+    .expect("fully trusted mode should not need a reviewer");
+
+    assert!(matches!(policy, CodingPermissionPolicy::FullyTrusted));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/merry/src/profiles/mod.rs
+++ b/crates/merry/src/profiles/mod.rs
@@ -5,10 +5,12 @@ pub use merry_coding::{
     CODING_AGENT_STABLE_PREFIX_LAYOUT, CodingAgentProfile, CodingAgentProfileBuildError,
     CodingAgentProfileBuilder, CodingAgentProfileHash, CodingAgentRunPolicy,
     CodingAgentRunPolicyError, CodingFinalReportPolicy, CodingModelRoleConfig,
-    CodingModelRoleConfigError, CodingPermissionPolicy, CodingRuntime, CodingRuntimeBuildError,
-    CodingRuntimeBuilder, CodingRuntimeInput, CodingSubagentsConfig,
-    DEFAULT_CODING_AGENT_MAX_MODEL_TURNS, MAX_ROOT_PROJECT_RULES_BYTES, ProjectRulesLoadError,
-    ROOT_PROJECT_RULES_FILE, WorkspaceToolLimits, coding_agent, load_root_project_rules,
+    CodingModelRoleConfigError, CodingPermissionPolicy, CodingPermissionPolicyError,
+    CodingProcessBoundary, CodingRuntime, CodingRuntimeBuildError, CodingRuntimeBuilder,
+    CodingRuntimeInput, CodingSubagentsConfig, CodingTrustMode,
+    DEFAULT_CODING_AGENT_MAX_MODEL_TURNS, MAX_ROOT_PROJECT_RULES_BYTES, NoSandboxReviewMode,
+    ProjectRulesLoadError, ROOT_PROJECT_RULES_FILE, WorkspaceToolLimits, coding_agent,
+    load_root_project_rules,
 };
 
 pub use merry_process::{ProcessBackend, ProcessSession};

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -32,6 +32,12 @@ profile = "default"
 # dbus is the D-Bus session bus, including Secret Service/keyring access.
 # ssh_agent = true
 # dbus = true
+# Permission reviews in --no-sandbox remain host-interactive by default. Set
+# this to "model" to review with the configured model first and fall back to
+# the host only when that model review is unavailable. TUI reviews use their
+# dialog; headless `merry run` reviews read yes/no from stdin and write prompts
+# to stderr.
+# no_sandbox_review = "model"
 
 readonly_paths = [
   "/etc",
@@ -145,8 +151,9 @@ format = "json"
 provider = "openai-compatible"
 model = "gpt-4.1-mini"
 # Optional. Sent as Responses API reasoning.effort when supported by the model.
-# Leave unset to use provider/model defaults. Common OpenAI values include
-# minimal, low, medium, high, and model-dependent xhigh.
+# Leave unset to use provider/model defaults. The TUI presets include minimal,
+# low, medium, high, xhigh, max, and ultra; custom provider-supported values
+# are also accepted.
 # reasoning_effort = "medium"
 
 [providers.retry]
@@ -175,6 +182,9 @@ default_model = "gpt-4.1-mini"
 type = "openai-compatible"
 protocol = "responses"
 base_url = "https://api.openai.com/v1"
+# Optional provider-specific default used when this provider is selected in TUI.
+# The value may be any provider-supported reasoning identifier.
+# reasoning_effort = "medium"
 # Prefer api_key_file for local sandboxed smoke runs so the key stays in the
 # mounted config directory instead of argv or process environment.
 api_key_file = "secrets/openai.key"
@@ -186,6 +196,7 @@ api_key_file = "secrets/openai.key"
 # display_name = "Anthropic"
 # default_model = "claude-sonnet-4-5"
 # type = "anthropic"
+# reasoning_effort = "medium"
 # base_url = "https://api.anthropic.com"
 # api_version = "2023-06-01"
 # default_max_output_tokens = 4096


### PR DESCRIPTION
## Summary

- Align permission review routing across outer + inner, inner-only, and --no-sandbox modes.
- Add configurable model-first review for --no-sandbox with host fallback only when the model cannot produce a decision.
- Add the same headless host review path using yes/no input on stdin and prompts on stderr.
- Add provider-managed reasoning effort configuration with built-in minimal, low, medium, high, xhigh, max, and ultra values plus custom values.
- Keep TUI model and reasoning selections per provider, prompt for reasoning after model selection, and preserve selections when editing provider configuration.
- Prepare Merry-owned provider and state directories for sandboxed provider management, including nested writable mounts under trusted read-only parents.

## Deliberate scope decisions

The following known issues are intentionally deferred to a follow-up change to keep this PR bounded:

- Stronger managed-secrets symlink and no-follow hardening in the outer sandbox.
- A shared provider transition coordinator and cross-store recovery/transaction model.
- A stricter atomic model-plus-reasoning selection domain type and removal of duplicated setup/runtime provider orchestration.

These are documented follow-ups, not accidental omissions.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p merry-cli --all-targets`
- `cargo test -p merry-coding --all-targets`
- `cargo test -p merry-runtime --all-targets`
- `cargo test --all --exclude merry-provider-anthropic --exclude merry-provider-openai`
- `cargo test --all` is otherwise blocked by six provider fixture listener tests failing with environment-level `Operation not permitted` while starting their local listener.