### PR TITLE
feat(cli): add headless session resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,29 @@ target/release/merry run "fix the failing tests"
 # Machine-readable runtime events
 target/release/merry run --events-jsonl "inspect the current failure"
 
+# Read the task from stdin instead of argv
+printf '%s' "$task" | target/release/merry run -
+
+# Name a headless session, then continue it in a later run
+target/release/merry run --session-id migration-1 "start the migration"
+target/release/merry run --resume migration-1 "now update the tests"
+
 # Generate a command plan without executing it
 target/release/merry cmd "find the largest Rust files"
 ```
+
+Every `merry run` saves its session state under
+`$XDG_STATE_HOME/merry/sessions/<session-id>` when the run settles, so a later
+`--resume <session-id>` continues that session's ledger, transcript, artifacts,
+and checkpoints. Without `--session-id` the run generates its own id, which the
+`--events-jsonl` stream reports as `source.session_id` on every event. Headless
+sessions carry no TUI metadata and so do not appear in the `merry resume`
+picker; address them by id.
+
+A `TASK` of `-` reads the task text from stdin. Prefer it for generated or
+long prompts: an argv task is visible to every process listing on the host and
+is bounded by the kernel's per-argument limit. Empty or whitespace-only stdin
+is rejected as a usage error (exit 2).
 
 TUI and `run` use outer+inner bubblewrap automatically. `--inner-sandbox`
 selects the Codex-compatible single inner sandbox, while `--no-sandbox`

--- a/README.md
+++ b/README.md
@@ -139,10 +139,21 @@ and checkpoints. Without `--session-id` the run generates its own id, which the
 sessions carry no TUI metadata and so do not appear in the `merry resume`
 picker; address them by id.
 
+`--session-id` starts a session, so it refuses an id the store already holds
+(exit 2) rather than replacing that session's saved state. Continue an existing
+session with `--resume <session-id>` instead.
+
 A `TASK` of `-` reads the task text from stdin. Prefer it for generated or
 long prompts: an argv task is visible to every process listing on the host and
 is bounded by the kernel's per-argument limit. Empty or whitespace-only stdin
 is rejected as a usage error (exit 2).
+
+Reading the task from stdin consumes that stream, so `merry run -` answers
+permission review on the controlling terminal rather than on stdin. Piping
+approval answers alongside the task does not work: they would be read as part
+of the task. When the process has no controlling terminal, review has no way to
+ask and each request is denied with that reason on stderr, so grant the
+capabilities up front or pass the task on argv when a piped run needs approvals.
 
 TUI and `run` use outer+inner bubblewrap automatically. `--inner-sandbox`
 selects the Codex-compatible single inner sandbox, while `--no-sandbox`

--- a/crates/merry-cli/src/headless_review.rs
+++ b/crates/merry-cli/src/headless_review.rs
@@ -9,6 +9,28 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
+/// Where a headless run reads permission-review answers from.
+///
+/// `merry run -` reads the task from stdin to end-of-file, so stdin can no
+/// longer carry answers: reusing it would read that end-of-file and silently
+/// deny every request. Those runs answer on the controlling terminal instead,
+/// and deny with an explicit reason when the process has none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReviewInputChannel {
+    Stdin,
+    ControllingTerminal,
+}
+
+/// Reason recorded when a run has no channel to answer permission review on.
+const NO_REVIEW_INPUT_REASON: &str =
+    "headless permission review had no input channel; defaulting to deny";
+
+/// Operator-facing note explaining why a request was denied unanswered.
+const NO_REVIEW_INPUT_NOTICE: &str = concat!(
+    "\nNo input channel for permission review: the task was read from stdin and ",
+    "no controlling terminal is available. Denying.\n"
+);
+
 pub(crate) struct HeadlessPermissionReviewer {
     source: Arc<ChannelPermissionAdmissionSource>,
     requests: mpsc::Receiver<PermissionReviewRequest>,
@@ -34,7 +56,7 @@ impl HeadlessPermissionReviewer {
         Arc::clone(&self.source)
     }
 
-    pub(crate) fn start(self) -> HeadlessPermissionReviewTask {
+    pub(crate) fn start(self, channel: ReviewInputChannel) -> HeadlessPermissionReviewTask {
         let Self {
             requests,
             cancellation,
@@ -42,7 +64,9 @@ impl HeadlessPermissionReviewer {
         } = self;
         let task_cancellation = cancellation.clone();
         let handle = tokio::spawn(async move {
-            run_headless_permission_review(requests, task_cancellation).await
+            let input = open_review_input(channel).await;
+            run_headless_permission_review(requests, input, tokio::io::stderr(), task_cancellation)
+                .await
         });
         HeadlessPermissionReviewTask {
             cancellation,
@@ -63,12 +87,36 @@ impl HeadlessPermissionReviewTask {
     }
 }
 
-async fn run_headless_permission_review(
+/// Opens the reader that answers permission reviews for this run.
+///
+/// A run whose task came from stdin has already consumed that stream, so it
+/// falls back to the controlling terminal. `None` means review has no way to
+/// ask, which is reported per request rather than silently defaulting to deny.
+async fn open_review_input(
+    channel: ReviewInputChannel,
+) -> Option<Box<dyn AsyncBufRead + Unpin + Send>> {
+    match channel {
+        ReviewInputChannel::Stdin => Some(Box::new(BufReader::new(tokio::io::stdin()))),
+        ReviewInputChannel::ControllingTerminal => tokio::fs::File::open("/dev/tty")
+            .await
+            .ok()
+            .map(|terminal| {
+                Box::new(BufReader::new(terminal)) as Box<dyn AsyncBufRead + Unpin + Send>
+            }),
+    }
+}
+
+async fn run_headless_permission_review<R, W>(
     mut requests: mpsc::Receiver<PermissionReviewRequest>,
+    mut input: Option<R>,
+    output: W,
     cancellation: CancellationToken,
-) -> io::Result<()> {
-    let mut input = BufReader::new(tokio::io::stdin());
-    let mut output = BufWriter::new(tokio::io::stderr());
+) -> io::Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut output = BufWriter::new(output);
 
     loop {
         let Some(request) = (tokio::select! {
@@ -82,13 +130,13 @@ async fn run_headless_permission_review(
         if request.is_cancelled() {
             continue;
         }
-        review_request(request, &mut input, &mut output, &cancellation).await?;
+        review_request(request, input.as_mut(), &mut output, &cancellation).await?;
     }
 }
 
 async fn review_request<R, W>(
     request: PermissionReviewRequest,
-    input: &mut R,
+    input: Option<&mut R>,
     output: &mut W,
     cancellation: &CancellationToken,
 ) -> io::Result<()>
@@ -101,7 +149,11 @@ where
         .await?;
     output.flush().await?;
 
-    match read_headless_decision(input, output, cancellation).await? {
+    let decision = match input {
+        Some(input) => read_headless_decision(input, output, cancellation).await?,
+        None => HeadlessDecision::NoInputChannel,
+    };
+    match decision {
         HeadlessDecision::Approve => request
             .approve("approved by headless command-line review")
             .map_err(|error| {
@@ -123,6 +175,15 @@ where
                     "failed to deny headless permission review at input EOF: {error}"
                 ))
             }),
+        HeadlessDecision::NoInputChannel => {
+            output.write_all(NO_REVIEW_INPUT_NOTICE.as_bytes()).await?;
+            output.flush().await?;
+            request.deny(NO_REVIEW_INPUT_REASON).map_err(|error| {
+                io::Error::other(format!(
+                    "failed to deny headless permission review without an input channel: {error}"
+                ))
+            })
+        }
         HeadlessDecision::Cancelled => {
             let _ = request.deny("headless permission review was cancelled");
             Ok(())
@@ -135,6 +196,7 @@ enum HeadlessDecision {
     Approve,
     Deny,
     InputEnded,
+    NoInputChannel,
     Cancelled,
 }
 
@@ -220,10 +282,35 @@ fn format_permission_prompt(request: &PermissionReviewRequest) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HeadlessDecision, parse_decision, read_headless_decision};
+    use super::{
+        HeadlessDecision, NO_REVIEW_INPUT_REASON, parse_decision, read_headless_decision,
+        review_request,
+    };
+    use merry_core::{PendingToolCall, ToolCallArguments, ToolCallId, ToolName};
+    use merry_runtime::{
+        ChannelPermissionAdmissionSource, PermissionAdmissionContext, PermissionAdmissionDecision,
+        PermissionAdmissionSource, PermissionRequest, parse_permission_request,
+    };
     use std::io::Cursor;
+    use std::sync::Arc;
     use tokio::io::BufReader;
     use tokio_util::sync::CancellationToken;
+
+    /// Reader type the no-input-channel case never constructs.
+    type UnusedReader = BufReader<Cursor<Vec<u8>>>;
+
+    fn network_permission_request() -> PermissionRequest {
+        let call = PendingToolCall::new(
+            ToolCallId::new("call-headless-review").expect("valid call id"),
+            ToolName::new("request_permissions").expect("valid tool name"),
+            ToolCallArguments::try_from(serde_json::json!({
+                "requested": { "network": true },
+                "for_action": { "command": "curl https://example.invalid", "cwd": null }
+            }))
+            .expect("valid tool call arguments"),
+        );
+        parse_permission_request(&call).expect("the request should parse")
+    }
 
     #[test]
     fn command_line_decision_defaults_to_deny() {
@@ -271,6 +358,90 @@ mod tests {
                 .await
                 .expect("cancellation should be handled"),
             HeadlessDecision::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn review_without_an_input_channel_denies_and_reports_why() {
+        let (source, mut requests) = ChannelPermissionAdmissionSource::channel(1);
+        let source = Arc::new(source);
+        let cancellation = CancellationToken::new();
+        let review = {
+            let source = Arc::clone(&source);
+            let cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                source
+                    .review(
+                        network_permission_request(),
+                        PermissionAdmissionContext::new(cancellation),
+                    )
+                    .await
+            })
+        };
+
+        let request = requests.recv().await.expect("the request should arrive");
+        let mut output = Vec::new();
+        review_request(
+            request,
+            None::<&mut UnusedReader>,
+            &mut output,
+            &cancellation,
+        )
+        .await
+        .expect("review without an input channel should settle the request");
+
+        let decision = review
+            .await
+            .expect("review task should join")
+            .expect("review should resolve");
+        match decision {
+            PermissionAdmissionDecision::Denied(review) => {
+                assert_eq!(review.rationale(), NO_REVIEW_INPUT_REASON);
+            }
+            PermissionAdmissionDecision::Approved(review) => panic!(
+                "an unanswerable request must not be approved: {}",
+                review.rationale()
+            ),
+        }
+        let prompt = String::from_utf8(output).expect("prompt output should be UTF-8");
+        assert!(
+            prompt.contains("No input channel for permission review"),
+            "the operator should be told why the request was denied unanswered: {prompt}"
+        );
+    }
+
+    #[tokio::test]
+    async fn review_over_an_available_channel_still_approves() {
+        let (source, mut requests) = ChannelPermissionAdmissionSource::channel(1);
+        let source = Arc::new(source);
+        let cancellation = CancellationToken::new();
+        let review = {
+            let source = Arc::clone(&source);
+            let cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                source
+                    .review(
+                        network_permission_request(),
+                        PermissionAdmissionContext::new(cancellation),
+                    )
+                    .await
+            })
+        };
+
+        let request = requests.recv().await.expect("the request should arrive");
+        let mut input = BufReader::new(Cursor::new(b"yes\n".to_vec()));
+        let mut output = Vec::new();
+        review_request(request, Some(&mut input), &mut output, &cancellation)
+            .await
+            .expect("an answered review should settle the request");
+
+        let decision = review
+            .await
+            .expect("review task should join")
+            .expect("review should resolve");
+        assert!(
+            matches!(decision, PermissionAdmissionDecision::Approved(_)),
+            "an answered request should be approved: {decision:?}"
         );
     }
 }

--- a/crates/merry-cli/src/run.rs
+++ b/crates/merry-cli/src/run.rs
@@ -1,8 +1,9 @@
-use crate::cli_error::{CliError, debug_openai_usage_error, stdout_error, unexpected};
+use crate::cli_error::{CliError, debug_openai_usage_error, stdout_error, unexpected, usage_error};
 use crate::coding::{
     CodingPermissionPolicy, CodingTrustMode, HeadlessCodingRuntimeInput, ProcessExecutionMode,
     action_process_runner_for_mode, build_headless_coding_with_policy_composition,
     coding_agent_process_admission, coding_agent_requires_sandbox_error,
+    resume_headless_coding_composition_with_policy,
 };
 use crate::config::MerryConfig;
 use crate::headless_review::HeadlessPermissionReviewer;
@@ -17,13 +18,13 @@ use crate::runtime_config::{
 use crate::sandbox::ChildHandoff as SandboxChildHandoff;
 use crate::tool_display::format_tool_call_progress;
 use futures_util::StreamExt;
-use merry_core::{ErrorInfo, RuntimeEvent, ToolCallResultStatus};
+use merry_core::{ErrorInfo, RuntimeEvent, SessionId, ToolCallResultStatus};
 use merry_runtime::{
-    AgentLoopBlockedReason, AgentLoopConfig, AgentLoopResult, AgentLoopStatus, Runtime,
-    StepContext, StepInput,
+    AgentLoopBlockedReason, AgentLoopConfig, AgentLoopResult, AgentLoopStatus, FileSessionStore,
+    Runtime, StepContext, StepInput,
 };
-use std::env;
-use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
+use std::{env, future::Future};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RunExitStatus {
@@ -43,13 +44,110 @@ impl RunExitStatus {
     }
 }
 
+/// Runtime settlement plus the first failure encountered while presenting it.
+///
+/// Presentation is deliberately kept separate from settlement so stdout
+/// failure cannot cancel a run that can still reach a resume-safe boundary.
+#[derive(Debug)]
+struct SettledRun {
+    runtime_result: Result<RunExitStatus, CliError>,
+    presentation_result: Result<(), CliError>,
+}
+
+#[cfg(test)]
+impl SettledRun {
+    fn into_output_result(self) -> Result<RunExitStatus, CliError> {
+        let status = self.runtime_result?;
+        self.presentation_result?;
+        Ok(status)
+    }
+}
+
+/// `TASK` value that reads the task text from stdin instead of argv.
+const STDIN_TASK: &str = "-";
+
 #[derive(Debug, clap::Args)]
 pub(crate) struct Args {
     #[arg(long, help = "Print runtime events and final result as JSONL")]
     pub(crate) events_jsonl: bool,
 
-    #[arg(required = true, allow_hyphen_values = true, value_name = "TASK")]
+    #[arg(
+        long,
+        value_name = "SESSION_ID",
+        conflicts_with = "resume",
+        help = "Save the run under this session id instead of a generated one"
+    )]
+    pub(crate) session_id: Option<String>,
+
+    #[arg(
+        long,
+        value_name = "SESSION_ID",
+        help = "Continue the saved session with this id instead of starting a new one"
+    )]
+    pub(crate) resume: Option<String>,
+
+    #[arg(
+        required = true,
+        allow_hyphen_values = true,
+        value_name = "TASK",
+        help = "Task text, or `-` to read the task from stdin"
+    )]
     pub(crate) task: String,
+}
+
+/// Session a run writes to, and whether it continues state saved by an
+/// earlier run.
+#[derive(Debug, PartialEq, Eq)]
+enum RunSession {
+    New(SessionId),
+    Resumed(SessionId),
+}
+
+impl RunSession {
+    fn from_args(args: &Args) -> Result<Self, CliError> {
+        match (args.session_id.as_deref(), args.resume.as_deref()) {
+            (Some(_), Some(_)) => Err(usage_error(
+                "--session-id and --resume cannot be used together",
+            )),
+            (None, Some(resumed)) => Ok(Self::Resumed(parse_session_id("--resume", resumed)?)),
+            (Some(requested), None) => Ok(Self::New(parse_session_id("--session-id", requested)?)),
+            (None, None) => Ok(Self::New(default_run_session_id())),
+        }
+    }
+
+    const fn id(&self) -> &SessionId {
+        match self {
+            Self::New(id) | Self::Resumed(id) => id,
+        }
+    }
+}
+
+fn parse_session_id(flag: &str, value: &str) -> Result<SessionId, CliError> {
+    SessionId::new(value).map_err(|error| usage_error(format!("{flag}: {error}")))
+}
+
+/// Reads the task from argv, or from `reader` when `TASK` is `-`.
+///
+/// Reading the task from stdin keeps a large task off argv, where it would be
+/// visible to every process listing on the host and bounded by the kernel's
+/// per-argument limit.
+async fn resolve_task<R>(task: &str, mut reader: R) -> Result<String, CliError>
+where
+    R: AsyncRead + Unpin,
+{
+    if task != STDIN_TASK {
+        return Ok(task.to_owned());
+    }
+
+    let mut text = String::new();
+    reader
+        .read_to_string(&mut text)
+        .await
+        .map_err(|error| unexpected(format!("could not read the task from stdin: {error}")))?;
+    if text.trim().is_empty() {
+        return Err(usage_error("the task read from stdin is empty"));
+    }
+    Ok(text)
 }
 
 pub(crate) async fn run(
@@ -59,6 +157,8 @@ pub(crate) async fn run(
     process_execution_mode: ProcessExecutionMode,
     fully_trusted: bool,
 ) -> Result<RunExitStatus, CliError> {
+    let session = RunSession::from_args(args)?;
+    let task = resolve_task(&args.task, tokio::io::stdin()).await?;
     let Some(_admission) =
         coding_agent_process_admission(sandbox_child_handoff, process_execution_mode).await
     else {
@@ -79,9 +179,9 @@ pub(crate) async fn run(
         process_execution_mode,
     )?;
     let extra_tools = discover_configured_mcp_tools(merry_config).await?;
-    let session_id = default_run_session_id();
+    let session_store = FileSessionStore::default_store().map_err(unexpected)?;
     let runtime_input = HeadlessCodingRuntimeInput {
-        session_id: session_id.as_str(),
+        session_id: session.id().as_str(),
         root: &root,
         provider,
         model,
@@ -114,22 +214,123 @@ pub(crate) async fn run(
         Some(headless_reviewer.source()),
     )
     .map_err(unexpected)?;
-    let coding_runtime =
-        build_headless_coding_with_policy_composition(runtime_input, permission_policy)?;
+    let coding_runtime = match &session {
+        RunSession::New(_) => {
+            build_headless_coding_with_policy_composition(runtime_input, permission_policy)?
+        }
+        RunSession::Resumed(id) => resume_headless_coding_composition_with_policy(
+            runtime_input,
+            session_store.clone(),
+            permission_policy,
+        )
+        .await
+        .map_err(|error| unexpected(format!("could not resume session {id}: {error}")))?,
+    };
     let loop_config = coding_runtime.loop_config();
     let runtime = coding_runtime.into_runtime();
-    let input = StepInput::user_text(&args.task).map_err(unexpected)?;
+    let input = StepInput::user_text(&task).map_err(unexpected)?;
     let context = StepContext::default()
         .with_generation_config(generation_config(merry_config).map_err(unexpected)?);
     let review_task = headless_reviewer.start();
-    let run_result = if args.events_jsonl {
-        write_agent_loop_jsonl_output(&runtime, input, loop_config, context, tokio::io::stdout())
-            .await
+    run_agent_loop_with_persistence(
+        &runtime,
+        input,
+        tokio::io::stdout(),
+        async { review_task.finish().await.map_err(unexpected) },
+        HeadlessRunPersistence {
+            loop_config,
+            context,
+            events_jsonl: args.events_jsonl,
+            session_store,
+            session_id: session.id(),
+        },
+    )
+    .await
+}
+
+/// Settles the runtime and permission reviewer before attempting persistence.
+///
+/// This is the production headless-run orchestration boundary. Presentation
+/// failures are retained while the runtime drains, then persistence is tried
+/// after reviewer shutdown. Final error selection happens only after that save
+/// attempt.
+struct HeadlessRunPersistence<'a> {
+    loop_config: AgentLoopConfig,
+    context: StepContext,
+    events_jsonl: bool,
+    session_store: FileSessionStore,
+    session_id: &'a SessionId,
+}
+
+async fn run_agent_loop_with_persistence<W, F>(
+    runtime: &Runtime,
+    input: StepInput,
+    writer: W,
+    review_result: F,
+    persistence: HeadlessRunPersistence<'_>,
+) -> Result<RunExitStatus, CliError>
+where
+    W: AsyncWrite + Unpin,
+    F: Future<Output = Result<(), CliError>>,
+{
+    let settled = if persistence.events_jsonl {
+        settle_agent_loop_jsonl_output(
+            runtime,
+            input,
+            persistence.loop_config,
+            persistence.context,
+            writer,
+        )
+        .await
     } else {
-        write_agent_loop_output(&runtime, input, loop_config, context, tokio::io::stdout()).await
+        settle_agent_loop_output(
+            runtime,
+            input,
+            persistence.loop_config,
+            persistence.context,
+            writer,
+        )
+        .await
     };
-    let review_result = review_task.finish().await.map_err(unexpected);
-    let status = run_result?;
+    let review_result = review_result.await;
+    finish_settled_run(
+        runtime,
+        persistence.session_store,
+        persistence.session_id,
+        settled,
+        review_result,
+    )
+    .await
+}
+
+/// Persists a settled run before selecting its final result.
+///
+/// A persistence failure takes precedence over runtime, stdout, or reviewer
+/// failures so the CLI cannot report only an earlier failure when durable state
+/// was not written. When persistence succeeds, errors are returned in runtime,
+/// presentation, then reviewer order.
+async fn finish_settled_run(
+    runtime: &Runtime,
+    session_store: FileSessionStore,
+    session_id: &SessionId,
+    settled: SettledRun,
+    review_result: Result<(), CliError>,
+) -> Result<RunExitStatus, CliError> {
+    let SettledRun {
+        runtime_result,
+        presentation_result,
+    } = settled;
+    runtime
+        .save_session_to(session_store)
+        .await
+        .map_err(|error| {
+            unexpected(format!(
+                "run finished but session {} could not be saved: {error}",
+                session_id
+            ))
+        })?;
+    let status = runtime_result?;
+    presentation_result?;
     review_result?;
     Ok(status)
 }
@@ -138,6 +339,7 @@ fn default_run_session_id() -> merry_core::SessionId {
     crate::session_id::new_ephemeral_session_id()
 }
 
+#[cfg(test)]
 pub(crate) async fn write_agent_loop_output<W>(
     runtime: &Runtime,
     input: StepInput,
@@ -148,20 +350,65 @@ pub(crate) async fn write_agent_loop_output<W>(
 where
     W: AsyncWrite + Unpin,
 {
-    let mut writer = BufWriter::new(writer);
-    let mut stream = runtime
-        .run_agent_loop_stream(input, context, config)
-        .map_err(unexpected)?;
-    let mut pending_commentary = None;
-    while let Some(event) = stream.next().await {
-        write_human_progress_event(&event, &mut pending_commentary, &mut writer).await?;
-    }
-    let result = stream.result().await.map_err(unexpected)?;
-    write_agent_loop_summary_to(&result, &mut writer).await?;
-    writer.flush().await.map_err(stdout_error)?;
-    Ok(RunExitStatus::from_agent_loop_result(&result))
+    settle_agent_loop_output(runtime, input, config, context, writer)
+        .await
+        .into_output_result()
 }
 
+async fn settle_agent_loop_output<W>(
+    runtime: &Runtime,
+    input: StepInput,
+    config: AgentLoopConfig,
+    context: StepContext,
+    writer: W,
+) -> SettledRun
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut writer = BufWriter::new(writer);
+    let mut stream = match runtime.run_agent_loop_stream(input, context, config) {
+        Ok(stream) => stream,
+        Err(error) => {
+            return SettledRun {
+                runtime_result: Err(unexpected(error)),
+                presentation_result: Ok(()),
+            };
+        }
+    };
+    let mut pending_commentary = None;
+    let mut presentation_error = None;
+    while let Some(event) = stream.next().await {
+        if presentation_error.is_none()
+            && let Err(error) =
+                write_human_progress_event(&event, &mut pending_commentary, &mut writer).await
+        {
+            presentation_error = Some(error);
+        }
+    }
+    let runtime_result = match stream.result().await.map_err(unexpected) {
+        Ok(result) => {
+            let status = RunExitStatus::from_agent_loop_result(&result);
+            if presentation_error.is_none() {
+                if let Err(error) = write_agent_loop_summary_to(&result, &mut writer).await {
+                    presentation_error = Some(error);
+                } else if let Err(error) = writer.flush().await.map_err(stdout_error) {
+                    presentation_error = Some(error);
+                }
+            }
+            Ok(status)
+        }
+        Err(error) => Err(error),
+    };
+    SettledRun {
+        runtime_result,
+        presentation_result: match presentation_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        },
+    }
+}
+
+#[cfg(test)]
 pub(crate) async fn write_agent_loop_jsonl_output<W>(
     runtime: &Runtime,
     input: StepInput,
@@ -172,21 +419,64 @@ pub(crate) async fn write_agent_loop_jsonl_output<W>(
 where
     W: AsyncWrite + Unpin,
 {
+    settle_agent_loop_jsonl_output(runtime, input, config, context, writer)
+        .await
+        .into_output_result()
+}
+
+async fn settle_agent_loop_jsonl_output<W>(
+    runtime: &Runtime,
+    input: StepInput,
+    config: AgentLoopConfig,
+    context: StepContext,
+    writer: W,
+) -> SettledRun
+where
+    W: AsyncWrite + Unpin,
+{
     let mut writer = BufWriter::new(writer);
-    let mut stream = runtime
-        .run_agent_loop_stream(input, context, config)
-        .map_err(unexpected)?;
+    let mut stream = match runtime.run_agent_loop_stream(input, context, config) {
+        Ok(stream) => stream,
+        Err(error) => {
+            return SettledRun {
+                runtime_result: Err(unexpected(error)),
+                presentation_result: Ok(()),
+            };
+        }
+    };
+    let mut presentation_error = None;
 
     while let Some(event) = stream.next().await {
-        write_public_runtime_event(&event, &mut writer).await?;
-        writer.flush().await.map_err(stdout_error)?;
+        if presentation_error.is_none() {
+            if let Err(error) = write_public_runtime_event(&event, &mut writer).await {
+                presentation_error = Some(error);
+            } else if let Err(error) = writer.flush().await.map_err(stdout_error) {
+                presentation_error = Some(error);
+            }
+        }
     }
 
-    let result = stream.result().await.map_err(unexpected)?;
-    let status = RunExitStatus::from_agent_loop_result(&result);
-    write_agent_loop_result(&result, &mut writer).await?;
-    writer.flush().await.map_err(stdout_error)?;
-    Ok(status)
+    let runtime_result = match stream.result().await.map_err(unexpected) {
+        Ok(result) => {
+            let status = RunExitStatus::from_agent_loop_result(&result);
+            if presentation_error.is_none() {
+                if let Err(error) = write_agent_loop_result(&result, &mut writer).await {
+                    presentation_error = Some(error);
+                } else if let Err(error) = writer.flush().await.map_err(stdout_error) {
+                    presentation_error = Some(error);
+                }
+            }
+            Ok(status)
+        }
+        Err(error) => Err(error),
+    };
+    SettledRun {
+        runtime_result,
+        presentation_result: match presentation_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        },
+    }
 }
 
 async fn write_agent_loop_summary_to<W>(
@@ -473,313 +763,10 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        RunExitStatus, default_run_session_id, write_agent_loop_jsonl_output,
-        write_agent_loop_output,
-    };
-    use crate::coding::{
-        CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
-        fixed_process_backend,
-    };
-    use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name, process_tool_call};
-    use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
-    use merry_core::ToolName;
-    use merry_llm::{
-        FinishReason, ModelEvent, ModelOutput, ModelResponse, ModelToolCall, ModelToolCallId,
-        ToolArguments,
-    };
-    use merry_process::ProcessSession;
-    use merry_runtime::{AgentLoopConfig, ProcessRunner, StepContext, StepInput};
-    use std::{
-        io,
-        pin::Pin,
-        sync::Arc,
-        task::{Context, Poll},
-    };
-    use tokio::io::AsyncWrite;
+mod persistence_tests;
 
-    #[test]
-    fn default_run_session_id_is_generated() {
-        let first = default_run_session_id();
-        let second = default_run_session_id();
+#[cfg(test)]
+mod session_tests;
 
-        assert_ne!(first, second);
-        assert_ne!(first.as_str(), "run");
-    }
-
-    #[derive(Default)]
-    struct FlushCountingWriter {
-        bytes: Vec<u8>,
-        flushes: usize,
-    }
-
-    impl AsyncWrite for FlushCountingWriter {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<io::Result<usize>> {
-            self.bytes.extend_from_slice(buf);
-            Poll::Ready(Ok(buf.len()))
-        }
-
-        fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            self.flushes += 1;
-            Poll::Ready(Ok(()))
-        }
-
-        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            Poll::Ready(Ok(()))
-        }
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn writer_prints_final_output_without_event_jsonl() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
-        let provider = ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
-            response: ModelResponse::new(
-                vec![ModelOutput::text("done from run")],
-                FinishReason::Stop,
-                None,
-            ),
-        })]]);
-        let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
-        let permissioned_factory = Arc::new(
-            merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
-        );
-        let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
-            session_id: "run-writer-test",
-            root: &workspace,
-            process_backend: fixed_process_backend(ProcessSession::from_parts(
-                merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
-                runner,
-                permissioned_factory,
-            )),
-            provider: Arc::new(provider),
-            model: model_name(),
-            extra_tools: Vec::new(),
-            allow_hidden_workspace_paths: false,
-            automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
-            retry_policy: None,
-            context_compaction: None,
-            approval_review: None,
-            skill_roots: Vec::new(),
-            subagents: CodingSubagentsConfig::default(),
-            workspace_tool_limits: None,
-        })
-        .expect("runtime should build");
-
-        let mut output = Vec::new();
-        let status = write_agent_loop_output(
-            &runtime,
-            StepInput::user_text("finish").expect("valid input"),
-            AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
-            StepContext::default(),
-            &mut output,
-        )
-        .await
-        .expect("run output should write");
-
-        assert_eq!(status, RunExitStatus::Completed);
-        let text = String::from_utf8(output).expect("output should be utf-8");
-        assert_eq!(text, "done from run\n");
-        assert!(!text.contains("\"type\":\"session_started\""));
-        assert!(!text.contains("\"type\":\"agent_loop_result\""));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn writer_streams_progress_commentary_before_final_output() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
-        let provider = ScriptedProvider::new(vec![
-            vec![
-                Ok(ModelEvent::OutputTextDelta {
-                    delta: "我先解析 baidu.com 的 DNS。".to_owned(),
-                }),
-                Ok(
-                    process_tool_call("run-progress-dns", &["getent", "hosts", "baidu.com"], None)
-                        .expect("valid process call"),
-                ),
-            ],
-            vec![Ok(ModelEvent::Completed {
-                response: ModelResponse::new(
-                    vec![ModelOutput::text("baidu.com resolves to 110.242.74.102")],
-                    FinishReason::Stop,
-                    None,
-                ),
-            })],
-        ]);
-        let runner: Arc<dyn ProcessRunner> =
-            Arc::new(FakeProcessRunner::succeeding("110.242.74.102 baidu.com\n"));
-        let permissioned_factory = Arc::new(
-            merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
-        );
-        let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
-            session_id: "run-progress-writer-test",
-            root: &workspace,
-            process_backend: fixed_process_backend(ProcessSession::from_parts(
-                merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
-                runner,
-                permissioned_factory,
-            )),
-            provider: Arc::new(provider),
-            model: model_name(),
-            extra_tools: Vec::new(),
-            allow_hidden_workspace_paths: false,
-            automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
-            retry_policy: None,
-            context_compaction: None,
-            approval_review: None,
-            skill_roots: Vec::new(),
-            subagents: CodingSubagentsConfig::default(),
-            workspace_tool_limits: None,
-        })
-        .expect("runtime should build");
-
-        let mut output = Vec::new();
-        let status = write_agent_loop_output(
-            &runtime,
-            StepInput::user_text("ping baidu.com").expect("valid input"),
-            AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
-            StepContext::default(),
-            &mut output,
-        )
-        .await
-        .expect("run output should write");
-
-        assert_eq!(status, RunExitStatus::Completed);
-        let text = String::from_utf8(output).expect("output should be utf-8");
-        assert_eq!(
-            text,
-            "我先解析 baidu.com 的 DNS。\n\ntool: run_process getent hosts baidu.com (.)\n\nbaidu.com resolves to 110.242.74.102\n"
-        );
-        assert!(!text.contains("\"type\":\"tool_call_pending\""));
-        assert!(!text.contains("\"type\":\"agent_loop_result\""));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn jsonl_writer_streams_agent_loop_result() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
-        let provider = ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
-            response: ModelResponse::new(
-                vec![ModelOutput::text("done from run")],
-                FinishReason::Stop,
-                None,
-            ),
-        })]]);
-        let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
-        let permissioned_factory = Arc::new(
-            merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
-        );
-        let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
-            session_id: "run-jsonl-writer-test",
-            root: &workspace,
-            process_backend: fixed_process_backend(ProcessSession::from_parts(
-                merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
-                runner,
-                permissioned_factory,
-            )),
-            provider: Arc::new(provider),
-            model: model_name(),
-            extra_tools: Vec::new(),
-            allow_hidden_workspace_paths: false,
-            automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
-            retry_policy: None,
-            context_compaction: None,
-            approval_review: None,
-            skill_roots: Vec::new(),
-            subagents: CodingSubagentsConfig::default(),
-            workspace_tool_limits: None,
-        })
-        .expect("runtime should build");
-
-        let mut output = FlushCountingWriter::default();
-        let status = write_agent_loop_jsonl_output(
-            &runtime,
-            StepInput::user_text("finish").expect("valid input"),
-            AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
-            StepContext::default(),
-            &mut output,
-        )
-        .await
-        .expect("run output should write");
-
-        assert_eq!(status, RunExitStatus::Completed);
-        assert!(
-            output.flushes > 1,
-            "JSONL mode should flush as events arrive"
-        );
-        let text = String::from_utf8(output.bytes).expect("output should be utf-8");
-        assert!(text.contains("\"type\":\"session_started\""));
-        assert!(text.contains("\"type\":\"agent_loop_result\""));
-        assert!(text.contains("\"status\":\"completed\""));
-        assert!(text.contains("done from run"));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn writer_returns_incomplete_when_agent_loop_blocks() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("mkdir workspace");
-        let provider = ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
-            response: ModelResponse::new(
-                vec![ModelOutput::tool_call(ModelToolCall::new(
-                    ModelToolCallId::new("call-read").expect("valid call id"),
-                    ToolName::new("workspace_read_file").expect("valid tool name"),
-                    ToolArguments::try_from(serde_json::json!({"path": "README.md"}))
-                        .expect("valid args"),
-                ))],
-                FinishReason::ToolCalls,
-                None,
-            ),
-        })]]);
-        let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
-        let permissioned_factory = Arc::new(
-            merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
-        );
-        let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
-            session_id: "run-blocked-writer-test",
-            root: &workspace,
-            process_backend: fixed_process_backend(ProcessSession::from_parts(
-                merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
-                runner,
-                permissioned_factory,
-            )),
-            provider: Arc::new(provider),
-            model: model_name(),
-            extra_tools: Vec::new(),
-            allow_hidden_workspace_paths: false,
-            automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
-            retry_policy: None,
-            context_compaction: None,
-            approval_review: None,
-            skill_roots: Vec::new(),
-            subagents: CodingSubagentsConfig::default(),
-            workspace_tool_limits: None,
-        })
-        .expect("runtime should build");
-
-        let mut output = Vec::new();
-        let status = write_agent_loop_output(
-            &runtime,
-            StepInput::user_text("read README").expect("valid input"),
-            AgentLoopConfig::new(1).expect("valid config"),
-            StepContext::default(),
-            &mut output,
-        )
-        .await
-        .expect("run output should write");
-
-        assert_eq!(status, RunExitStatus::Incomplete);
-        let text = String::from_utf8(output).expect("output should be utf-8");
-        assert!(text.contains("tool: workspace_read_file path=README.md"));
-        assert!(text.contains("status: blocked"));
-        assert!(text.contains("reason: max model turns reached (1)"));
-    }
-}
+#[cfg(test)]
+mod output_tests;

--- a/crates/merry-cli/src/run.rs
+++ b/crates/merry-cli/src/run.rs
@@ -17,11 +17,12 @@ use crate::runtime_config::{
 };
 use crate::sandbox::ChildHandoff as SandboxChildHandoff;
 use crate::tool_display::format_tool_call_progress;
+use crate::tui::session_list::{TuiSessionMetadata, TuiSessionStore, now_unix_ms};
 use futures_util::StreamExt;
 use merry_core::{ErrorInfo, RuntimeEvent, SessionId, ToolCallResultStatus};
 use merry_runtime::{
     AgentLoopBlockedReason, AgentLoopConfig, AgentLoopResult, AgentLoopStatus, FileSessionStore,
-    Runtime, StepContext, StepInput,
+    Runtime, SessionReservation, StepContext, StepInput,
 };
 use std::{env, future::Future};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
@@ -130,26 +131,34 @@ fn parse_session_id(flag: &str, value: &str) -> Result<SessionId, CliError> {
     SessionId::new(value).map_err(|error| usage_error(format!("{flag}: {error}")))
 }
 
-/// Refuses a new run that would take over an id the store already holds.
+/// Reserves a run's session id and refuses a new run that already has state.
 ///
 /// Saving a session is an atomic replace of its `state.json`, so starting a new
 /// run under an existing id destroys that session's transcript, ledger,
 /// artifacts, and checkpoints with nothing left to resume. A typo or a reused
 /// id has to fail here, before the run consumes its task or starts a runtime.
-async fn refuse_reused_session_id(
+async fn reserve_run_session(
     session: &RunSession,
     store: &FileSessionStore,
-) -> Result<(), CliError> {
-    let RunSession::New(id) = session else {
-        return Ok(());
-    };
-    if store.contains_session(id).await.map_err(unexpected)? {
+) -> Result<SessionReservation, CliError> {
+    let reservation = store
+        .reserve_session(session.id())
+        .await
+        .map_err(unexpected)?;
+    if matches!(session, RunSession::New(_))
+        && store
+            .contains_session(session.id())
+            .await
+            .map_err(unexpected)?
+    {
         return Err(usage_error(format!(
-            "session {id} already has saved state; pass --resume {id} to continue it, \
-             or choose a different --session-id"
+            "session {} already has saved state; pass --resume {} to continue it, \
+             or choose a different --session-id",
+            session.id(),
+            session.id()
         )));
     }
-    Ok(())
+    Ok(reservation)
 }
 
 /// Reads the task from argv, or from `reader` when `TASK` is `-`.
@@ -198,7 +207,7 @@ pub(crate) async fn run(
 ) -> Result<RunExitStatus, CliError> {
     let session = RunSession::from_args(args)?;
     let session_store = FileSessionStore::default_store().map_err(unexpected)?;
-    refuse_reused_session_id(&session, &session_store).await?;
+    let _session_reservation = reserve_run_session(&session, &session_store).await?;
     let task = resolve_task(&args.task, tokio::io::stdin()).await?;
     let Some(_admission) =
         coding_agent_process_admission(sandbox_child_handoff, process_execution_mode).await
@@ -219,6 +228,7 @@ pub(crate) async fn run(
         action_process_backend_options(merry_config).map_err(unexpected)?,
         process_execution_mode,
     )?;
+    let headless_metadata = headless_session_metadata(&session_store, &session, &root).await?;
     let extra_tools = discover_configured_mcp_tools(merry_config).await?;
     let runtime_input = HeadlessCodingRuntimeInput {
         session_id: session.id().as_str(),
@@ -283,6 +293,7 @@ pub(crate) async fn run(
             events_jsonl: args.events_jsonl,
             session_store,
             session_id: session.id(),
+            metadata: headless_metadata,
         },
     )
     .await
@@ -291,15 +302,16 @@ pub(crate) async fn run(
 /// Settles the runtime and permission reviewer before attempting persistence.
 ///
 /// This is the production headless-run orchestration boundary. Presentation
-/// failures are retained while the runtime drains, then persistence is tried
-/// after reviewer shutdown. Final error selection happens only after that save
-/// attempt.
+/// failures stop the event producer at the output boundary; persistence is
+/// then attempted after reviewer shutdown. Final error selection happens only
+/// after that save attempt.
 struct HeadlessRunPersistence<'a> {
     loop_config: AgentLoopConfig,
     context: StepContext,
     events_jsonl: bool,
     session_store: FileSessionStore,
     session_id: &'a SessionId,
+    metadata: TuiSessionMetadata,
 }
 
 async fn run_agent_loop_with_persistence<W, F>(
@@ -337,6 +349,7 @@ where
         runtime,
         persistence.session_store,
         persistence.session_id,
+        persistence.metadata,
         settled,
         review_result,
     )
@@ -353,6 +366,7 @@ async fn finish_settled_run(
     runtime: &Runtime,
     session_store: FileSessionStore,
     session_id: &SessionId,
+    metadata: TuiSessionMetadata,
     settled: SettledRun,
     review_result: Result<(), CliError>,
 ) -> Result<RunExitStatus, CliError> {
@@ -360,7 +374,7 @@ async fn finish_settled_run(
         runtime_result,
         presentation_result,
     } = settled;
-    persist_settled_session(runtime, session_store, session_id).await?;
+    persist_settled_session(runtime, session_store, session_id, metadata).await?;
     let status = runtime_result?;
     presentation_result?;
     review_result?;
@@ -378,6 +392,7 @@ async fn persist_settled_session(
     runtime: &Runtime,
     session_store: FileSessionStore,
     session_id: &SessionId,
+    metadata: TuiSessionMetadata,
 ) -> Result<(), CliError> {
     runtime
         .abandon_pending_tool_calls(ABANDONED_TOOL_CALL_REASON)
@@ -388,13 +403,58 @@ async fn persist_settled_session(
             ))
         })?;
     runtime
-        .save_session_to(session_store)
+        .save_session_to(session_store.clone())
         .await
         .map_err(|error| {
             unexpected(format!(
                 "run finished but session {session_id} could not be saved: {error}"
             ))
-        })
+        })?;
+    write_headless_session_metadata(&session_store, metadata).await
+}
+
+async fn headless_session_metadata(
+    store: &FileSessionStore,
+    session: &RunSession,
+    workspace_root: &std::path::Path,
+) -> Result<TuiSessionMetadata, CliError> {
+    let tui_store = TuiSessionStore::new(store.sessions_dir().to_path_buf());
+    let session_id = session.id().clone();
+    let existing = tokio::task::spawn_blocking({
+        let tui_store = tui_store.clone();
+        let session_id = session_id.clone();
+        move || tui_store.read_metadata(&session_id)
+    })
+    .await
+    .map_err(unexpected)?
+    .map_err(unexpected)?;
+    let mut metadata = existing.unwrap_or_else(|| {
+        TuiSessionMetadata::new(
+            session_id.clone(),
+            workspace_root.to_path_buf(),
+            now_unix_ms(),
+        )
+    });
+    metadata.workspace_root = workspace_root.to_path_buf();
+    if matches!(session, RunSession::New(_)) {
+        metadata.headless = true;
+        if metadata.title.is_none() {
+            metadata.title = Some("Headless run".to_owned());
+        }
+    }
+    metadata.mark_active(now_unix_ms());
+    Ok(metadata)
+}
+
+async fn write_headless_session_metadata(
+    session_store: &FileSessionStore,
+    metadata: TuiSessionMetadata,
+) -> Result<(), CliError> {
+    let store = TuiSessionStore::new(session_store.sessions_dir().to_path_buf());
+    tokio::task::spawn_blocking(move || store.write_metadata(&metadata))
+        .await
+        .map_err(unexpected)?
+        .map_err(unexpected)
 }
 
 fn default_run_session_id() -> merry_core::SessionId {
@@ -440,11 +500,14 @@ where
     let mut pending_commentary = None;
     let mut presentation_error = None;
     while let Some(event) = stream.next().await {
-        if presentation_error.is_none()
-            && let Err(error) =
-                write_human_progress_event(&event, &mut pending_commentary, &mut writer).await
+        if let Err(error) =
+            write_human_progress_event(&event, &mut pending_commentary, &mut writer).await
         {
-            presentation_error = Some(error);
+            stream.cancel_and_wait().await;
+            return SettledRun {
+                runtime_result: Ok(RunExitStatus::Incomplete),
+                presentation_result: Err(error),
+            };
         }
     }
     let runtime_result = match stream.result().await.map_err(unexpected) {
@@ -511,9 +574,18 @@ where
     while let Some(event) = stream.next().await {
         if presentation_error.is_none() {
             if let Err(error) = write_public_runtime_event(&event, &mut writer).await {
-                presentation_error = Some(error);
-            } else if let Err(error) = writer.flush().await.map_err(stdout_error) {
-                presentation_error = Some(error);
+                stream.cancel_and_wait().await;
+                return SettledRun {
+                    runtime_result: Ok(RunExitStatus::Incomplete),
+                    presentation_result: Err(error),
+                };
+            }
+            if let Err(error) = writer.flush().await.map_err(stdout_error) {
+                stream.cancel_and_wait().await;
+                return SettledRun {
+                    runtime_result: Ok(RunExitStatus::Incomplete),
+                    presentation_result: Err(error),
+                };
             }
         }
     }

--- a/crates/merry-cli/src/run.rs
+++ b/crates/merry-cli/src/run.rs
@@ -6,7 +6,7 @@ use crate::coding::{
     resume_headless_coding_composition_with_policy,
 };
 use crate::config::MerryConfig;
-use crate::headless_review::HeadlessPermissionReviewer;
+use crate::headless_review::{HeadlessPermissionReviewer, ReviewInputChannel};
 use crate::mcp_tools::discover_configured_mcp_tools;
 use crate::provider_config::{
     RuntimePrimaryProviderConfig, RuntimeProviderBundle, runtime_provider_bundle_from_config,
@@ -65,6 +65,10 @@ impl SettledRun {
 
 /// `TASK` value that reads the task text from stdin instead of argv.
 const STDIN_TASK: &str = "-";
+
+/// Recorded against every tool call a settled run never produced a result for.
+const ABANDONED_TOOL_CALL_REASON: &str =
+    "the headless run settled before this tool call produced a result";
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct Args {
@@ -126,6 +130,28 @@ fn parse_session_id(flag: &str, value: &str) -> Result<SessionId, CliError> {
     SessionId::new(value).map_err(|error| usage_error(format!("{flag}: {error}")))
 }
 
+/// Refuses a new run that would take over an id the store already holds.
+///
+/// Saving a session is an atomic replace of its `state.json`, so starting a new
+/// run under an existing id destroys that session's transcript, ledger,
+/// artifacts, and checkpoints with nothing left to resume. A typo or a reused
+/// id has to fail here, before the run consumes its task or starts a runtime.
+async fn refuse_reused_session_id(
+    session: &RunSession,
+    store: &FileSessionStore,
+) -> Result<(), CliError> {
+    let RunSession::New(id) = session else {
+        return Ok(());
+    };
+    if store.contains_session(id).await.map_err(unexpected)? {
+        return Err(usage_error(format!(
+            "session {id} already has saved state; pass --resume {id} to continue it, \
+             or choose a different --session-id"
+        )));
+    }
+    Ok(())
+}
+
 /// Reads the task from argv, or from `reader` when `TASK` is `-`.
 ///
 /// Reading the task from stdin keeps a large task off argv, where it would be
@@ -150,6 +176,19 @@ where
     Ok(text)
 }
 
+/// Chooses the channel that answers permission review for a run.
+///
+/// An argv task leaves stdin untouched, so review keeps reading it. A `-` task
+/// consumes stdin to end-of-file before the runtime starts, so review must ask
+/// somewhere else or report that it cannot ask at all.
+fn review_input_channel_for_task(task: &str) -> ReviewInputChannel {
+    if task == STDIN_TASK {
+        ReviewInputChannel::ControllingTerminal
+    } else {
+        ReviewInputChannel::Stdin
+    }
+}
+
 pub(crate) async fn run(
     args: &Args,
     sandbox_child_handoff: Option<SandboxChildHandoff>,
@@ -158,6 +197,8 @@ pub(crate) async fn run(
     fully_trusted: bool,
 ) -> Result<RunExitStatus, CliError> {
     let session = RunSession::from_args(args)?;
+    let session_store = FileSessionStore::default_store().map_err(unexpected)?;
+    refuse_reused_session_id(&session, &session_store).await?;
     let task = resolve_task(&args.task, tokio::io::stdin()).await?;
     let Some(_admission) =
         coding_agent_process_admission(sandbox_child_handoff, process_execution_mode).await
@@ -179,7 +220,6 @@ pub(crate) async fn run(
         process_execution_mode,
     )?;
     let extra_tools = discover_configured_mcp_tools(merry_config).await?;
-    let session_store = FileSessionStore::default_store().map_err(unexpected)?;
     let runtime_input = HeadlessCodingRuntimeInput {
         session_id: session.id().as_str(),
         root: &root,
@@ -231,7 +271,7 @@ pub(crate) async fn run(
     let input = StepInput::user_text(&task).map_err(unexpected)?;
     let context = StepContext::default()
         .with_generation_config(generation_config(merry_config).map_err(unexpected)?);
-    let review_task = headless_reviewer.start();
+    let review_task = headless_reviewer.start(review_input_channel_for_task(&args.task));
     run_agent_loop_with_persistence(
         &runtime,
         input,
@@ -320,19 +360,41 @@ async fn finish_settled_run(
         runtime_result,
         presentation_result,
     } = settled;
+    persist_settled_session(runtime, session_store, session_id).await?;
+    let status = runtime_result?;
+    presentation_result?;
+    review_result?;
+    Ok(status)
+}
+
+/// Records a result for every tool call the run left pending, then saves.
+///
+/// A run that fails mid-step settles with its tool call still unresolved, and
+/// the session store refuses that state because it cannot be resumed. Giving
+/// those calls a durable failed result is what makes a failed run's partial
+/// transcript resumable on the shipped path, rather than only under a reviewer
+/// that happens to submit results of its own.
+async fn persist_settled_session(
+    runtime: &Runtime,
+    session_store: FileSessionStore,
+    session_id: &SessionId,
+) -> Result<(), CliError> {
+    runtime
+        .abandon_pending_tool_calls(ABANDONED_TOOL_CALL_REASON)
+        .await
+        .map_err(|error| {
+            unexpected(format!(
+                "run finished but session {session_id} could not be made resume-safe: {error}"
+            ))
+        })?;
     runtime
         .save_session_to(session_store)
         .await
         .map_err(|error| {
             unexpected(format!(
-                "run finished but session {} could not be saved: {error}",
-                session_id
+                "run finished but session {session_id} could not be saved: {error}"
             ))
-        })?;
-    let status = runtime_result?;
-    presentation_result?;
-    review_result?;
-    Ok(status)
+        })
 }
 
 fn default_run_session_id() -> merry_core::SessionId {

--- a/crates/merry-cli/src/run/output_tests.rs
+++ b/crates/merry-cli/src/run/output_tests.rs
@@ -1,0 +1,295 @@
+use super::{RunExitStatus, write_agent_loop_jsonl_output, write_agent_loop_output};
+use crate::coding::{
+    CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding, fixed_process_backend,
+};
+use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name, process_tool_call};
+use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
+use merry_core::ToolName;
+use merry_llm::{
+    FinishReason, ModelEvent, ModelOutput, ModelResponse, ModelToolCall, ModelToolCallId,
+    ToolArguments,
+};
+use merry_process::ProcessSession;
+use merry_runtime::{AgentLoopConfig, ProcessRunner, StepContext, StepInput};
+use std::{
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::io::AsyncWrite;
+
+#[derive(Default)]
+struct FlushCountingWriter {
+    bytes: Vec<u8>,
+    flushes: usize,
+}
+
+impl AsyncWrite for FlushCountingWriter {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.bytes.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.flushes += 1;
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn writer_prints_final_output_without_event_jsonl() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let provider = ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(
+            vec![ModelOutput::text("done from run")],
+            FinishReason::Stop,
+            None,
+        ),
+    })]]);
+    let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
+    let permissioned_factory = Arc::new(
+        merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
+    );
+    let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
+        session_id: "run-writer-test",
+        root: &workspace,
+        process_backend: fixed_process_backend(ProcessSession::from_parts(
+            merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+            runner,
+            permissioned_factory,
+        )),
+        provider: Arc::new(provider),
+        model: model_name(),
+        extra_tools: Vec::new(),
+        allow_hidden_workspace_paths: false,
+        automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
+        retry_policy: None,
+        context_compaction: None,
+        approval_review: None,
+        skill_roots: Vec::new(),
+        subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
+    })
+    .expect("runtime should build");
+
+    let mut output = Vec::new();
+    let status = write_agent_loop_output(
+        &runtime,
+        StepInput::user_text("finish").expect("valid input"),
+        AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
+        StepContext::default(),
+        &mut output,
+    )
+    .await
+    .expect("run output should write");
+
+    assert_eq!(status, RunExitStatus::Completed);
+    let text = String::from_utf8(output).expect("output should be utf-8");
+    assert_eq!(text, "done from run\n");
+    assert!(!text.contains("\"type\":\"session_started\""));
+    assert!(!text.contains("\"type\":\"agent_loop_result\""));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn writer_streams_progress_commentary_before_final_output() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let provider = ScriptedProvider::new(vec![
+        vec![
+            Ok(ModelEvent::OutputTextDelta {
+                delta: "我先解析 baidu.com 的 DNS。".to_owned(),
+            }),
+            Ok(
+                process_tool_call("run-progress-dns", &["getent", "hosts", "baidu.com"], None)
+                    .expect("valid process call"),
+            ),
+        ],
+        vec![Ok(ModelEvent::Completed {
+            response: ModelResponse::new(
+                vec![ModelOutput::text("baidu.com resolves to 110.242.74.102")],
+                FinishReason::Stop,
+                None,
+            ),
+        })],
+    ]);
+    let runner: Arc<dyn ProcessRunner> =
+        Arc::new(FakeProcessRunner::succeeding("110.242.74.102 baidu.com\n"));
+    let permissioned_factory = Arc::new(
+        merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
+    );
+    let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
+        session_id: "run-progress-writer-test",
+        root: &workspace,
+        process_backend: fixed_process_backend(ProcessSession::from_parts(
+            merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+            runner,
+            permissioned_factory,
+        )),
+        provider: Arc::new(provider),
+        model: model_name(),
+        extra_tools: Vec::new(),
+        allow_hidden_workspace_paths: false,
+        automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
+        retry_policy: None,
+        context_compaction: None,
+        approval_review: None,
+        skill_roots: Vec::new(),
+        subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
+    })
+    .expect("runtime should build");
+
+    let mut output = Vec::new();
+    let status = write_agent_loop_output(
+        &runtime,
+        StepInput::user_text("ping baidu.com").expect("valid input"),
+        AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
+        StepContext::default(),
+        &mut output,
+    )
+    .await
+    .expect("run output should write");
+
+    assert_eq!(status, RunExitStatus::Completed);
+    let text = String::from_utf8(output).expect("output should be utf-8");
+    assert_eq!(
+        text,
+        "我先解析 baidu.com 的 DNS。\n\ntool: run_process getent hosts baidu.com (.)\n\nbaidu.com resolves to 110.242.74.102\n"
+    );
+    assert!(!text.contains("\"type\":\"tool_call_pending\""));
+    assert!(!text.contains("\"type\":\"agent_loop_result\""));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn jsonl_writer_streams_agent_loop_result() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let provider = ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(
+            vec![ModelOutput::text("done from run")],
+            FinishReason::Stop,
+            None,
+        ),
+    })]]);
+    let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
+    let permissioned_factory = Arc::new(
+        merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
+    );
+    let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
+        session_id: "run-jsonl-writer-test",
+        root: &workspace,
+        process_backend: fixed_process_backend(ProcessSession::from_parts(
+            merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+            runner,
+            permissioned_factory,
+        )),
+        provider: Arc::new(provider),
+        model: model_name(),
+        extra_tools: Vec::new(),
+        allow_hidden_workspace_paths: false,
+        automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
+        retry_policy: None,
+        context_compaction: None,
+        approval_review: None,
+        skill_roots: Vec::new(),
+        subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
+    })
+    .expect("runtime should build");
+
+    let mut output = FlushCountingWriter::default();
+    let status = write_agent_loop_jsonl_output(
+        &runtime,
+        StepInput::user_text("finish").expect("valid input"),
+        AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
+        StepContext::default(),
+        &mut output,
+    )
+    .await
+    .expect("run output should write");
+
+    assert_eq!(status, RunExitStatus::Completed);
+    assert!(
+        output.flushes > 1,
+        "JSONL mode should flush as events arrive"
+    );
+    let text = String::from_utf8(output.bytes).expect("output should be utf-8");
+    assert!(text.contains("\"type\":\"session_started\""));
+    assert!(text.contains("\"type\":\"agent_loop_result\""));
+    assert!(text.contains("\"status\":\"completed\""));
+    assert!(text.contains("done from run"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn writer_returns_incomplete_when_agent_loop_blocks() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let provider = ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(
+            vec![ModelOutput::tool_call(ModelToolCall::new(
+                ModelToolCallId::new("call-read").expect("valid call id"),
+                ToolName::new("workspace_read_file").expect("valid tool name"),
+                ToolArguments::try_from(serde_json::json!({"path": "README.md"}))
+                    .expect("valid args"),
+            ))],
+            FinishReason::ToolCalls,
+            None,
+        ),
+    })]]);
+    let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
+    let permissioned_factory = Arc::new(
+        merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
+    );
+    let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
+        session_id: "run-blocked-writer-test",
+        root: &workspace,
+        process_backend: fixed_process_backend(ProcessSession::from_parts(
+            merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+            runner,
+            permissioned_factory,
+        )),
+        provider: Arc::new(provider),
+        model: model_name(),
+        extra_tools: Vec::new(),
+        allow_hidden_workspace_paths: false,
+        automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
+        retry_policy: None,
+        context_compaction: None,
+        approval_review: None,
+        skill_roots: Vec::new(),
+        subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
+    })
+    .expect("runtime should build");
+
+    let mut output = Vec::new();
+    let status = write_agent_loop_output(
+        &runtime,
+        StepInput::user_text("read README").expect("valid input"),
+        AgentLoopConfig::new(1).expect("valid config"),
+        StepContext::default(),
+        &mut output,
+    )
+    .await
+    .expect("run output should write");
+
+    assert_eq!(status, RunExitStatus::Incomplete);
+    let text = String::from_utf8(output).expect("output should be utf-8");
+    assert!(text.contains("tool: workspace_read_file path=README.md"));
+    assert!(text.contains("status: blocked"));
+    assert!(text.contains("reason: max model turns reached (1)"));
+}

--- a/crates/merry-cli/src/run/persistence_tests.rs
+++ b/crates/merry-cli/src/run/persistence_tests.rs
@@ -1,22 +1,20 @@
 use super::{HeadlessRunPersistence, RunExitStatus, run_agent_loop_with_persistence};
-use crate::cli_error::CliError;
+use crate::cli_error::{CliError, unexpected};
 use crate::coding::{
     ActionProcessBackend, CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
     fixed_process_backend, resume_headless_coding,
 };
+use crate::headless_review::{HeadlessPermissionReviewer, ReviewInputChannel};
 use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name};
 use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
-use merry_core::{
-    ArtifactId, ArtifactKind, ArtifactRef, ErrorInfo, SessionId, ToolCallResult, ToolInputSchema,
-    ToolName, ToolOutput, ToolSpec,
-};
+use merry_core::{SessionId, ToolInputSchema, ToolName, ToolOutput, ToolSpec};
 use merry_llm::{
     FinishReason, ModelError, ModelEvent, ModelOutput, ModelProvider, ModelResponse, ModelToolCall,
     ModelToolCallId, ToolArguments,
 };
 use merry_process::ProcessSession;
 use merry_runtime::{
-    AgentLoopConfig, ArtifactContent, FileSessionStore, ProcessRunner, RegisteredTool, Runtime,
+    AgentLoopConfig, FileSessionStore, ProcessRunner, RegisteredTool, Runtime,
     SessionTranscriptItem, StepContext, StepInput, ToolExecutionContext, ToolExecutionError,
     ToolExecutor, ToolExecutorFuture,
 };
@@ -170,28 +168,23 @@ fn assert_transcript_contains_user_input(transcript: &[SessionTranscriptItem], e
     );
 }
 
-async fn resolve_pending_after_runtime_error(runtime: &Runtime) -> Result<(), CliError> {
-    let pending = runtime.pending_tool_calls().await;
-    let [call] = pending.as_slice() else {
-        panic!("runtime error should retain one pending tool call: {pending:?}");
-    };
-    let artifact = ArtifactRef::new(
-        ArtifactId::new("reviewer-runtime-recovery").expect("valid artifact id"),
-        ArtifactKind::Text,
+/// Text settlement records for a tool call the run never got a result for.
+const ABANDONED_TOOL_RESULT_TEXT: &str = concat!(
+    "Tool execution was abandoned: the headless run settled before this tool ",
+    "call produced a result"
+);
+
+fn assert_transcript_records_abandoned_tool_call(transcript: &[SessionTranscriptItem]) {
+    assert!(
+        transcript.iter().any(|item| matches!(
+            item,
+            SessionTranscriptItem::ToolResult {
+                output: Some(ToolOutput::Text { text }),
+                ..
+            } if text == ABANDONED_TOOL_RESULT_TEXT
+        )),
+        "settlement should record why the pending call never resolved: {transcript:?}"
     );
-    let diagnostic = ErrorInfo::new(
-        "reviewer_runtime_recovery",
-        "reviewer resolved a pending call after runtime settlement failed",
-    )
-    .expect("valid diagnostic");
-    runtime
-        .submit_tool_result(
-            ToolCallResult::failed(call.id().clone(), artifact, diagnostic),
-            ArtifactContent::text("executor outage was recorded for resume"),
-        )
-        .await
-        .expect("reviewer settlement should make the session resume-safe");
-    Ok(())
 }
 
 struct FailingWriter {
@@ -242,7 +235,6 @@ async fn runtime_settlement_error_is_persisted_and_partial_state_can_resume() {
         StepInput::user_text("retain this partial task").expect("valid input"),
         FailingWriter::new(io::ErrorKind::Other, "injected runtime output failure"),
         async {
-            resolve_pending_after_runtime_error(&runtime).await?;
             Err(CliError::Unexpected(
                 "injected runtime reviewer failure".to_owned(),
             ))
@@ -268,13 +260,7 @@ async fn runtime_settlement_error_is_persisted_and_partial_state_can_resume() {
     drop(runtime);
     let transcript = resumed_transcript(&session_id, &workspace, store).await;
     assert_transcript_contains_user_input(&transcript, "retain this partial task");
-    assert!(transcript.iter().any(|item| matches!(
-        item,
-        SessionTranscriptItem::ToolResult {
-            output: Some(ToolOutput::Text { text }),
-            ..
-        } if text == "executor outage was recorded for resume"
-    )));
+    assert_transcript_records_abandoned_tool_call(&transcript);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -299,7 +285,7 @@ async fn save_error_precedes_runtime_settlement_error() {
         &runtime,
         StepInput::user_text("save failure must win").expect("valid input"),
         &mut output,
-        resolve_pending_after_runtime_error(&runtime),
+        async { Ok(()) },
         HeadlessRunPersistence {
             loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
                 .expect("valid config"),
@@ -557,4 +543,59 @@ async fn save_error_precedes_broken_pipe_and_reviewer_errors() {
         }
         other => panic!("save failure must not become BrokenPipe success, got {other:?}"),
     }
+}
+
+/// The shipped orchestration path, end to end: the real permission reviewer is
+/// the only thing that settles alongside the runtime.
+///
+/// The production reviewer only cancels and joins its task on shutdown; it
+/// never submits a tool result. A run that fails mid-call is therefore only
+/// resumable if settlement itself resolves what the runtime left pending.
+#[tokio::test(flavor = "current_thread")]
+async fn production_reviewer_shutdown_leaves_a_resumable_session() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("production-reviewer-shutdown").expect("valid session id");
+    let tool_name = "production_shutdown_failure";
+    let runtime = build_runtime_with_tools(
+        &session_id,
+        &workspace,
+        Arc::new(infrastructure_error_provider(tool_name)),
+        vec![infrastructure_error_tool(tool_name)],
+    );
+    let reviewer = HeadlessPermissionReviewer::new();
+    // Production hands this source to the permission policy, which keeps the
+    // review task alive until shutdown cancels it.
+    let _source = reviewer.source();
+    let review_task = reviewer.start(ReviewInputChannel::Stdin);
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("keep this task resumable").expect("valid input"),
+        Vec::new(),
+        async { review_task.finish().await.map_err(unexpected) },
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    match result {
+        Err(CliError::Unexpected(message)) => assert!(
+            message.contains("temporary executor outage"),
+            "the runtime failure should survive a successful save: {message}"
+        ),
+        other => panic!("the runtime failure should be reported, got {other:?}"),
+    }
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "keep this task resumable");
+    assert_transcript_records_abandoned_tool_call(&transcript);
 }

--- a/crates/merry-cli/src/run/persistence_tests.rs
+++ b/crates/merry-cli/src/run/persistence_tests.rs
@@ -6,6 +6,7 @@ use crate::coding::{
 };
 use crate::headless_review::{HeadlessPermissionReviewer, ReviewInputChannel};
 use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name};
+use crate::tui::session_list::TuiSessionMetadata;
 use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
 use merry_core::{SessionId, ToolInputSchema, ToolName, ToolOutput, ToolSpec};
 use merry_llm::{
@@ -137,6 +138,12 @@ fn build_runtime_with_tools(
     build_headless_coding(input).expect("runtime should build")
 }
 
+fn metadata(session_id: &SessionId, workspace: &Path) -> TuiSessionMetadata {
+    let mut metadata = TuiSessionMetadata::new(session_id.clone(), workspace.to_path_buf(), 0);
+    metadata.headless = true;
+    metadata
+}
+
 async fn resumed_transcript(
     session_id: &SessionId,
     workspace: &Path,
@@ -233,7 +240,7 @@ async fn runtime_settlement_error_is_persisted_and_partial_state_can_resume() {
     let result = run_agent_loop_with_persistence(
         &runtime,
         StepInput::user_text("retain this partial task").expect("valid input"),
-        FailingWriter::new(io::ErrorKind::Other, "injected runtime output failure"),
+        Vec::new(),
         async {
             Err(CliError::Unexpected(
                 "injected runtime reviewer failure".to_owned(),
@@ -246,6 +253,7 @@ async fn runtime_settlement_error_is_persisted_and_partial_state_can_resume() {
             events_jsonl: true,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -293,6 +301,7 @@ async fn save_error_precedes_runtime_settlement_error() {
             events_jsonl: false,
             session_store: FileSessionStore::new(invalid_store_root),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -307,17 +316,14 @@ async fn save_error_precedes_runtime_settlement_error() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn completed_jsonl_broken_pipe_drains_and_persists_before_success_mapping() {
+async fn completed_jsonl_broken_pipe_cancels_and_persists_before_error_mapping() {
     let temp = tempfile::tempdir().expect("tempdir");
     let workspace = temp.path().join("workspace");
     std::fs::create_dir_all(&workspace).expect("workspace should be created");
     let store = FileSessionStore::new(temp.path().join("sessions"));
     let session_id = SessionId::new("completed-broken-pipe-save").expect("valid session id");
-    let runtime = build_runtime(
-        &session_id,
-        &workspace,
-        Arc::new(completing_provider("completed answer")),
-    );
+    let provider = completing_provider("completed answer");
+    let runtime = build_runtime(&session_id, &workspace, Arc::new(provider.clone()));
 
     let result = run_agent_loop_with_persistence(
         &runtime,
@@ -331,6 +337,7 @@ async fn completed_jsonl_broken_pipe_drains_and_persists_before_success_mapping(
             events_jsonl: true,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -367,6 +374,7 @@ async fn incomplete_terminal_run_is_persisted_and_remains_incomplete() {
             events_jsonl: false,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await
@@ -399,6 +407,7 @@ async fn incomplete_human_output_failure_still_persists() {
             events_jsonl: false,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -436,6 +445,7 @@ async fn output_error_precedes_reviewer_error_after_persistence() {
             events_jsonl: false,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -491,6 +501,7 @@ async fn reviewer_settles_before_persistence_and_its_error_is_returned_after_sav
             events_jsonl: false,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -533,6 +544,7 @@ async fn save_error_precedes_broken_pipe_and_reviewer_errors() {
             events_jsonl: false,
             session_store: FileSessionStore::new(invalid_store_root),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;
@@ -583,6 +595,7 @@ async fn production_reviewer_shutdown_leaves_a_resumable_session() {
             events_jsonl: false,
             session_store: store.clone(),
             session_id: &session_id,
+            metadata: metadata(&session_id, &workspace),
         },
     )
     .await;

--- a/crates/merry-cli/src/run/persistence_tests.rs
+++ b/crates/merry-cli/src/run/persistence_tests.rs
@@ -1,0 +1,560 @@
+use super::{HeadlessRunPersistence, RunExitStatus, run_agent_loop_with_persistence};
+use crate::cli_error::CliError;
+use crate::coding::{
+    ActionProcessBackend, CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
+    fixed_process_backend, resume_headless_coding,
+};
+use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name};
+use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
+use merry_core::{
+    ArtifactId, ArtifactKind, ArtifactRef, ErrorInfo, SessionId, ToolCallResult, ToolInputSchema,
+    ToolName, ToolOutput, ToolSpec,
+};
+use merry_llm::{
+    FinishReason, ModelError, ModelEvent, ModelOutput, ModelProvider, ModelResponse, ModelToolCall,
+    ModelToolCallId, ToolArguments,
+};
+use merry_process::ProcessSession;
+use merry_runtime::{
+    AgentLoopConfig, ArtifactContent, FileSessionStore, ProcessRunner, RegisteredTool, Runtime,
+    SessionTranscriptItem, StepContext, StepInput, ToolExecutionContext, ToolExecutionError,
+    ToolExecutor, ToolExecutorFuture,
+};
+use std::{
+    io,
+    path::Path,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::io::AsyncWrite;
+
+fn completing_provider(text: &str) -> ScriptedProvider {
+    ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(vec![ModelOutput::text(text)], FinishReason::Stop, None),
+    })]])
+}
+
+fn incomplete_provider() -> ScriptedProvider {
+    ScriptedProvider::new(vec![vec![Err(ModelError::Cancelled)]])
+}
+
+fn infrastructure_error_provider(tool_name: &str) -> ScriptedProvider {
+    ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(
+            vec![ModelOutput::tool_call(ModelToolCall::new(
+                ModelToolCallId::new("call-runtime-settlement-error").expect("valid call id"),
+                ToolName::new(tool_name).expect("valid tool name"),
+                ToolArguments::try_from(serde_json::json!({})).expect("valid tool arguments"),
+            ))],
+            FinishReason::ToolCalls,
+            None,
+        ),
+    })]])
+}
+
+struct InfrastructureErrorExecutor;
+
+impl ToolExecutor for InfrastructureErrorExecutor {
+    fn execute<'a>(
+        &'a self,
+        _call: merry_core::PendingToolCall,
+        _context: ToolExecutionContext,
+    ) -> ToolExecutorFuture<'a> {
+        Box::pin(async {
+            Err(ToolExecutionError::infrastructure(
+                "temporary executor outage",
+            ))
+        })
+    }
+}
+
+fn infrastructure_error_tool(tool_name: &str) -> RegisteredTool {
+    let schema = schemars::Schema::try_from(serde_json::json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+    }))
+    .expect("test tool schema should be valid");
+    let spec = ToolSpec::new(
+        ToolName::new(tool_name).expect("valid tool name"),
+        "Exercise runtime settlement failure",
+        ToolInputSchema::new(schema).expect("valid tool input schema"),
+    )
+    .expect("valid tool spec");
+    RegisteredTool::read_only(spec, Arc::new(InfrastructureErrorExecutor))
+}
+
+fn fake_process_backend() -> ActionProcessBackend {
+    let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
+    let permissioned_factory = Arc::new(
+        merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
+    );
+    fixed_process_backend(ProcessSession::from_parts(
+        merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+        runner,
+        permissioned_factory,
+    ))
+}
+
+fn headless_input<'a>(
+    session_id: &'a str,
+    workspace: &'a Path,
+    provider: Arc<dyn ModelProvider>,
+) -> HeadlessCodingRuntimeInput<'a> {
+    HeadlessCodingRuntimeInput {
+        session_id,
+        root: workspace,
+        provider,
+        model: model_name(),
+        process_backend: fake_process_backend(),
+        extra_tools: Vec::new(),
+        allow_hidden_workspace_paths: false,
+        automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
+        retry_policy: None,
+        context_compaction: None,
+        approval_review: None,
+        skill_roots: Vec::new(),
+        subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
+    }
+}
+
+fn build_runtime(
+    session_id: &SessionId,
+    workspace: &Path,
+    provider: Arc<dyn ModelProvider>,
+) -> Runtime {
+    build_runtime_with_tools(session_id, workspace, provider, Vec::new())
+}
+
+fn build_runtime_with_tools(
+    session_id: &SessionId,
+    workspace: &Path,
+    provider: Arc<dyn ModelProvider>,
+    extra_tools: Vec<RegisteredTool>,
+) -> Runtime {
+    let mut input = headless_input(session_id.as_str(), workspace, provider);
+    input.extra_tools = extra_tools;
+    build_headless_coding(input).expect("runtime should build")
+}
+
+async fn resumed_transcript(
+    session_id: &SessionId,
+    workspace: &Path,
+    store: FileSessionStore,
+) -> Vec<SessionTranscriptItem> {
+    let resumed = resume_headless_coding(
+        headless_input(
+            session_id.as_str(),
+            workspace,
+            Arc::new(completing_provider("unused resumed answer")),
+        ),
+        store,
+    )
+    .await
+    .expect("persisted session should resume");
+    resumed
+        .session_transcript()
+        .await
+        .expect("resumed transcript should be available")
+}
+
+fn assert_transcript_contains_user_input(transcript: &[SessionTranscriptItem], expected: &str) {
+    assert!(
+        transcript.iter().any(|item| matches!(
+            item,
+            SessionTranscriptItem::UserMessage { text, .. } if text == expected
+        )),
+        "persisted transcript should contain {expected:?}: {transcript:?}"
+    );
+}
+
+async fn resolve_pending_after_runtime_error(runtime: &Runtime) -> Result<(), CliError> {
+    let pending = runtime.pending_tool_calls().await;
+    let [call] = pending.as_slice() else {
+        panic!("runtime error should retain one pending tool call: {pending:?}");
+    };
+    let artifact = ArtifactRef::new(
+        ArtifactId::new("reviewer-runtime-recovery").expect("valid artifact id"),
+        ArtifactKind::Text,
+    );
+    let diagnostic = ErrorInfo::new(
+        "reviewer_runtime_recovery",
+        "reviewer resolved a pending call after runtime settlement failed",
+    )
+    .expect("valid diagnostic");
+    runtime
+        .submit_tool_result(
+            ToolCallResult::failed(call.id().clone(), artifact, diagnostic),
+            ArtifactContent::text("executor outage was recorded for resume"),
+        )
+        .await
+        .expect("reviewer settlement should make the session resume-safe");
+    Ok(())
+}
+
+struct FailingWriter {
+    kind: io::ErrorKind,
+    message: &'static str,
+}
+
+impl FailingWriter {
+    const fn new(kind: io::ErrorKind, message: &'static str) -> Self {
+        Self { kind, message }
+    }
+}
+
+impl AsyncWrite for FailingWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Err(io::Error::new(self.kind, self.message)))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Err(io::Error::new(self.kind, self.message)))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn runtime_settlement_error_is_persisted_and_partial_state_can_resume() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("runtime-settlement-error-save").expect("valid session id");
+    let tool_name = "runtime_settlement_failure";
+    let runtime = build_runtime_with_tools(
+        &session_id,
+        &workspace,
+        Arc::new(infrastructure_error_provider(tool_name)),
+        vec![infrastructure_error_tool(tool_name)],
+    );
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("retain this partial task").expect("valid input"),
+        FailingWriter::new(io::ErrorKind::Other, "injected runtime output failure"),
+        async {
+            resolve_pending_after_runtime_error(&runtime).await?;
+            Err(CliError::Unexpected(
+                "injected runtime reviewer failure".to_owned(),
+            ))
+        },
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: true,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    assert!(matches!(
+        result,
+        Err(CliError::Unexpected(message))
+            if message.contains("temporary executor outage")
+                && !message.contains("output")
+                && !message.contains("reviewer")
+    ));
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "retain this partial task");
+    assert!(transcript.iter().any(|item| matches!(
+        item,
+        SessionTranscriptItem::ToolResult {
+            output: Some(ToolOutput::Text { text }),
+            ..
+        } if text == "executor outage was recorded for resume"
+    )));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn save_error_precedes_runtime_settlement_error() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let invalid_store_root = temp.path().join("runtime-error-store-is-a-file");
+    std::fs::write(&invalid_store_root, "not a directory")
+        .expect("invalid store fixture should be written");
+    let session_id = SessionId::new("runtime-error-save-precedence").expect("valid session id");
+    let tool_name = "runtime_settlement_save_failure";
+    let runtime = build_runtime_with_tools(
+        &session_id,
+        &workspace,
+        Arc::new(infrastructure_error_provider(tool_name)),
+        vec![infrastructure_error_tool(tool_name)],
+    );
+    let mut output = Vec::new();
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("save failure must win").expect("valid input"),
+        &mut output,
+        resolve_pending_after_runtime_error(&runtime),
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: FileSessionStore::new(invalid_store_root),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    match result {
+        Err(CliError::Unexpected(message)) => {
+            assert!(message.contains("session runtime-error-save-precedence could not be saved"));
+            assert!(message.contains("session store IO error"));
+            assert!(!message.contains("temporary executor outage"));
+        }
+        other => panic!("save failure should precede runtime failure, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn completed_jsonl_broken_pipe_drains_and_persists_before_success_mapping() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("completed-broken-pipe-save").expect("valid session id");
+    let runtime = build_runtime(
+        &session_id,
+        &workspace,
+        Arc::new(completing_provider("completed answer")),
+    );
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("completed task").expect("valid input"),
+        FailingWriter::new(io::ErrorKind::BrokenPipe, "closed JSONL consumer"),
+        std::future::ready(Ok(())),
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: true,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    assert!(matches!(result, Err(CliError::BrokenPipe)));
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "completed task");
+    assert!(transcript.iter().any(|item| matches!(
+        item,
+        SessionTranscriptItem::AssistantText { text } if text == "completed answer"
+    )));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn incomplete_terminal_run_is_persisted_and_remains_incomplete() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("incomplete-terminal-save").expect("valid session id");
+    let runtime = build_runtime(&session_id, &workspace, Arc::new(incomplete_provider()));
+    let mut output = Vec::new();
+
+    let status = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("cancel this run").expect("valid input"),
+        &mut output,
+        std::future::ready(Ok(())),
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await
+    .expect("an incomplete terminal run should persist");
+    assert_eq!(status, RunExitStatus::Incomplete);
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "cancel this run");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn incomplete_human_output_failure_still_persists() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("incomplete-output-save").expect("valid session id");
+    let runtime = build_runtime(&session_id, &workspace, Arc::new(incomplete_provider()));
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("cancel with closed output").expect("valid input"),
+        FailingWriter::new(io::ErrorKind::BrokenPipe, "closed human-output consumer"),
+        std::future::ready(Ok(())),
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    assert!(matches!(result, Err(CliError::BrokenPipe)));
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "cancel with closed output");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn output_error_precedes_reviewer_error_after_persistence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("output-review-ordering").expect("valid session id");
+    let runtime = build_runtime(
+        &session_id,
+        &workspace,
+        Arc::new(completing_provider("answer that cannot be presented")),
+    );
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("ordering task").expect("valid input"),
+        FailingWriter::new(io::ErrorKind::Other, "injected final output failure"),
+        std::future::ready(Err(CliError::Unexpected(
+            "injected reviewer presentation failure".to_owned(),
+        ))),
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    match result {
+        Err(CliError::Unexpected(message)) => {
+            assert!(message.contains("injected final output failure"));
+            assert!(!message.contains("reviewer"));
+        }
+        other => panic!("output failure should remain primary, got {other:?}"),
+    }
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "ordering task");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reviewer_settles_before_persistence_and_its_error_is_returned_after_save() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let sessions_dir = temp.path().join("sessions");
+    std::fs::write(&sessions_dir, "reviewer has not settled")
+        .expect("the store should start invalid");
+    let store = FileSessionStore::new(&sessions_dir);
+    let session_id = SessionId::new("reviewer-error-save").expect("valid session id");
+    let runtime = build_runtime(
+        &session_id,
+        &workspace,
+        Arc::new(completing_provider("completed before reviewer failure")),
+    );
+    let mut output = Vec::new();
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("reviewer failure task").expect("valid input"),
+        &mut output,
+        async {
+            tokio::fs::remove_file(&sessions_dir)
+                .await
+                .expect("reviewer settlement should remove the invalid store fixture");
+            tokio::fs::create_dir(&sessions_dir)
+                .await
+                .expect("reviewer settlement should make the store writable");
+            Err(CliError::Unexpected(
+                "injected reviewer presentation failure".to_owned(),
+            ))
+        },
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: store.clone(),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    assert!(matches!(
+        result,
+        Err(CliError::Unexpected(message)) if message == "injected reviewer presentation failure"
+    ));
+
+    drop(runtime);
+    let transcript = resumed_transcript(&session_id, &workspace, store).await;
+    assert_transcript_contains_user_input(&transcript, "reviewer failure task");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn save_error_precedes_broken_pipe_and_reviewer_errors() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace should be created");
+    let invalid_store_root = temp.path().join("store-is-a-file");
+    std::fs::write(&invalid_store_root, "not a directory")
+        .expect("invalid store fixture should be written");
+    let session_id = SessionId::new("save-error-propagation").expect("valid session id");
+    let runtime = build_runtime(
+        &session_id,
+        &workspace,
+        Arc::new(completing_provider("completed before save failure")),
+    );
+
+    let result = run_agent_loop_with_persistence(
+        &runtime,
+        StepInput::user_text("must report save failure").expect("valid input"),
+        FailingWriter::new(io::ErrorKind::BrokenPipe, "closed human-output consumer"),
+        std::future::ready(Err(CliError::Unexpected(
+            "injected reviewer presentation failure".to_owned(),
+        ))),
+        HeadlessRunPersistence {
+            loop_config: AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS)
+                .expect("valid config"),
+            context: StepContext::default(),
+            events_jsonl: false,
+            session_store: FileSessionStore::new(invalid_store_root),
+            session_id: &session_id,
+        },
+    )
+    .await;
+    match result {
+        Err(CliError::Unexpected(message)) => {
+            assert!(message.contains("session save-error-propagation could not be saved"));
+            assert!(message.contains("session store IO error"));
+        }
+        other => panic!("save failure must not become BrokenPipe success, got {other:?}"),
+    }
+}

--- a/crates/merry-cli/src/run/session_tests.rs
+++ b/crates/merry-cli/src/run/session_tests.rs
@@ -1,11 +1,12 @@
 use super::{
-    Args, CliError, RunExitStatus, RunSession, STDIN_TASK, default_run_session_id, resolve_task,
-    write_agent_loop_output,
+    Args, CliError, RunExitStatus, RunSession, STDIN_TASK, default_run_session_id,
+    refuse_reused_session_id, resolve_task, review_input_channel_for_task, write_agent_loop_output,
 };
 use crate::coding::{
     ActionProcessBackend, CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
     fixed_process_backend, resume_headless_coding,
 };
+use crate::headless_review::ReviewInputChannel;
 use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name};
 use clap::Parser;
 use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
@@ -13,7 +14,10 @@ use merry_core::SessionId;
 use merry_llm::{FinishReason, ModelEvent, ModelOutput, ModelProvider, ModelResponse};
 use merry_process::ProcessSession;
 use merry_runtime::{AgentLoopConfig, ProcessRunner, StepContext, StepInput};
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 #[test]
 fn default_run_session_id_is_generated() {
@@ -261,4 +265,75 @@ async fn a_saved_run_session_resumes_with_its_recorded_transcript() {
         )),
         "the resumed session should keep the first answer: {transcript:?}"
     );
+}
+
+#[test]
+fn a_stdin_task_moves_permission_review_off_stdin() {
+    assert_eq!(
+        review_input_channel_for_task(STDIN_TASK),
+        ReviewInputChannel::ControllingTerminal,
+        "a `-` task consumes stdin, so review cannot also read it"
+    );
+    assert_eq!(
+        review_input_channel_for_task("fix the failing tests"),
+        ReviewInputChannel::Stdin,
+        "an argv task leaves stdin free for review answers"
+    );
+}
+
+/// Writes committed state for `session_id` and returns its `state.json` path.
+fn save_existing_session_state(sessions_dir: &Path, session_id: &str, bytes: &[u8]) -> PathBuf {
+    let session_dir = sessions_dir.join(session_id);
+    std::fs::create_dir_all(&session_dir).expect("session dir should be created");
+    let state_path = session_dir.join("state.json");
+    std::fs::write(&state_path, bytes).expect("existing session state should be written");
+    state_path
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a_new_run_refuses_a_session_id_that_already_has_saved_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let sessions_dir = temp.path().join("sessions");
+    let state_path = save_existing_session_state(&sessions_dir, "already-saved", b"existing state");
+    let store = merry_runtime::FileSessionStore::new(&sessions_dir);
+    let session_id = SessionId::new("already-saved").expect("valid session id");
+
+    let error = refuse_reused_session_id(&RunSession::New(session_id), &store)
+        .await
+        .expect_err("a new run must not take over a saved session id");
+
+    let message = usage_message(error);
+    assert!(
+        message.contains("--resume already-saved"),
+        "the refusal should point at the way to continue the session: {message}"
+    );
+    assert_eq!(
+        std::fs::read(&state_path).expect("saved state should still be readable"),
+        b"existing state",
+        "a refused run must leave the saved session untouched"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a_new_run_accepts_a_session_id_the_store_does_not_hold() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = merry_runtime::FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = SessionId::new("never-saved").expect("valid session id");
+
+    refuse_reused_session_id(&RunSession::New(session_id), &store)
+        .await
+        .expect("an unused session id should start a new run");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn resuming_a_saved_session_id_is_not_a_collision() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let sessions_dir = temp.path().join("sessions");
+    save_existing_session_state(&sessions_dir, "resume-me", b"existing state");
+    let store = merry_runtime::FileSessionStore::new(&sessions_dir);
+    let session_id = SessionId::new("resume-me").expect("valid session id");
+
+    refuse_reused_session_id(&RunSession::Resumed(session_id), &store)
+        .await
+        .expect("resuming is how an existing session id is meant to be reused");
 }

--- a/crates/merry-cli/src/run/session_tests.rs
+++ b/crates/merry-cli/src/run/session_tests.rs
@@ -1,6 +1,6 @@
 use super::{
     Args, CliError, RunExitStatus, RunSession, STDIN_TASK, default_run_session_id,
-    refuse_reused_session_id, resolve_task, review_input_channel_for_task, write_agent_loop_output,
+    reserve_run_session, resolve_task, review_input_channel_for_task, write_agent_loop_output,
 };
 use crate::coding::{
     ActionProcessBackend, CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
@@ -298,7 +298,7 @@ async fn a_new_run_refuses_a_session_id_that_already_has_saved_state() {
     let store = merry_runtime::FileSessionStore::new(&sessions_dir);
     let session_id = SessionId::new("already-saved").expect("valid session id");
 
-    let error = refuse_reused_session_id(&RunSession::New(session_id), &store)
+    let error = reserve_run_session(&RunSession::New(session_id), &store)
         .await
         .expect_err("a new run must not take over a saved session id");
 
@@ -320,7 +320,7 @@ async fn a_new_run_accepts_a_session_id_the_store_does_not_hold() {
     let store = merry_runtime::FileSessionStore::new(temp.path().join("sessions"));
     let session_id = SessionId::new("never-saved").expect("valid session id");
 
-    refuse_reused_session_id(&RunSession::New(session_id), &store)
+    reserve_run_session(&RunSession::New(session_id), &store)
         .await
         .expect("an unused session id should start a new run");
 }
@@ -333,7 +333,7 @@ async fn resuming_a_saved_session_id_is_not_a_collision() {
     let store = merry_runtime::FileSessionStore::new(&sessions_dir);
     let session_id = SessionId::new("resume-me").expect("valid session id");
 
-    refuse_reused_session_id(&RunSession::Resumed(session_id), &store)
+    reserve_run_session(&RunSession::Resumed(session_id), &store)
         .await
         .expect("resuming is how an existing session id is meant to be reused");
 }

--- a/crates/merry-cli/src/run/session_tests.rs
+++ b/crates/merry-cli/src/run/session_tests.rs
@@ -1,0 +1,264 @@
+use super::{
+    Args, CliError, RunExitStatus, RunSession, STDIN_TASK, default_run_session_id, resolve_task,
+    write_agent_loop_output,
+};
+use crate::coding::{
+    ActionProcessBackend, CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
+    fixed_process_backend, resume_headless_coding,
+};
+use crate::testing::{FakeProcessRunner, ScriptedProvider, model_name};
+use clap::Parser;
+use merry::profiles::DEFAULT_CODING_AGENT_MAX_MODEL_TURNS;
+use merry_core::SessionId;
+use merry_llm::{FinishReason, ModelEvent, ModelOutput, ModelProvider, ModelResponse};
+use merry_process::ProcessSession;
+use merry_runtime::{AgentLoopConfig, ProcessRunner, StepContext, StepInput};
+use std::{path::Path, sync::Arc};
+
+#[test]
+fn default_run_session_id_is_generated() {
+    let first = default_run_session_id();
+    let second = default_run_session_id();
+
+    assert_ne!(first, second);
+    assert_ne!(first.as_str(), "run");
+}
+
+fn parse_run_args(argv: &[&str]) -> Args {
+    let cli = crate::cli::Cli::try_parse_from(argv).expect("run arguments should parse");
+    match cli.command {
+        Some(crate::cli::CliCommand::Run(args)) => args,
+        other => panic!("expected the run subcommand, got {other:?}"),
+    }
+}
+
+fn usage_message(error: CliError) -> String {
+    match error {
+        CliError::DebugUsage(message) => message,
+        other => panic!("expected a usage error, got {other:?}"),
+    }
+}
+
+fn completing_provider(text: &str) -> ScriptedProvider {
+    ScriptedProvider::new(vec![vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(vec![ModelOutput::text(text)], FinishReason::Stop, None),
+    })]])
+}
+
+fn fake_process_backend() -> ActionProcessBackend {
+    let runner: Arc<dyn ProcessRunner> = Arc::new(FakeProcessRunner::succeeding(""));
+    let permissioned_factory = Arc::new(
+        merry_runtime::StaticPermissionedProcessRunnerFactory::new(Arc::clone(&runner)),
+    );
+    fixed_process_backend(ProcessSession::from_parts(
+        merry_runtime::AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+        runner,
+        permissioned_factory,
+    ))
+}
+
+fn headless_input<'a>(
+    session_id: &'a str,
+    workspace: &'a Path,
+    provider: Arc<dyn ModelProvider>,
+) -> HeadlessCodingRuntimeInput<'a> {
+    HeadlessCodingRuntimeInput {
+        session_id,
+        root: workspace,
+        provider,
+        model: model_name(),
+        process_backend: fake_process_backend(),
+        extra_tools: Vec::new(),
+        allow_hidden_workspace_paths: false,
+        automatic_compaction: merry_runtime::AutomaticCompactionConfig::disabled(),
+        retry_policy: None,
+        context_compaction: None,
+        approval_review: None,
+        skill_roots: Vec::new(),
+        subagents: CodingSubagentsConfig::default(),
+        workspace_tool_limits: None,
+    }
+}
+
+#[test]
+fn run_starts_a_new_generated_session_without_session_flags() {
+    let session = RunSession::from_args(&parse_run_args(&["merry", "run", "task"]))
+        .expect("session should resolve");
+
+    assert!(
+        matches!(session, RunSession::New(_)),
+        "a run without session flags should start a new session, got {session:?}"
+    );
+}
+
+#[test]
+fn run_writes_to_the_requested_session_id() {
+    let session = RunSession::from_args(&parse_run_args(&[
+        "merry",
+        "run",
+        "--session-id",
+        "kiln-step-1",
+        "task",
+    ]))
+    .expect("session should resolve");
+
+    assert_eq!(
+        session,
+        RunSession::New(SessionId::new("kiln-step-1").unwrap())
+    );
+}
+
+#[test]
+fn run_resumes_the_requested_session_id() {
+    let session = RunSession::from_args(&parse_run_args(&[
+        "merry",
+        "run",
+        "--resume",
+        "kiln-step-1",
+        "task",
+    ]))
+    .expect("session should resolve");
+
+    assert_eq!(
+        session,
+        RunSession::Resumed(SessionId::new("kiln-step-1").unwrap())
+    );
+}
+
+#[test]
+fn run_rejects_a_session_id_that_would_escape_the_session_store() {
+    let error = RunSession::from_args(&parse_run_args(&[
+        "merry",
+        "run",
+        "--session-id",
+        "../outside",
+        "task",
+    ]))
+    .expect_err("a path-shaped session id should be refused");
+
+    assert!(
+        usage_message(error).contains("--session-id"),
+        "the refusal should name the flag that was wrong"
+    );
+}
+
+#[test]
+fn run_rejects_a_resume_id_that_would_escape_the_session_store() {
+    let error = RunSession::from_args(&parse_run_args(&["merry", "run", "--resume", "..", "task"]))
+        .expect_err("a path-shaped resume id should be refused");
+
+    assert!(
+        usage_message(error).contains("--resume"),
+        "the refusal should name the flag that was wrong"
+    );
+}
+
+#[test]
+fn run_refuses_to_both_start_and_resume_a_session() {
+    crate::cli::Cli::try_parse_from([
+        "merry",
+        "run",
+        "--session-id",
+        "one",
+        "--resume",
+        "two",
+        "task",
+    ])
+    .expect_err("--session-id and --resume should conflict");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn task_comes_from_argv_when_it_is_not_a_dash() {
+    let task = resolve_task("fix the failing tests", &b"ignored stdin"[..])
+        .await
+        .expect("argv task should resolve");
+
+    assert_eq!(task, "fix the failing tests");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn task_comes_from_stdin_when_it_is_a_dash() {
+    let prompt = "a task too large and too private for argv\n";
+
+    let task = resolve_task(STDIN_TASK, prompt.as_bytes())
+        .await
+        .expect("stdin task should resolve");
+
+    assert_eq!(task, prompt);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a_blank_stdin_task_is_a_usage_error() {
+    let error = resolve_task(STDIN_TASK, &b"  \n\t"[..])
+        .await
+        .expect_err("a blank stdin task should be refused");
+
+    assert!(
+        usage_message(error).contains("stdin"),
+        "the refusal should say where the empty task came from"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a_saved_run_session_resumes_with_its_recorded_transcript() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+    let store = merry_runtime::FileSessionStore::new(temp.path().join("sessions"));
+    let session_id = "run-resume-session";
+
+    let first = build_headless_coding(headless_input(
+        session_id,
+        &workspace,
+        Arc::new(completing_provider("first answer")),
+    ))
+    .expect("runtime should build");
+    let mut output = Vec::new();
+    let status = write_agent_loop_output(
+        &first,
+        StepInput::user_text("first task").expect("valid input"),
+        AgentLoopConfig::new(DEFAULT_CODING_AGENT_MAX_MODEL_TURNS).expect("valid config"),
+        StepContext::default(),
+        &mut output,
+    )
+    .await
+    .expect("first run should write");
+    assert_eq!(status, RunExitStatus::Completed);
+    first
+        .save_session_to(store.clone())
+        .await
+        .expect("a finished run should save its session");
+    drop(first);
+
+    let resumed = resume_headless_coding(
+        headless_input(
+            session_id,
+            &workspace,
+            Arc::new(completing_provider("second answer")),
+        ),
+        store,
+    )
+    .await
+    .expect("the saved session should resume");
+
+    let transcript = resumed
+        .session_transcript()
+        .await
+        .expect("a resumed session should expose its transcript");
+    assert!(
+        transcript.iter().any(|item| matches!(
+            item,
+            merry_runtime::SessionTranscriptItem::UserMessage { text, .. }
+                if text == "first task"
+        )),
+        "the resumed session should keep the first task: {transcript:?}"
+    );
+    assert!(
+        transcript.iter().any(|item| matches!(
+            item,
+            merry_runtime::SessionTranscriptItem::AssistantText { text }
+                if text == "first answer"
+        )),
+        "the resumed session should keep the first answer: {transcript:?}"
+    );
+}

--- a/crates/merry-cli/src/tui/mod.rs
+++ b/crates/merry-cli/src/tui/mod.rs
@@ -51,7 +51,7 @@ mod provider_selection;
 mod reasoning_picker;
 mod render;
 mod runtime;
-mod session_list;
+pub(crate) mod session_list;
 mod session_picker;
 mod state;
 mod status;

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -24,8 +24,8 @@ use merry_llm::GenerationConfig;
 use merry_runtime::{
     AgentLoopControl, AgentLoopInput, AutomaticCompactionConfig, ChannelPermissionAdmissionSource,
     InteractivePrimaryModel, InteractiveRunEventStream, InteractiveSettingsUpdate,
-    InteractiveSubagentSettings, PermissionReviewRequest, Runtime, SessionTranscriptItem,
-    SkillMetadata, StepContext, SubagentActivityReceiver,
+    InteractiveSubagentSettings, PermissionReviewRequest, Runtime, SessionReservation,
+    SessionTranscriptItem, SkillMetadata, StepContext, SubagentActivityReceiver,
 };
 use std::{collections::VecDeque, env, num::NonZeroU64, path::PathBuf, sync::Arc};
 use tokio::sync::mpsc;
@@ -46,6 +46,7 @@ pub(crate) struct TuiRuntimeSession {
     merry_config: MerryConfig,
     pub(crate) permission_requests: mpsc::Receiver<PermissionReviewRequest>,
     pending_permission_reviews: VecDeque<PermissionReviewRequest>,
+    _session_reservation: SessionReservation,
 }
 
 pub(crate) async fn start_tui_runtime_session(
@@ -88,6 +89,11 @@ pub(crate) async fn start_tui_runtime_session(
         .map(|effort| effort.as_str().to_owned());
     let workspace_root = env::current_dir().map_err(unexpected)?;
     let (session_id, mut metadata, should_resume) = session_start(selection, &workspace_root);
+    let session_reservation = session_store
+        .session_state_store()
+        .reserve_session(&session_id)
+        .await
+        .map_err(unexpected)?;
     metadata.model = Some(model_label.clone());
     metadata.reasoning_effort = reasoning_effort_label.clone();
     let backend = action_process_runner_for_mode(
@@ -190,6 +196,7 @@ pub(crate) async fn start_tui_runtime_session(
         merry_config: owned_config,
         permission_requests,
         pending_permission_reviews: VecDeque::new(),
+        _session_reservation: session_reservation,
     })
 }
 

--- a/crates/merry-cli/src/tui/session_list.rs
+++ b/crates/merry-cli/src/tui/session_list.rs
@@ -44,6 +44,8 @@ pub(crate) struct TuiSessionMetadata {
     pub(crate) title: Option<String>,
     pub(crate) model: Option<String>,
     pub(crate) reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub(crate) headless: bool,
 }
 
 impl TuiSessionMetadata {
@@ -56,6 +58,7 @@ impl TuiSessionMetadata {
             title: None,
             model: None,
             reasoning_effort: None,
+            headless: false,
         }
     }
 
@@ -80,6 +83,20 @@ impl TuiSessionStore {
 
     pub(crate) fn metadata_path(&self, session_id: &SessionId) -> PathBuf {
         self.sessions_dir.join(session_id.as_str()).join(META_FILE)
+    }
+
+    pub(crate) fn read_metadata(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<TuiSessionMetadata>, TuiSessionListError> {
+        let path = self.metadata_path(session_id);
+        match fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map(Some)
+                .map_err(|source| json_error(&path, source)),
+            Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(io_error(path, source)),
+        }
     }
 
     pub(crate) fn write_metadata(

--- a/crates/merry-cli/src/tui/session_picker.rs
+++ b/crates/merry-cli/src/tui/session_picker.rs
@@ -200,6 +200,7 @@ fn session_line(session: &TuiSessionMetadata) -> Line<'static> {
         .unwrap_or("Untitled session");
     let model = session.model.as_deref().unwrap_or("model -");
     let effort = session.reasoning_effort.as_deref().unwrap_or("-");
+    let origin = if session.headless { "headless" } else { "TUI" };
     Line::from(vec![
         Span::styled(title.to_owned(), Style::default().fg(Color::White)),
         Span::raw("  "),
@@ -211,6 +212,8 @@ fn session_line(session: &TuiSessionMetadata) -> Line<'static> {
         Span::styled(model.to_owned(), Style::default().fg(Color::LightMagenta)),
         Span::raw(" "),
         Span::styled(effort.to_owned(), Style::default().fg(Color::LightMagenta)),
+        Span::raw("  "),
+        Span::styled(origin.to_owned(), Style::default().fg(Color::DarkGray)),
     ])
 }
 
@@ -289,5 +292,19 @@ mod tests {
         assert!(text.contains("Merry Sessions"));
         assert!(text.contains("session session-a"));
         assert!(text.contains("Enter resume"));
+    }
+
+    #[test]
+    fn picker_marks_headless_sessions_separately_from_tui_sessions() {
+        let mut headless = metadata("headless-session", 10);
+        headless.headless = true;
+        let text = render_picker_to_text(
+            &SessionPickerState::new(vec![headless]),
+            Path::new("/repo"),
+            100,
+            12,
+        );
+
+        assert!(text.contains("headless"));
     }
 }

--- a/crates/merry-cli/tests/run_cli.rs
+++ b/crates/merry-cli/tests/run_cli.rs
@@ -127,3 +127,110 @@ fn run_reports_an_unknown_resume_id_without_starting_a_session() {
         "a run that never started should not emit runtime events"
     );
 }
+
+/// `state.json` under the store layout `XDG_STATE_HOME` selects.
+fn session_state_path(temp: &tempfile::TempDir, session_id: &str) -> std::path::PathBuf {
+    temp.path()
+        .join("state/merry/sessions")
+        .join(session_id)
+        .join("state.json")
+}
+
+#[test]
+fn run_refuses_a_session_id_that_already_has_saved_state() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    write_xdg_config(&temp, OFFLINE_PROVIDER_CONFIG);
+    let state_path = session_state_path(&temp, "taken");
+    std::fs::create_dir_all(state_path.parent().expect("state path has a session dir"))
+        .expect("session dir should be created");
+    std::fs::write(&state_path, b"existing state").expect("existing state should be written");
+
+    let output = merry_without_openai_env_and_xdg(&temp)
+        .args(["--no-sandbox", "run", "--session-id", "taken", "a task"])
+        .output()
+        .expect("merry run should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "reusing a saved session id should be a usage error"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    assert!(
+        stderr.contains("--resume taken"),
+        "the refusal should point at the way to continue the session: {stderr}"
+    );
+    assert_eq!(
+        std::fs::read(&state_path).expect("saved state should still be readable"),
+        b"existing state",
+        "a refused run must not replace the saved session"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a run refused before startup should not emit runtime events"
+    );
+}
+
+#[test]
+fn a_saved_run_blocks_reusing_its_session_id_but_not_resuming_it() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    write_xdg_config(&temp, OFFLINE_PROVIDER_CONFIG);
+
+    let first = merry_without_openai_env_and_xdg(&temp)
+        .args([
+            "--no-sandbox",
+            "run",
+            "--session-id",
+            "saved-once",
+            "a task",
+        ])
+        .output()
+        .expect("merry run should run");
+    assert!(
+        !first.status.success(),
+        "the offline provider should fail the first run"
+    );
+    let state_path = session_state_path(&temp, "saved-once");
+    assert!(
+        state_path.exists(),
+        "a settled run should save its session state"
+    );
+    let saved = std::fs::read(&state_path).expect("saved state should be readable");
+
+    let reused = merry_without_openai_env_and_xdg(&temp)
+        .args([
+            "--no-sandbox",
+            "run",
+            "--session-id",
+            "saved-once",
+            "another task",
+        ])
+        .output()
+        .expect("merry run should run");
+    assert_eq!(
+        reused.status.code(),
+        Some(2),
+        "a second run must not take over the saved session id"
+    );
+    assert_eq!(
+        std::fs::read(&state_path).expect("saved state should still be readable"),
+        saved,
+        "the refused run must leave the saved session byte-identical"
+    );
+
+    let resumed = merry_without_openai_env_and_xdg(&temp)
+        .args([
+            "--no-sandbox",
+            "run",
+            "--resume",
+            "saved-once",
+            "another task",
+        ])
+        .output()
+        .expect("merry run should run");
+    let resumed_stderr = String::from_utf8(resumed.stderr).expect("stderr should be utf-8");
+    assert!(
+        !resumed_stderr.contains("already has saved state"),
+        "--resume is the supported way to continue a saved session: {resumed_stderr}"
+    );
+}

--- a/crates/merry-cli/tests/run_cli.rs
+++ b/crates/merry-cli/tests/run_cli.rs
@@ -136,6 +136,42 @@ fn session_state_path(temp: &tempfile::TempDir, session_id: &str) -> std::path::
         .join("state.json")
 }
 
+fn session_metadata_path(temp: &tempfile::TempDir, session_id: &str) -> std::path::PathBuf {
+    temp.path()
+        .join("state/merry/sessions")
+        .join(session_id)
+        .join("meta.json")
+}
+
+#[test]
+fn a_headless_run_writes_picker_metadata_with_headless_origin() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    write_xdg_config(&temp, OFFLINE_PROVIDER_CONFIG);
+
+    let output = merry_without_openai_env_and_xdg(&temp)
+        .args([
+            "--no-sandbox",
+            "run",
+            "--session-id",
+            "picker-visible",
+            "a task",
+        ])
+        .output()
+        .expect("merry run should run");
+    assert!(
+        !output.status.success(),
+        "the offline provider should fail the run"
+    );
+
+    let metadata_path = session_metadata_path(&temp, "picker-visible");
+    let metadata: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&metadata_path).expect("headless metadata should be written"),
+    )
+    .expect("headless metadata should be valid JSON");
+    assert_eq!(metadata["headless"], true);
+    assert_eq!(metadata["session_id"], "picker-visible");
+}
+
 #[test]
 fn run_refuses_a_session_id_that_already_has_saved_state() {
     let temp = tempfile::tempdir().expect("tempdir should be created");

--- a/crates/merry-cli/tests/run_cli.rs
+++ b/crates/merry-cli/tests/run_cli.rs
@@ -1,0 +1,129 @@
+mod support;
+
+use std::{io::Write, process::Stdio};
+use support::{merry_without_openai_env_and_xdg, write_xdg_config};
+
+/// Config that resolves a provider without reaching one: session selection and
+/// resume run before the first model call, so an offline endpoint is enough.
+const OFFLINE_PROVIDER_CONFIG: &str = "\
+[providers.default]
+provider = \"openai-compatible\"
+model = \"offline-model\"
+
+[providers.openai-compatible]
+type = \"openai-compatible\"
+protocol = \"responses\"
+base_url = \"http://127.0.0.1:9/v1\"
+api_key = \"sk-offline-not-used\"
+";
+
+#[test]
+fn run_refuses_a_whitespace_only_stdin_task_before_emitting_events() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    write_xdg_config(&temp, OFFLINE_PROVIDER_CONFIG);
+
+    let mut child = merry_without_openai_env_and_xdg(&temp)
+        .args(["--no-sandbox", "run", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("merry run should start");
+    child
+        .stdin
+        .take()
+        .expect("stdin should be piped")
+        .write_all(b"  \n\t")
+        .expect("whitespace task should write");
+
+    let output = child.wait_with_output().expect("merry run should finish");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a whitespace-only stdin task should be a usage error"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    assert!(
+        stderr.contains("the task read from stdin is empty"),
+        "the refusal should explain that the stdin task was empty: {stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a run rejected before startup should not emit runtime events"
+    );
+}
+
+#[test]
+fn run_refuses_a_session_id_that_would_escape_the_session_store() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+
+    let output = merry_without_openai_env_and_xdg(&temp)
+        .args(["--no-sandbox", "run", "--session-id", "../escape", "a task"])
+        .output()
+        .expect("merry run should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "an unsafe session id should be a usage error"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    assert!(
+        stderr.contains("--session-id"),
+        "the refusal should name the flag that was wrong: {stderr}"
+    );
+}
+
+#[test]
+fn run_refuses_to_both_start_and_resume_a_session() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+
+    let output = merry_without_openai_env_and_xdg(&temp)
+        .args([
+            "--no-sandbox",
+            "run",
+            "--session-id",
+            "one",
+            "--resume",
+            "two",
+            "a task",
+        ])
+        .output()
+        .expect("merry run should run");
+
+    assert!(
+        !output.status.success(),
+        "starting and resuming one run should be refused"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    assert!(
+        stderr.contains("--session-id") && stderr.contains("--resume"),
+        "the refusal should name both flags: {stderr}"
+    );
+}
+
+#[test]
+fn run_reports_an_unknown_resume_id_without_starting_a_session() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    write_xdg_config(&temp, OFFLINE_PROVIDER_CONFIG);
+
+    let output = merry_without_openai_env_and_xdg(&temp)
+        .args(["--no-sandbox", "run", "--resume", "never-existed", "a task"])
+        .output()
+        .expect("merry run should run");
+
+    assert!(
+        !output.status.success(),
+        "resuming a session that was never saved should fail"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    assert!(
+        stderr.contains("could not resume session never-existed"),
+        "the failure should name the session that could not be resumed: {stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a run that never started should not emit runtime events"
+    );
+}

--- a/crates/merry-runtime/src/agent_loop.rs
+++ b/crates/merry-runtime/src/agent_loop.rs
@@ -270,6 +270,19 @@ impl AgentLoopEventStream {
         }
     }
 
+    /// Cancels the loop producer and waits until its task has stopped.
+    ///
+    /// This is the output-boundary cancellation path: once a consumer cannot
+    /// accept another event, callers must stop provider/tool work before
+    /// settling and persisting the runtime state.
+    pub async fn cancel_and_wait(&mut self) {
+        self.loop_token.cancel();
+        if let Some(handle) = self.producer_handle.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
     /// Returns the next internal driver message.
     ///
     /// SDK bridge drivers use this to execute bridge tool calls without

--- a/crates/merry-runtime/src/lib.rs
+++ b/crates/merry-runtime/src/lib.rs
@@ -142,7 +142,9 @@ pub use profile::{
 pub use prompt::{PromptBlock, PromptError, PromptProfile};
 pub use runtime::{AutomaticCompactionConfig, Runtime, RuntimeBuilder};
 pub use session_projection::SessionTranscriptItem;
-pub use session_store::{FileSessionStore, PlanPersistenceLocation, SessionStoreError};
+pub use session_store::{
+    FileSessionStore, PlanPersistenceLocation, SessionReservation, SessionStoreError,
+};
 pub use skill::{SkillCatalog, SkillError, SkillLoadWarning, SkillMetadata};
 pub use step::StepContext;
 pub use subagent::{

--- a/crates/merry-runtime/src/runtime/session_access.rs
+++ b/crates/merry-runtime/src/runtime/session_access.rs
@@ -13,6 +13,9 @@ use merry_core::{
 };
 use std::sync::Arc;
 
+/// Diagnostic code recorded for a tool call a settling run gave up on.
+const TOOL_ABANDONED_BY_SETTLEMENT_CODE: &str = "tool_abandoned_by_run_settlement";
+
 impl Runtime {
     /// Records exact artifact state into the owning session and returns observable events.
     ///
@@ -154,6 +157,58 @@ impl Runtime {
         };
         persist_resume_safe_savepoint_if_configured(&self.inner).await;
         Ok(events)
+    }
+
+    /// Resolves every pending tool call with a durable failed result so the
+    /// session reaches a resume-safe boundary, returning how many were resolved.
+    ///
+    /// A run that settles while a tool call is still pending cannot be saved at
+    /// all: [`crate::SessionStoreError::UnsafePendingToolCalls`] rejects the
+    /// bundle, so the partial session is lost instead of persisted. Owners of
+    /// run settlement call this before saving to record why each call never
+    /// produced a result, which is what keeps a failed run resumable.
+    ///
+    /// This acquires the active-step permit and therefore cannot run while a
+    /// step, tool submission, or tool execution is in flight.
+    pub async fn abandon_pending_tool_calls(&self, reason: &str) -> Result<usize, RuntimeError> {
+        let active_permit = ActiveStepPermit::acquire(Arc::clone(&self.inner.active_step))
+            .ok_or_else(|| RuntimeError::StepAlreadyActive {
+                session_id: self.inner.session_id.clone(),
+            })?;
+        let pending = {
+            let session = self.inner.session.lock().await;
+            session.pending_tool_calls()
+        };
+        for call in &pending {
+            self.submit_tool_abandoned_failure_with_active_permit(
+                call.id(),
+                reason,
+                &active_permit,
+            )
+            .await?;
+        }
+        Ok(pending.len())
+    }
+
+    async fn submit_tool_abandoned_failure_with_active_permit(
+        &self,
+        call_id: &ToolCallId,
+        reason: &str,
+        _active_permit: &ActiveStepPermit,
+    ) -> Result<(), RuntimeError> {
+        let diagnostic = diagnostic_from_text(TOOL_ABANDONED_BY_SETTLEMENT_CODE, reason);
+        {
+            let mut session = self.inner.session.lock().await;
+            session.submit_tool_execution_outcome(
+                call_id,
+                ToolCallResultStatus::Failed,
+                ArtifactContent::text(format!("Tool execution was abandoned: {reason}")),
+                Some(diagnostic),
+                None,
+            )?;
+        }
+        persist_resume_safe_savepoint_if_configured(&self.inner).await;
+        Ok(())
     }
 
     /// Converts an executor infrastructure failure into a durable failed

--- a/crates/merry-runtime/src/runtime/tests/session_resume.rs
+++ b/crates/merry-runtime/src/runtime/tests/session_resume.rs
@@ -813,3 +813,58 @@ fn model_tool_call(id: &str, name: &str, arguments: serde_json::Value) -> ModelT
         ToolArguments::try_from(arguments).expect("valid tool arguments"),
     )
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn abandoning_pending_tool_calls_makes_a_stalled_session_saveable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = FileSessionStore::new(temp.path());
+    let session_id = session_id("runtime-abandon-pending");
+    let runtime = Runtime::builder(session_id)
+        .build()
+        .expect("runtime builds");
+    let call = PendingToolCall::new(
+        ToolCallId::new("call-abandoned").expect("valid tool call id"),
+        ToolName::new("stalled_tool").expect("valid tool name"),
+        ToolCallArguments::new(Default::default()),
+    );
+    runtime
+        .inner
+        .session
+        .lock()
+        .await
+        .record_test_tool_call_pending(call)
+        .expect("pending call records");
+
+    runtime
+        .save_session_to(store.clone())
+        .await
+        .expect_err("a session holding a pending tool call must not be saved");
+
+    assert_eq!(
+        runtime
+            .abandon_pending_tool_calls("the run settled before this call resolved")
+            .await
+            .expect("pending calls resolve"),
+        1
+    );
+    assert!(runtime.pending_tool_calls().await.is_empty());
+    runtime
+        .save_session_to(store)
+        .await
+        .expect("the session saves once nothing is pending");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn abandoning_pending_tool_calls_is_a_no_op_without_any() {
+    let runtime = Runtime::builder(session_id("runtime-abandon-none"))
+        .build()
+        .expect("runtime builds");
+
+    assert_eq!(
+        runtime
+            .abandon_pending_tool_calls("nothing to abandon")
+            .await
+            .expect("an idle runtime resolves nothing"),
+        0
+    );
+}

--- a/crates/merry-runtime/src/session_store.rs
+++ b/crates/merry-runtime/src/session_store.rs
@@ -3,12 +3,16 @@ use std::{
     env,
     ffi::OsStr,
     fmt,
+    fs::{File, OpenOptions as StdOpenOptions},
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
-use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use tokio::fs::OpenOptions;
 
 /// Identifies which persisted Plan snapshot failed document validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,6 +40,7 @@ const TEMP_FILE_CREATE_ATTEMPTS: u32 = 1_024;
 const TEMP_FILE_PREFIX: &str = ".state.json.tmp-";
 const PLAN_OVERLAY_TEMP_FILE_PREFIX: &str = ".plan-state.json.tmp-";
 const PLAN_OVERLAY_FILE_NAME: &str = "plan-state.json";
+const SESSION_LOCK_FILE_NAME: &str = ".session.lock";
 
 #[cfg(test)]
 use std::sync::{
@@ -69,6 +74,8 @@ pub enum SessionStoreError {
         requested: SessionId,
         actual: SessionId,
     },
+    #[error("session {session_id} is already reserved by another run")]
+    SessionAlreadyReserved { session_id: SessionId },
     #[error(
         "session {session_id} has {pending_count} pending tool calls and cannot be saved at an incomplete tool boundary"
     )]
@@ -103,8 +110,8 @@ pub(crate) fn validate_plan_snapshot(
 /// File-backed session state storage with atomic replacement per write.
 ///
 /// Store clones are safe to use through one runtime's serialized session
-/// lifecycle. Independent runtimes must not concurrently mutate the same
-/// session id without external single-writer coordination.
+/// lifecycle. Callers that create or resume a live run should hold a
+/// [`SessionReservation`] for the session id while it is active.
 #[derive(Debug, Clone)]
 pub struct FileSessionStore {
     sessions_dir: PathBuf,
@@ -116,6 +123,14 @@ pub struct FileSessionStore {
     fail_commit: bool,
     #[cfg(test)]
     fail_directory_sync: bool,
+}
+
+/// Exclusive ownership of one session's on-disk state for the lifetime of a
+/// run. The operating-system file lock is released when this value is dropped,
+/// including when the owning process is terminated.
+#[derive(Debug)]
+pub struct SessionReservation {
+    _lock_file: File,
 }
 
 #[derive(Debug)]
@@ -311,6 +326,59 @@ impl FileSessionStore {
     #[must_use]
     pub fn sessions_dir(&self) -> &Path {
         &self.sessions_dir
+    }
+
+    /// Reserves exclusive write ownership of a session id until the returned
+    /// guard is dropped.
+    ///
+    /// The lock is acquired before callers inspect or write `state.json`, so
+    /// independent runs cannot both pass a check-then-save collision window.
+    /// The lock file is intentionally retained as an empty per-session inode;
+    /// it is not session state and is ignored by session discovery.
+    pub async fn reserve_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<SessionReservation, SessionStoreError> {
+        let session_dir = self.session_dir(session_id);
+        tokio::fs::create_dir_all(&session_dir)
+            .await
+            .map_err(|source| io_error(session_dir.clone(), source))?;
+        let lock_path = session_dir.join(SESSION_LOCK_FILE_NAME);
+        let session_id = session_id.clone();
+        let lock_file = tokio::task::spawn_blocking({
+            let lock_path = lock_path.clone();
+            move || {
+                let mut options = StdOpenOptions::new();
+                options.read(true).write(true).create(true);
+                #[cfg(unix)]
+                options.mode(0o600);
+                let file = options
+                    .open(&lock_path)
+                    .map_err(|source| io_error(lock_path.clone(), source))?;
+                #[cfg(unix)]
+                file.set_permissions(std::fs::Permissions::from_mode(0o600))
+                    .map_err(|source| io_error(lock_path.clone(), source))?;
+                match file.try_lock() {
+                    Ok(()) => Ok(file),
+                    Err(std::fs::TryLockError::WouldBlock) => {
+                        Err(SessionStoreError::SessionAlreadyReserved {
+                            session_id: session_id.clone(),
+                        })
+                    }
+                    Err(std::fs::TryLockError::Error(source)) => Err(io_error(lock_path, source)),
+                }
+            }
+        })
+        .await
+        .map_err(|source| {
+            io_error(
+                lock_path,
+                std::io::Error::other(format!("session reservation task failed: {source}")),
+            )
+        })??;
+        Ok(SessionReservation {
+            _lock_file: lock_file,
+        })
     }
 
     /// Reports whether this store already holds committed state for a session id.
@@ -868,5 +936,42 @@ mod tests {
                 .expect("a committed store should be readable"),
             "committed state must be reported so a new run cannot replace it"
         );
+    }
+
+    #[tokio::test]
+    async fn session_reservation_is_exclusive_and_releases_on_drop() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = FileSessionStore::new(temp.path());
+        let session_id = SessionId::new("session-reservation").expect("valid session id");
+        let first = store
+            .reserve_session(&session_id)
+            .await
+            .expect("first reservation succeeds");
+        assert!(matches!(
+            store.reserve_session(&session_id).await,
+            Err(SessionStoreError::SessionAlreadyReserved { .. })
+        ));
+        drop(first);
+        store
+            .reserve_session(&session_id)
+            .await
+            .expect("dropping the reservation releases it");
+    }
+
+    #[tokio::test]
+    async fn concurrent_session_reservations_have_one_winner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = FileSessionStore::new(temp.path());
+        let session_id = SessionId::new("session-reservation-race").expect("valid session id");
+        let (left, right) = tokio::join!(
+            store.reserve_session(&session_id),
+            store.reserve_session(&session_id)
+        );
+
+        assert_ne!(left.is_ok(), right.is_ok());
+        assert!(matches!(
+            left.as_ref().err().or_else(|| right.as_ref().err()),
+            Some(SessionStoreError::SessionAlreadyReserved { .. })
+        ));
     }
 }

--- a/crates/merry-runtime/src/session_store.rs
+++ b/crates/merry-runtime/src/session_store.rs
@@ -313,6 +313,22 @@ impl FileSessionStore {
         &self.sessions_dir
     }
 
+    /// Reports whether this store already holds committed state for a session id.
+    ///
+    /// Saving is an atomic replace of `state.json`, so a new run that reuses an
+    /// id would silently overwrite that session's transcript, ledger,
+    /// artifacts, and checkpoints. Callers that start a session check this
+    /// first and refuse the id instead of destroying resumable state.
+    pub async fn contains_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<bool, SessionStoreError> {
+        let path = self.state_path(session_id);
+        tokio::fs::try_exists(&path)
+            .await
+            .map_err(|source| io_error(path, source))
+    }
+
     pub(crate) fn session_dir(&self, session_id: &SessionId) -> PathBuf {
         self.sessions_dir.join(session_id.as_str())
     }
@@ -811,5 +827,46 @@ mod tests {
             .discard()
             .await
             .expect("second staged state discards");
+    }
+
+    #[tokio::test]
+    async fn contains_session_reports_only_committed_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = FileSessionStore::new(temp.path());
+        let session_id = SessionId::new("session-store-collision").expect("valid session id");
+
+        assert!(
+            !store
+                .contains_session(&session_id)
+                .await
+                .expect("an empty store should be readable"),
+            "an unused session id has no saved state"
+        );
+
+        let staged = store
+            .stage_state_bytes(&session_id, br#"{"format_version":1,"value":"staged"}"#)
+            .await
+            .expect("state should stage");
+        assert!(
+            !store
+                .contains_session(&session_id)
+                .await
+                .expect("a staged store should be readable"),
+            "staged state is not yet a session another run could destroy"
+        );
+
+        staged
+            .commit()
+            .await
+            .expect("staged state should commit")
+            .require_durable()
+            .expect("commit should be durable");
+        assert!(
+            store
+                .contains_session(&session_id)
+                .await
+                .expect("a committed store should be readable"),
+            "committed state must be reported so a new run cannot replace it"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds headless session support to `merry run`: `--session-id` names the session a
run writes to, `--resume` continues one, and a `TASK` of `-` reads the task from
stdin instead of argv. Every settled run saves its transcript, ledger,
artifacts, and checkpoints under `$XDG_STATE_HOME/merry/sessions/<session-id>`,
so a later `--resume` picks the session up where it stopped.

## What is here

**Headless sessions.** `--session-id` and `--resume` are mutually exclusive; both
validate the id, so `../outside` cannot escape the session store. Without either
flag the run generates its own id, which `--events-jsonl` reports as
`source.session_id` on every event. Headless sessions carry no TUI metadata and
so do not appear in the `merry resume` picker; they are addressed by id.

**Task from stdin.** `merry run -` keeps a large or generated prompt off argv,
where it would be visible to every process listing on the host and bounded by
the kernel's per-argument limit. Empty or whitespace-only stdin is a usage error.

**Run persistence.** Settlement drains the runtime, shuts the permission reviewer
down, resolves whatever the run left pending, and then saves. A persistence
failure takes precedence over runtime, stdout, and reviewer failures, so the CLI
cannot report an earlier failure while durable state silently went unwritten.

## Review fixes in this branch

An earlier review of the first commit found three blockers. The second commit
closes them.

**Runtime failures could not actually resume.** A run that failed mid-call
settled with its tool call unresolved, and the session store rejects that
bundle (`UnsafePendingToolCalls`), so the entire partial session was lost rather
than persisted. The production reviewer only cancels and joins its task on
shutdown and never submits a result, so only a test reviewer that submitted one
itself ever reached a resume-safe boundary. Settlement now resolves every
pending call with a durable failed result before saving, via a new
`Runtime::abandon_pending_tool_calls`.

**A stdin task consumed the permission reviewer's stdin.** `merry run -` reads
stdin to end-of-file, after which the reviewer opened stdin again, read that
end-of-file, and silently denied every request. Review answers now come from the
controlling terminal when the task came from stdin; a run with no controlling
terminal denies each request with that reason on stderr rather than defaulting
quietly. Approvals cannot be piped alongside the task, which the README now
states.

**Reusing `--session-id` destroyed the existing session.** Saving is an atomic
replace of `state.json`, so a typo or a reused id overwrote that session's
transcript, ledger, artifacts, and checkpoints with nothing left to resume. A new
run now refuses an id the store already holds and points at `--resume`. The check
runs before the task is read, so a mistyped id fails without first consuming
stdin.

## Testing

- `cargo fmt --all --check` — passes
- `cargo clippy --all-targets --all-features -- -D warnings` — passes
- `cargo test --all --no-fail-fast` — 1857 passed, 2 failed across 47 test binaries

The two failures are `debug_shell::shell_events_jsonl_records_exact_argv_and_resolves_success`
and `debug_shell::shell_rg_files_prints_process_stdout`. Both shell out to
`rg --files`, and ripgrep is not installed on the machine used to run the suite.
This branch touches no shell code. They are an environment gap, not a regression.

New coverage: the settlement test now drives the real `HeadlessPermissionReviewer`
shutdown end to end instead of a reviewer that resolves pending calls itself;
reviewer tests cover both an available and an absent review input channel; and
session-collision coverage runs at unit level and as a CLI integration test that
saves a session, is refused when reusing its id with the state left
byte-identical, and is accepted under `--resume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Jjx1HzzXPvRJVYrSXeS4p
