### PR TITLE
test(reliability): add deterministic T6 evidence gates

### DIFF
--- a/.github/workflows/reliability-gate.yml
+++ b/.github/workflows/reliability-gate.yml
@@ -1,0 +1,120 @@
+name: Deterministic Reliability Gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reliability-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  rust:
+    name: Rust reliability and security
+    needs: web
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Download tested Web assets
+        uses: actions/download-artifact@v4
+        with:
+          name: merry-web-dist
+          path: web/dist
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install shell and sandbox test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes bubblewrap ripgrep
+
+      - name: Enable unprivileged sandbox namespaces
+        run: |
+          set -euo pipefail
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
+          bwrap --unshare-user --die-with-parent --ro-bind / / -- /usr/bin/true
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run named T6 evidence scenario
+        run: >-
+          cargo test --locked -p merry-runtime --test provider_boundary
+          t6_failure_evidence -- --nocapture
+
+      - name: Run deterministic security and lifecycle scenarios
+        run: |
+          set -euo pipefail
+          cargo test --locked -p merry-runtime --test provider_boundary provider_stream_eof_before_completed_emits_failed -- --nocapture
+          cargo test --locked -p merry-runtime --test provider_boundary provider_stream_error_emits_failed_without_step_completed -- --nocapture
+          cargo test --locked -p merry-runtime --test provider_boundary duplicate_tool_result_after_resolved_does_not_mutate_session -- --nocapture
+          cargo test --locked -p merry-runtime --test provider_boundary provider_cancel_keeps_tool_exchange_for_retry -- --nocapture
+          cargo test --locked -p merry-runtime --test cancellation cancelling_ -- --nocapture
+          cargo test --locked -p merry-runtime --test agent_loop agent_loop_process_command_invalid_arguments -- --nocapture
+          cargo test --locked -p merry-runtime --test agent_loop provider_request_trace_includes_checkpoint_budget_diagnostics -- --nocapture
+          cargo test --locked -p merry-tool-workspace --test runtime_integration denied_workspace_patch -- --nocapture
+          cargo test --locked -p merry-tool-workspace --test runtime_integration registered_list_dir_domain_failure -- --nocapture
+          cargo test --locked -p merry-process --lib bwrap_process_plan_hides_unapproved_host_integrations -- --nocapture
+          cargo test --locked -p merry-cli --bin merry settings_debug_does_not_include_secret_material -- --nocapture
+          cargo test --locked -p merry-cli --bin merry sandbox_rejects_symlinked_product_write_roots -- --nocapture
+
+      - name: Run deterministic Rust suite
+        run: cargo test --locked --all
+
+      - name: Run Rust lint gate
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Summarize deterministic diagnostics
+        if: always()
+        run: |
+          {
+            echo "## Deterministic reliability/security gate"
+            echo "- revision: \`${GITHUB_SHA}\`"
+            echo "- named evidence scenario: \`t6_failure_evidence\`"
+            echo "- live provider and Harbor: not used"
+            echo "- runtime event, artifact, ledger, trajectory, and test-result links are asserted by the named scenario"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  web:
+    name: Web trajectory contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build and test Web assets
+        working-directory: web
+        run: npm ci && npm test
+
+      - name: Verify generated Web sources
+        run: git diff --exit-code -- web/src/trajectory-contract.generated.ts
+
+      - name: Upload tested Web assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: merry-web-dist
+          path: web/dist
+          if-no-files-found: error

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ issues. This file keeps only the major delivery sequence and its dependencies.
 - [x] [T3: Establish the unique CodingAgentProfile (implemented; shared facade/CLI profile, stable-prefix and admission evidence)](https://github.com/locez/merry/issues/12)
 - [x] [T4: Internal Coding Eval Suite (closed; no standalone runner)](https://github.com/locez/merry/issues/13)
 - [x] [T5: Unify CLI, Debug, and Rust Runtime Builder](https://github.com/locez/merry/issues/14) (shared builder, validated permission policy, parent-child inheritance tests, full Rust verification; read-only capability-closure follow-up deferred by approval)
-- [ ] [T6: Establish production reliability, security, and observability harness](https://github.com/locez/merry/issues/15)
+- [ ] [T6: Establish production reliability, security, and observability harness](https://github.com/locez/merry/issues/15) (deterministic PR gate and cross-layer failure evidence added; live/nightly coverage remains)
 - [ ] [T7: Release a stable Rust SDK](https://github.com/locez/merry/issues/16)
 - [ ] [T8: Align Python and Rust SDK capabilities](https://github.com/locez/merry/issues/17)
 - [ ] [T9: Integrate external coding-agent evaluation suites](https://github.com/locez/merry/issues/18)

--- a/crates/merry-eval/src/numeric.rs
+++ b/crates/merry-eval/src/numeric.rs
@@ -80,9 +80,7 @@ fn parse_integral_decimal(raw: &str) -> Result<u64, &'static str> {
         return Err("number has an invalid exponent");
     }
 
-    let (whole, fraction) = mantissa
-        .split_once('.')
-        .map_or((mantissa, ""), |parts| parts);
+    let (whole, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
     if whole.is_empty() || !whole.bytes().all(|byte| byte.is_ascii_digit()) {
         return Err("number has an invalid integer part");
     }

--- a/crates/merry-runtime/src/agent_loop.rs
+++ b/crates/merry-runtime/src/agent_loop.rs
@@ -415,12 +415,15 @@ pub enum AgentLoopBlockedReason {
 pub struct AgentLoopError {
     events: Vec<RuntimeJournalEvent>,
     #[source]
-    source: RuntimeError,
+    source: Box<RuntimeError>,
 }
 
 impl AgentLoopError {
     fn new(events: Vec<RuntimeJournalEvent>, source: RuntimeError) -> Self {
-        Self { events, source }
+        Self {
+            events,
+            source: Box::new(source),
+        }
     }
 
     /// Runtime events collected before the method error.
@@ -438,7 +441,7 @@ impl AgentLoopError {
     /// Consumes the error into its preserved events and runtime error.
     #[must_use]
     pub fn into_parts(self) -> (Vec<RuntimeJournalEvent>, RuntimeError) {
-        (self.events, self.source)
+        (self.events, *self.source)
     }
 }
 

--- a/crates/merry-runtime/src/runtime/tests/rolling_compaction.rs
+++ b/crates/merry-runtime/src/runtime/tests/rolling_compaction.rs
@@ -517,7 +517,7 @@ async fn assert_provider_projection_has_six_raw_turns(
     assert_eq!(projection.len(), 12);
     let expected_users = &submitted_inputs[submitted_inputs.len() - 6..];
     let first_global_index = submitted_inputs.len() - 6;
-    for (index, pair) in projection.chunks_exact(2).enumerate() {
+    for (index, pair) in projection.as_chunks::<2>().0.iter().enumerate() {
         assert!(matches!(
             &pair[0],
             TranscriptItemSnapshot::UserMessage { text, .. } if text == &expected_users[index]

--- a/crates/merry-runtime/src/runtime/tests/session_resume.rs
+++ b/crates/merry-runtime/src/runtime/tests/session_resume.rs
@@ -952,7 +952,8 @@ async fn abandoning_pending_tool_calls_makes_a_stalled_session_saveable() {
     let temp = tempfile::tempdir().expect("tempdir");
     let store = FileSessionStore::new(temp.path());
     let session_id = session_id("runtime-abandon-pending");
-    let runtime = Runtime::builder(session_id)
+    let runtime = Runtime::builder(session_id.clone())
+        .session_store(store.clone())
         .build()
         .expect("runtime builds");
     let call = PendingToolCall::new(
@@ -1004,10 +1005,38 @@ async fn abandoning_pending_tool_calls_makes_a_stalled_session_saveable() {
         abandoned_record.status(),
         merry_core::TrajectoryRecordStatus::Failed
     );
-    runtime
-        .save_session_to(store)
+    assert_eq!(
+        abandoned_record
+            .diagnostic()
+            .map(|diagnostic| diagnostic.code()),
+        Some("tool_abandoned_by_run_settlement")
+    );
+    drop(runtime);
+
+    let resumed = Runtime::builder(session_id)
+        .resume_from_store(store)
         .await
-        .expect("the session saves once nothing is pending");
+        .expect("the automatic savepoint resumes");
+    assert!(resumed.pending_tool_calls().await.is_empty());
+    let resumed_trajectory = resumed
+        .trajectory_snapshot()
+        .await
+        .expect("resumed trajectory snapshot reads");
+    let resumed_record = resumed_trajectory
+        .records()
+        .iter()
+        .find(|record| record.tool_call_id() == Some(&call_id))
+        .expect("the abandoned tool remains visible after resume");
+    assert_eq!(
+        resumed_record.status(),
+        merry_core::TrajectoryRecordStatus::Failed
+    );
+    assert_eq!(
+        resumed_record
+            .diagnostic()
+            .map(|diagnostic| diagnostic.code()),
+        Some("tool_abandoned_by_run_settlement")
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/merry-runtime/tests/provider_boundary.rs
+++ b/crates/merry-runtime/tests/provider_boundary.rs
@@ -3,7 +3,8 @@ use merry_core::{
     ArtifactId, ArtifactKind, ArtifactRef, ErrorInfo, EvidenceLocator, EvidenceRef,
     PendingToolCall, PendingToolCallBatch, ProviderName, RuntimeJournalEvent,
     RuntimeJournalPayload, SessionId, ToolCallId, ToolCallResult, ToolCallResultStatus,
-    ToolInputSchema, ToolName, ToolSpec, TrajectoryLane,
+    ToolInputSchema, ToolName, ToolSpec, TrajectoryLane, TrajectoryRecordDetails,
+    TrajectoryRecordKind, TrajectoryRecordStatus,
 };
 use merry_llm::{
     FinishReason, GenerationConfig, ModelCapabilities, ModelContent, ModelError, ModelEvent,

--- a/crates/merry-runtime/tests/provider_boundary/diagnostics.rs
+++ b/crates/merry-runtime/tests/provider_boundary/diagnostics.rs
@@ -64,8 +64,7 @@ async fn failed_tool_result_status_diagnostic_and_content_are_compiled_without_r
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn submit_failed_tool_result_preserves_diagnostic_and_failure_artifact_without_failed_event()
-{
+async fn t6_failure_evidence_links_journal_artifact_ledger_and_trajectory() {
     let provider = FakeModelProvider::new(vec![Ok(completed_outputs_event(
         vec![ModelOutput::tool_call(model_tool_call())],
         FinishReason::ToolCalls,
@@ -152,4 +151,48 @@ async fn submit_failed_tool_result_preserves_diagnostic_and_failure_artifact_wit
             },
         ]
     );
+
+    let pending_sequence = pending_events
+        .iter()
+        .find_map(|event| match event.payload {
+            RuntimeJournalPayload::ToolCallPending {
+                call: ref pending_call,
+            } if pending_call.id() == call.id() => Some(event.sequence),
+            _ => None,
+        })
+        .expect("pending tool event should have a journal sequence");
+    let resolved_sequence = events
+        .iter()
+        .find_map(|event| match event.payload {
+            RuntimeJournalPayload::ToolCallResolved {
+                result: ref resolved_result,
+            } if resolved_result.call_id() == call.id() => Some(event.sequence),
+            _ => None,
+        })
+        .expect("resolved tool event should have a journal sequence");
+    let trajectory = runtime
+        .trajectory_snapshot()
+        .await
+        .expect("trajectory snapshot should be available");
+    assert_eq!(trajectory.latest_sequence(), resolved_sequence);
+    let tool_record = trajectory
+        .records()
+        .iter()
+        .find(|record| record.tool_call_id() == Some(call.id()))
+        .expect("trajectory should locate the resolved tool call");
+    assert_eq!(tool_record.kind(), TrajectoryRecordKind::ToolCall);
+    assert_eq!(tool_record.status(), TrajectoryRecordStatus::Failed);
+    assert_eq!(tool_record.start_sequence(), pending_sequence);
+    assert_eq!(tool_record.end_sequence(), Some(resolved_sequence));
+    assert_eq!(tool_record.artifacts(), &[result_artifact]);
+    assert_eq!(
+        tool_record.diagnostic().map(merry_core::ErrorInfo::code),
+        Some("tool_failed")
+    );
+    assert!(matches!(
+        tool_record.details(),
+        TrajectoryRecordDetails::Tool { tool }
+            if tool.output().map(|output| output.content())
+                == Some(r#"{"stderr":"permission denied"}"#)
+    ));
 }


### PR DESCRIPTION
## Summary

- Add a deterministic PR gate for Rust reliability/security scenarios and Web trajectory contract checks.
- Link failed tool-result evidence across journal, artifact, ledger, and trajectory state.
- Verify abandoned pending-tool settlement survives the configured automatic savepoint and a fresh resume.
- Record that deterministic T6 coverage is added while live/nightly coverage remains.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked -p merry-runtime --test provider_boundary t6_failure_evidence -- --nocapture`
- `cargo test --locked -p merry-runtime --lib session_resume -- --nocapture`
- `(cd web && npm test)`
- `git diff --check`

Closes: #15