### PR TITLE
fix(runtime): 修复放弃工具调用后的事件提交

### DIFF
--- a/crates/merry-runtime/src/runtime/session_access.rs
+++ b/crates/merry-runtime/src/runtime/session_access.rs
@@ -200,7 +200,7 @@ impl Runtime {
         _active_permit: &ActiveStepPermit,
     ) -> Result<(), RuntimeError> {
         let diagnostic = diagnostic_from_text(TOOL_ABANDONED_BY_SETTLEMENT_CODE, reason);
-        {
+        let events = {
             let mut session = self.inner.session.lock().await;
             session.submit_tool_execution_outcome(
                 call_id,
@@ -208,9 +208,9 @@ impl Runtime {
                 ArtifactContent::text(format!("Tool execution was abandoned: {reason}")),
                 Some(diagnostic),
                 None,
-            )?;
-        }
-        persist_resume_safe_savepoint_if_configured(&self.inner).await;
+            )?
+        };
+        self.inner.commit_journal_events(&events).await;
         Ok(())
     }
 

--- a/crates/merry-runtime/src/runtime/tests/session_resume.rs
+++ b/crates/merry-runtime/src/runtime/tests/session_resume.rs
@@ -960,13 +960,19 @@ async fn abandoning_pending_tool_calls_makes_a_stalled_session_saveable() {
         ToolName::new("stalled_tool").expect("valid tool name"),
         ToolCallArguments::new(Default::default()),
     );
-    runtime
+    let call_id = call.id().clone();
+    let pending_event = runtime
         .inner
         .session
         .lock()
         .await
         .record_test_tool_call_pending(call)
         .expect("pending call records");
+    runtime.observe_recorded_journal_events(std::slice::from_ref(&pending_event));
+    let trajectory_before_abandonment = runtime
+        .trajectory_snapshot()
+        .await
+        .expect("trajectory snapshot reads");
 
     runtime
         .save_session_to(store.clone())
@@ -981,6 +987,23 @@ async fn abandoning_pending_tool_calls_makes_a_stalled_session_saveable() {
         1
     );
     assert!(runtime.pending_tool_calls().await.is_empty());
+    let trajectory_after_abandonment = runtime
+        .trajectory_snapshot()
+        .await
+        .expect("trajectory snapshot reads");
+    assert!(
+        trajectory_after_abandonment.revision() > trajectory_before_abandonment.revision(),
+        "abandonment must advance the live trajectory projection"
+    );
+    let abandoned_record = trajectory_after_abandonment
+        .records()
+        .iter()
+        .find(|record| record.tool_call_id() == Some(&call_id))
+        .expect("abandoned tool remains visible in the trajectory");
+    assert_eq!(
+        abandoned_record.status(),
+        merry_core::TrajectoryRecordStatus::Failed
+    );
     runtime
         .save_session_to(store)
         .await


### PR DESCRIPTION
## 问题

#35 重构后，放弃待处理工具调用的路径仍调用已移入私有模块的 helper，导致 `merry-runtime` 报 `E0425`、无法编译。该路径还丢弃了工具结果返回的 journal events；仅补充导入会使 live trajectory 继续落后于 ledger 和 transcript。

## 修复

- 通过既有 `commit_journal_events` 提交 abandonment events。
- 让 live trajectory 与 resume savepoint 保持一致。
- 补充回归测试，验证 trajectory revision 前进且工具记录最终为 `Failed`。

## 验证

- `cargo fmt --all --check`
- `cargo check -p merry-runtime --all-targets`
- `cargo test --all`（1,082 通过，1 个 live test 忽略）
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm test`（14 通过）