### PR TITLE
fix(sandbox): support symlinked bwrap mount sources

### DIFF
--- a/.github/workflows/reliability-gate.yml
+++ b/.github/workflows/reliability-gate.yml
@@ -71,7 +71,7 @@ jobs:
           cargo test --locked -p merry-tool-workspace --test runtime_integration registered_list_dir_domain_failure -- --nocapture
           cargo test --locked -p merry-process --lib bwrap_process_plan_hides_unapproved_host_integrations -- --nocapture
           cargo test --locked -p merry-cli --bin merry settings_debug_does_not_include_secret_material -- --nocapture
-          cargo test --locked -p merry-cli --bin merry sandbox_rejects_symlinked_product_write_roots -- --nocapture
+          cargo test --locked -p merry-cli --bin merry sandbox_supports_symlinked_product_write_roots -- --nocapture
 
       - name: Run deterministic Rust suite
         run: cargo test --locked --all

--- a/crates/merry-cli/src/sandbox.rs
+++ b/crates/merry-cli/src/sandbox.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, EffectiveLogSettings, MerryConfig, XdgPaths};
 use crate::provider_config::MERRY_OPENAI_DEBUG_ENV;
+use merry_process::resolve_bwrap_path;
 use merry_runtime::{
     AcceptedLocalWorkspaceProcessAdmission, HostIntegration, PathAccess, PathAccessRule,
     PathAccessRuleSource,
@@ -444,10 +445,6 @@ impl SandboxPathPlan {
             host.xdg_paths.state_dir().to_path_buf(),
             host.xdg_paths.managed_config_dir(),
         ];
-        for product_path in &product_paths {
-            validate_product_path_identity(product_path)?;
-        }
-
         validate_trusted_rule_conflicts(&host.trusted_path_rules)?;
         for rule in &host.trusted_path_rules {
             if rule.access() == PathAccess::Deny
@@ -479,46 +476,12 @@ impl SandboxPathPlan {
     }
 }
 
-fn validate_product_path_identity(path: &Path) -> Result<(), Error> {
-    let mut current = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => current.push(prefix.as_os_str()),
-            Component::RootDir => current.push(component.as_os_str()),
-            Component::CurDir => continue,
-            Component::ParentDir => {
-                current.pop();
-                continue;
-            }
-            Component::Normal(part) => current.push(part),
-        }
-
-        match fs::symlink_metadata(&current) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                return Err(Error::ProductPathContainsSymlink {
-                    product_path: path.to_path_buf(),
-                    symlink_path: current,
-                });
-            }
-            Ok(_) => {}
-            Err(source) if source.kind() == io::ErrorKind::NotFound => break,
-            Err(source) => {
-                return Err(Error::ProductPathMetadata {
-                    path: current,
-                    source,
-                });
-            }
-        }
-    }
-    Ok(())
-}
-
 fn validate_trusted_rule_conflicts(rules: &[PathAccessRule]) -> Result<(), Error> {
     for (index, rule) in rules.iter().enumerate() {
-        if let Some(conflicting) = rules[index + 1..]
-            .iter()
-            .find(|other| other.path() == rule.path() && other.access() != rule.access())
-        {
+        if let Some(conflicting) = rules[index + 1..].iter().find(|other| {
+            resolve_bwrap_path(other.path()) == resolve_bwrap_path(rule.path())
+                && other.access() != rule.access()
+        }) {
             return Err(Error::ConflictingTrustedPathRules {
                 path: rule.path().to_path_buf(),
                 first_access: rule.access(),
@@ -548,13 +511,17 @@ fn path_depth(path: &Path) -> usize {
 }
 
 fn paths_overlap(left: &Path, right: &Path) -> bool {
-    left.starts_with(right) || right.starts_with(left)
+    let left = resolve_bwrap_path(left);
+    let right = resolve_bwrap_path(right);
+    left.starts_with(&right) || right.starts_with(&left)
 }
 
 fn path_is_inside_product(path: &Path, product_paths: &[PathBuf]) -> bool {
+    let path = resolve_bwrap_path(path);
     product_paths
         .iter()
-        .any(|product_path| path.starts_with(product_path))
+        .map(|product_path| resolve_bwrap_path(product_path))
+        .any(|product_path| path.starts_with(&product_path))
 }
 
 fn ensure_host_log_directory(host: &Host) -> Result<(), Error> {
@@ -863,53 +830,31 @@ fn build_plan(
         os(SANDBOX_HOME_ROOT),
     ];
     if !Path::new(&home).starts_with(Path::new(SANDBOX_HOME_ROOT)) {
-        append_mount_parent_args(&mut args, home.as_os_str());
+        append_mount_parent_args(&mut args, Path::new(&home));
         args.extend([os("--tmpfs"), home.clone()]);
     }
     args.extend([os("--perms"), os("0700"), os("--dir"), home.clone()]);
     append_bind_dir_try_args(&mut args, &config_dir, &config_dir);
-    args.extend([
-        os("--ro-bind"),
-        os("/usr"),
-        os("/usr"),
-        os("--ro-bind-try"),
-        os("/bin"),
-        os("/bin"),
-        os("--ro-bind-try"),
-        os("/lib"),
-        os("/lib"),
-        os("--ro-bind-try"),
-        os("/lib64"),
-        os("/lib64"),
-        os("--ro-bind-try"),
-        os("/opt"),
-        os("/opt"),
-    ]);
+    append_bind_dir_args(&mut args, Path::new("/usr"), Path::new("/usr"));
+    for path in ["/bin", "/lib", "/lib64", "/opt"] {
+        append_bind_dir_try_args(&mut args, Path::new(path), Path::new(path));
+    }
     for path in SANDBOX_ETC_READ_ONLY_FILE_PATHS {
         if Path::new(path).exists() {
-            append_bind_file_args(&mut args, OsStr::new(path), OsStr::new(path));
+            append_bind_file_args(&mut args, Path::new(path), Path::new(path));
         }
     }
     for path in SANDBOX_ETC_READ_ONLY_DIR_PATHS {
         if Path::new(path).exists() {
-            append_bind_dir_args(&mut args, OsStr::new(path), OsStr::new(path));
+            append_bind_dir_args(&mut args, Path::new(path), Path::new(path));
         }
     }
-    args.extend([
-        os("--bind"),
-        cwd.clone(),
-        cwd.clone(),
-        os("--chdir"),
-        cwd.clone(),
-    ]);
+    append_bind_dir_rw_args(&mut args, &host.cwd, &host.cwd);
+    args.extend([os("--chdir"), cwd.clone()]);
     if let Some(log_settings) = host.log_settings.as_ref()
         && let Some(host_log_dir) = log_settings.path.parent()
     {
-        args.extend([
-            os("--bind"),
-            host_log_dir.as_os_str().to_owned(),
-            host_log_dir.as_os_str().to_owned(),
-        ]);
+        append_bind_dir_rw_args(&mut args, host_log_dir, host_log_dir);
     }
     for rule in &path_plan.development_rules {
         append_path_rule_args(&mut args, rule);
@@ -926,18 +871,10 @@ fn build_plan(
         append_path_rule_args(&mut args, rule);
     }
     for mount in &graphical_plan.mounts {
-        append_bind_file_args(
-            &mut args,
-            mount.source.as_os_str(),
-            mount.destination.as_os_str(),
-        );
+        append_bind_file_args(&mut args, &mount.source, &mount.destination);
     }
     for mount in &host_integration_plan.mounts {
-        append_bind_file_args(
-            &mut args,
-            mount.source.as_os_str(),
-            mount.destination.as_os_str(),
-        );
+        append_bind_file_args(&mut args, &mount.source, &mount.destination);
     }
     args.extend([
         os("--clearenv"),
@@ -1001,57 +938,70 @@ pub(crate) fn find_bwrap_in_path(
         .find(|candidate| file_exists(candidate))
 }
 
-fn append_bind_file_args(args: &mut Vec<OsString>, source: &OsStr, destination: &OsStr) {
+fn append_bind_file_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
     append_mount_parent_args(args, destination);
-    args.extend([os("--ro-bind"), source.to_owned(), destination.to_owned()]);
+    args.extend([
+        os("--ro-bind"),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
+        destination.as_os_str().to_owned(),
+    ]);
 }
 
-fn append_bind_dir_args(args: &mut Vec<OsString>, source: &OsStr, destination: &OsStr) {
+fn append_bind_dir_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
     append_mount_parent_args(args, destination);
-    args.extend([os("--ro-bind"), source.to_owned(), destination.to_owned()]);
+    args.extend([
+        os("--ro-bind"),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
+        destination.as_os_str().to_owned(),
+    ]);
 }
 
 fn append_bind_dir_try_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
-    append_mount_parent_args(args, destination.as_os_str());
+    append_mount_parent_args(args, destination);
     args.extend([
         os("--ro-bind-try"),
-        source.as_os_str().to_owned(),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
         destination.as_os_str().to_owned(),
     ]);
 }
 
 fn append_bind_dir_rw_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
-    append_mount_parent_args(args, destination.as_os_str());
+    append_mount_parent_args(args, destination);
     args.extend([
         os("--bind"),
-        source.as_os_str().to_owned(),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
         destination.as_os_str().to_owned(),
     ]);
 }
 
 fn append_path_rule_args(args: &mut Vec<OsString>, rule: &PathAccessRule) {
-    let path = rule.path().as_os_str();
+    let path = rule.path();
     match rule.access() {
         PathAccess::ReadOnly => {
             append_mount_parent_args(args, path);
-            args.extend([os("--ro-bind-try"), path.to_owned(), path.to_owned()]);
+            args.extend([
+                os("--ro-bind-try"),
+                resolve_bwrap_path(path).as_os_str().to_owned(),
+                path.as_os_str().to_owned(),
+            ]);
         }
         PathAccess::ReadWrite => {
             append_mount_parent_args(args, path);
-            args.extend([os("--bind-try"), path.to_owned(), path.to_owned()]);
+            args.extend([
+                os("--bind-try"),
+                resolve_bwrap_path(path).as_os_str().to_owned(),
+                path.as_os_str().to_owned(),
+            ]);
         }
         PathAccess::Deny => {
             append_mount_parent_args(args, path);
-            args.extend([os("--tmpfs"), path.to_owned()]);
+            args.extend([os("--tmpfs"), path.as_os_str().to_owned()]);
         }
     }
 }
 
-fn append_mount_parent_args(args: &mut Vec<OsString>, destination: &OsStr) {
-    let Some(destination) = destination.to_str() else {
-        return;
-    };
-    let Some(parent) = Path::new(destination).parent() else {
+fn append_mount_parent_args(args: &mut Vec<OsString>, destination: &Path) {
+    let Some(parent) = destination.parent() else {
         return;
     };
     let mut parents = parent
@@ -1217,7 +1167,7 @@ struct MountInfoMount<'a> {
 
 #[cfg(target_os = "linux")]
 fn filesystem_path_metadata(path: &Path) -> Option<HostPathMetadata> {
-    let metadata = fs::symlink_metadata(path).ok()?;
+    let metadata = fs::metadata(path).ok()?;
     let file_type = metadata.file_type();
     let kind = if file_type.is_socket() {
         HostPathKind::UnixSocket
@@ -1273,14 +1223,6 @@ pub(crate) enum Error {
         product_path: PathBuf,
         rule_path: PathBuf,
         access: PathAccess,
-    },
-    ProductPathContainsSymlink {
-        product_path: PathBuf,
-        symlink_path: PathBuf,
-    },
-    ProductPathMetadata {
-        path: PathBuf,
-        source: io::Error,
     },
     ConflictingTrustedPathRules {
         path: PathBuf,
@@ -1349,20 +1291,6 @@ impl fmt::Display for Error {
                 product_path.display(),
                 access.as_str(),
                 rule_path.display()
-            ),
-            Error::ProductPathContainsSymlink {
-                product_path,
-                symlink_path,
-            } => write!(
-                formatter,
-                "sandbox product path {} contains symlink component {}; refusing writable mount",
-                product_path.display(),
-                symlink_path.display()
-            ),
-            Error::ProductPathMetadata { path, source } => write!(
-                formatter,
-                "failed to inspect sandbox product path component {}: {source}",
-                path.display()
             ),
             Error::ConflictingTrustedPathRules {
                 path,

--- a/crates/merry-cli/src/sandbox/tests.rs
+++ b/crates/merry-cli/src/sandbox/tests.rs
@@ -281,80 +281,22 @@ fn plan_mounts_runtime_paths_and_workspace() {
         &["--perms", "0700", "--dir", SANDBOX_HOME]
     ));
     assert!(contains_sequence(&args, &["--dir", "/etc"]));
-    assert!(contains_sequence(&args, &["--ro-bind", "/usr", "/usr"]));
-    assert!(contains_sequence(&args, &["--ro-bind-try", "/bin", "/bin"]));
-    assert!(contains_sequence(&args, &["--ro-bind-try", "/lib", "/lib"]));
-    assert!(contains_sequence(
-        &args,
-        &["--ro-bind-try", "/lib64", "/lib64"]
-    ));
-    assert!(contains_sequence(&args, &["--ro-bind-try", "/opt", "/opt"]));
-    assert!(contains_sequence(
-        &args,
-        &[
-            "--dir",
-            "/etc",
-            "--ro-bind",
-            "/etc/ld.so.conf",
-            "/etc/ld.so.conf"
-        ]
-    ));
-    assert!(contains_sequence(
-        &args,
-        &[
-            "--dir",
-            "/etc",
-            "--ro-bind",
-            "/etc/resolv.conf",
-            "/etc/resolv.conf"
-        ]
-    ));
-    assert!(contains_sequence(
-        &args,
-        &["--dir", "/etc", "--ro-bind", "/etc/hosts", "/etc/hosts"]
-    ));
-    assert!(contains_sequence(
-        &args,
-        &[
-            "--dir",
-            "/etc",
-            "--ro-bind",
-            "/etc/nsswitch.conf",
-            "/etc/nsswitch.conf"
-        ]
-    ));
-    assert!(contains_sequence(
-        &args,
-        &[
-            "--dir",
-            "/etc",
-            "--ro-bind",
-            "/etc/ld.so.conf.d",
-            "/etc/ld.so.conf.d"
-        ]
-    ));
-    assert!(contains_sequence(
-        &args,
-        &["--dir", "/etc", "--ro-bind", "/etc/ssl", "/etc/ssl"]
-    ));
-    assert!(contains_sequence(
-        &args,
-        &[
-            "--dir",
-            "/etc",
-            "--ro-bind",
-            "/etc/ld.so.cache",
-            "/etc/ld.so.cache"
-        ]
-    ));
-    assert!(!contains_sequence(
-        &args,
-        &["--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache"]
-    ));
-    assert!(!contains_sequence(
-        &args,
-        &["--ro-bind-try", "/etc/resolv.conf", "/etc/resolv.conf"]
-    ));
+    assert_ro_mount(&args, "--ro-bind", "/usr", "/usr");
+    for path in ["/bin", "/lib", "/lib64", "/opt"] {
+        if Path::new(path).exists() {
+            assert_ro_mount(&args, "--ro-bind-try", path, path);
+        }
+    }
+    for path in SANDBOX_ETC_READ_ONLY_FILE_PATHS {
+        if Path::new(path).exists() {
+            assert_ro_mount(&args, "--ro-bind", path, path);
+        }
+    }
+    for path in SANDBOX_ETC_READ_ONLY_DIR_PATHS {
+        if Path::new(path).exists() {
+            assert_ro_mount(&args, "--ro-bind", path, path);
+        }
+    }
     assert!(!contains_sequence(
         &args,
         &["--ro-bind-try", "/etc", "/etc"]
@@ -646,7 +588,7 @@ fn sandbox_rejects_conflicting_rules_for_the_same_path() {
 
 #[cfg(unix)]
 #[test]
-fn sandbox_rejects_symlinked_product_write_roots() {
+fn sandbox_supports_symlinked_product_write_roots() {
     use std::os::unix::fs::symlink;
 
     let temp = tempfile::tempdir().expect("temporary sandbox paths");
@@ -658,12 +600,114 @@ fn sandbox_rejects_symlinked_product_write_roots() {
     let mut host = sandbox_host();
     host.xdg_paths = XdgPaths::from_parts(
         PathBuf::from("/home/alice"),
-        Some(linked_config),
+        Some(linked_config.clone()),
         Some(temp.path().join("state")),
     );
 
-    let error = plan_sandbox(true, &host).expect_err("symlinked write root must fail closed");
-    assert!(matches!(error, Error::ProductPathContainsSymlink { .. }));
+    let Bootstrap::Reexec(plan) =
+        plan_sandbox(true, &host).expect("symlinked write root should be mountable")
+    else {
+        panic!("expected sandbox reexec plan");
+    };
+    let args = plan_args(&plan);
+    let config_dir = linked_config.join("merry");
+    let managed_config_dir = config_dir.join("managed");
+    let resolved_config_dir = real_config.join("merry");
+    let resolved_managed_config_dir = resolved_config_dir.join("managed");
+
+    assert!(contains_sequence(
+        &args,
+        &[
+            "--ro-bind-try",
+            resolved_config_dir.to_str().expect("UTF-8 test path"),
+            config_dir.to_str().expect("UTF-8 test path"),
+        ],
+    ));
+    assert!(contains_sequence(
+        &args,
+        &[
+            "--bind",
+            resolved_managed_config_dir
+                .to_str()
+                .expect("UTF-8 test path"),
+            managed_config_dir.to_str().expect("UTF-8 test path"),
+        ],
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn sandbox_mounts_symlinked_file_sources_at_their_logical_paths() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("temporary sandbox paths");
+    let real_file = temp.path().join("real.conf");
+    let linked_file = temp.path().join("resolv.conf");
+    std::fs::write(&real_file, "nameserver 192.0.2.1\n").expect("real file");
+    symlink(&real_file, &linked_file).expect("file symlink");
+
+    let mut args = Vec::new();
+    append_bind_file_args(&mut args, &linked_file, Path::new("/etc/resolv.conf"));
+    let args = plan_args(&Plan {
+        program: OsString::from("bwrap"),
+        args,
+        env: Vec::new(),
+    });
+
+    assert!(contains_sequence(
+        &args,
+        &[
+            "--ro-bind",
+            real_file.to_str().expect("UTF-8 test path"),
+            "/etc/resolv.conf",
+        ],
+    ));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bubblewrap_reads_a_symlinked_file_through_its_logical_mount_path() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("temporary sandbox paths");
+    let real_file = temp.path().join("real.conf");
+    let linked_file = temp.path().join("resolv.conf");
+    std::fs::write(&real_file, "nameserver 192.0.2.1\n").expect("real file");
+    symlink(&real_file, &linked_file).expect("file symlink");
+
+    let destination = Path::new("/etc/resolv.conf");
+    let mut args = vec![
+        os("--unshare-user"),
+        os("--die-with-parent"),
+        os("--ro-bind"),
+        os("/"),
+        os("/"),
+    ];
+    args.extend([
+        os("--ro-bind"),
+        merry_process::resolve_bwrap_path(&linked_file)
+            .as_os_str()
+            .to_owned(),
+        destination.as_os_str().to_owned(),
+    ]);
+    args.extend([
+        os("--"),
+        os("/usr/bin/cat"),
+        destination.as_os_str().to_owned(),
+    ]);
+
+    let output = match Command::new("bwrap").args(args).output() {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => panic!("bubblewrap test could not start: {error}"),
+    };
+
+    assert!(
+        output.status.success(),
+        "bubblewrap symlink mount probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, b"nameserver 192.0.2.1\n");
 }
 
 #[test]
@@ -1371,6 +1415,22 @@ fn args_without_sandbox_bootstrap_flags_preserves_shell_trailing_argv() {
             os(SANDBOX_CHILD_HANDOFF_ARG),
             os(SANDBOX_CHILD_HANDOFF_CLI_BWRAP),
         ]
+    );
+}
+
+fn assert_ro_mount(args: &[String], flag: &str, source: &str, destination: &str) {
+    let resolved_source = merry_process::resolve_bwrap_path(Path::new(source));
+    assert!(
+        contains_sequence(
+            args,
+            &[
+                flag,
+                resolved_source.to_str().expect("UTF-8 test path"),
+                destination,
+            ],
+        ),
+        "missing mount {flag} {} {destination}",
+        resolved_source.display()
     );
 }
 

--- a/crates/merry-process/src/bwrap_path.rs
+++ b/crates/merry-process/src/bwrap_path.rs
@@ -1,0 +1,77 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Resolves the host-side source path used by a bubblewrap mount.
+///
+/// Bubblewrap destinations remain logical paths inside the sandbox, while
+/// this helper follows symlink components in the host source path. The last
+/// existing prefix is resolved so a path below a symlinked directory can be
+/// mounted before its leaf has been created. If no prefix can be resolved, the
+/// original path is retained so optional bubblewrap mounts keep their existing
+/// missing-source behavior.
+#[must_use]
+pub fn resolve_bwrap_path(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    let mut unresolved = Vec::new();
+
+    loop {
+        if let Ok(resolved) = fs::canonicalize(&current) {
+            let mut result = resolved;
+            for component in unresolved.iter().rev() {
+                result.push(component);
+            }
+            return result;
+        }
+
+        let Some(component) = current.file_name() else {
+            return path.to_path_buf();
+        };
+        unresolved.push(component.to_owned());
+        if !current.pop() {
+            return path.to_path_buf();
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::resolve_bwrap_path;
+    use std::{fs, os::unix::fs::symlink, path::Path};
+
+    #[test]
+    fn resolves_existing_symlink_components() {
+        let temp = tempfile::tempdir().expect("temporary path");
+        let real = temp.path().join("real");
+        let link = temp.path().join("link");
+        fs::create_dir_all(&real).expect("real directory");
+        symlink(&real, &link).expect("directory symlink");
+
+        assert_eq!(resolve_bwrap_path(&link), fs::canonicalize(real).unwrap());
+    }
+
+    #[test]
+    fn resolves_existing_prefix_for_missing_leaf() {
+        let temp = tempfile::tempdir().expect("temporary path");
+        let real = temp.path().join("real");
+        let link = temp.path().join("link");
+        fs::create_dir_all(&real).expect("real directory");
+        symlink(&real, &link).expect("directory symlink");
+        let missing = link.join("future").join("file");
+
+        assert_eq!(
+            resolve_bwrap_path(&missing),
+            real.join("future").join("file")
+        );
+    }
+
+    #[test]
+    fn leaves_dangling_leaf_symlink_unresolved() {
+        let temp = tempfile::tempdir().expect("temporary path");
+        let link = temp.path().join("link");
+        symlink(Path::new("missing"), &link).expect("dangling symlink");
+
+        assert_eq!(resolve_bwrap_path(&link), link);
+    }
+}

--- a/crates/merry-process/src/lib.rs
+++ b/crates/merry-process/src/lib.rs
@@ -6,7 +6,10 @@
 //! platform can replace the concrete backend without changing coding
 //! composition or runtime call sites.
 
+mod bwrap_path;
 mod process_runner;
+
+pub use bwrap_path::resolve_bwrap_path;
 
 pub use process_runner::TokioProcessRunner;
 

--- a/crates/merry-process/src/process_runner.rs
+++ b/crates/merry-process/src/process_runner.rs
@@ -4,6 +4,7 @@
 //! [`merry_runtime::ProcessRunner`] boundary. It does not decide whether a process is
 //! admitted; callers must still opt in through runtime permission profiles.
 
+use crate::resolve_bwrap_path;
 use merry_runtime::{
     HostIntegration, PathAccess, PathAccessRule, PathAccessRuleSource, PermissionRequest,
     PermissionedProcessRunnerFactory, ProcessActionIntent, ProcessExitStatus, ProcessRunner,
@@ -780,8 +781,10 @@ fn effective_requested_path_access(
 ) -> Result<PathAccess, ProcessRunnerError> {
     if let Some(rule) = configured_rules
         .iter()
-        .filter(|rule| requested_path.starts_with(rule.path()) && rule.access() == PathAccess::Deny)
-        .max_by_key(|rule| path_depth(rule.path()))
+        .filter(|rule| {
+            path_matches_rule(requested_path, rule.path()) && rule.access() == PathAccess::Deny
+        })
+        .max_by_key(|rule| resolved_path_depth(rule.path()))
     {
         return Err(ProcessRunnerError::infrastructure(format!(
             "requested path `{}` is denied by configured path policy `{}`",
@@ -791,7 +794,7 @@ fn effective_requested_path_access(
     }
 
     if configured_rules.iter().any(|rule| {
-        requested_path.starts_with(rule.path())
+        path_matches_rule(requested_path, rule.path())
             && rule.access() == PathAccess::ReadOnly
             && rule.source() == PathAccessRuleSource::TrustedGlobalConfig
     }) {
@@ -812,15 +815,14 @@ fn path_rule_covers(
     if requested_access == PathAccess::Deny || is_git_metadata_path(requested_path) {
         return false;
     }
-    if rules
-        .iter()
-        .any(|rule| requested_path.starts_with(rule.path()) && rule.access() == PathAccess::Deny)
-    {
+    if rules.iter().any(|rule| {
+        path_matches_rule(requested_path, rule.path()) && rule.access() == PathAccess::Deny
+    }) {
         return false;
     }
     if requested_access == PathAccess::ReadWrite
         && rules.iter().any(|rule| {
-            requested_path.starts_with(rule.path())
+            path_matches_rule(requested_path, rule.path())
                 && rule.access() == PathAccess::ReadOnly
                 && matches!(
                     rule.source(),
@@ -835,11 +837,11 @@ fn path_rule_covers(
     rules
         .iter()
         .filter(|rule| {
-            requested_path.starts_with(rule.path())
+            path_matches_rule(requested_path, rule.path())
                 && rule.access() != PathAccess::Deny
                 && rule.source() != PathAccessRuleSource::GitMetadataBaseline
         })
-        .max_by_key(|rule| path_depth(rule.path()))
+        .max_by_key(|rule| resolved_path_depth(rule.path()))
         .is_some_and(|rule| rule.access().covers(requested_access))
 }
 
@@ -896,8 +898,8 @@ fn normalize_session_path_rules(rules: Vec<PathAccessRule>) -> Vec<PathAccessRul
     let mut retained = Vec::with_capacity(rules.len());
     for rule in rules {
         let covered_by_ancestor = retained.iter().any(|ancestor: &PathAccessRule| {
-            rule.path() != ancestor.path()
-                && rule.path().starts_with(ancestor.path())
+            resolve_bwrap_path(rule.path()) != resolve_bwrap_path(ancestor.path())
+                && path_matches_rule(rule.path(), ancestor.path())
                 && match ancestor.access() {
                     PathAccess::Deny => true,
                     PathAccess::ReadOnly => rule.access() == PathAccess::ReadOnly,
@@ -985,8 +987,19 @@ fn merged_path_rule(
 }
 
 fn is_git_metadata_path(path: &Path) -> bool {
-    path.components()
+    resolve_bwrap_path(path)
+        .components()
         .any(|component| matches!(component, Component::Normal(name) if name == OsStr::new(".git")))
+}
+
+fn path_matches_rule(path: &Path, rule_path: &Path) -> bool {
+    let path = resolve_bwrap_path(path);
+    let rule_path = resolve_bwrap_path(rule_path);
+    path == rule_path || path.starts_with(&rule_path)
+}
+
+fn resolved_path_depth(path: &Path) -> usize {
+    path_depth(&resolve_bwrap_path(path))
 }
 
 fn git_metadata_baseline_rule(path: impl Into<PathBuf>) -> PathAccessRule {
@@ -1131,7 +1144,9 @@ fn bwrap_process_plan_with_environment(
         os("--tmpfs"),
         os(ACTION_SANDBOX_TMPDIR),
         os("--bind"),
-        environment.tmp_source.as_os_str().to_owned(),
+        resolve_bwrap_path(&environment.tmp_source)
+            .as_os_str()
+            .to_owned(),
         os(ACTION_SANDBOX_TMPDIR),
     ];
     if !environment.home.exists() {
@@ -1145,23 +1160,10 @@ fn bwrap_process_plan_with_environment(
             environment.home.as_os_str().to_owned(),
         ]);
     }
-    args.extend([
-        os("--ro-bind"),
-        os("/usr"),
-        os("/usr"),
-        os("--ro-bind-try"),
-        os("/bin"),
-        os("/bin"),
-        os("--ro-bind-try"),
-        os("/lib"),
-        os("/lib"),
-        os("--ro-bind-try"),
-        os("/lib64"),
-        os("/lib64"),
-        os("--ro-bind-try"),
-        os("/opt"),
-        os("/opt"),
-    ]);
+    append_bwrap_dir_bind_args(&mut args, Path::new("/usr"), Path::new("/usr"));
+    for path in ["/bin", "/lib", "/lib64", "/opt"] {
+        append_bwrap_dir_bind_try_args(&mut args, Path::new(path), Path::new(path));
+    }
     for path in ACTION_SANDBOX_ETC_READ_ONLY_FILE_PATHS {
         if Path::new(path).exists() {
             append_bwrap_file_bind_args(&mut args, Path::new(path), Path::new(path));
@@ -1247,7 +1249,7 @@ fn append_bwrap_file_bind_args(args: &mut Vec<OsString>, source: &Path, destinat
     append_bwrap_mount_parent_args(args, destination);
     args.extend([
         os("--ro-bind"),
-        source.as_os_str().to_owned(),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
         destination.as_os_str().to_owned(),
     ]);
 }
@@ -1289,7 +1291,16 @@ fn append_bwrap_dir_bind_args(args: &mut Vec<OsString>, source: &Path, destinati
     append_bwrap_mount_parent_args(args, destination);
     args.extend([
         os("--ro-bind"),
-        source.as_os_str().to_owned(),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
+        destination.as_os_str().to_owned(),
+    ]);
+}
+
+fn append_bwrap_dir_bind_try_args(args: &mut Vec<OsString>, source: &Path, destination: &Path) {
+    append_bwrap_mount_parent_args(args, destination);
+    args.extend([
+        os("--ro-bind-try"),
+        resolve_bwrap_path(source).as_os_str().to_owned(),
         destination.as_os_str().to_owned(),
     ]);
 }
@@ -1299,12 +1310,12 @@ fn append_bwrap_path_rule(args: &mut Vec<OsString>, path: &Path, access: PathAcc
     match access {
         PathAccess::ReadOnly => args.extend([
             os("--ro-bind-try"),
-            path.as_os_str().to_owned(),
+            resolve_bwrap_path(path).as_os_str().to_owned(),
             path.as_os_str().to_owned(),
         ]),
         PathAccess::ReadWrite => args.extend([
             os("--bind-try"),
-            path.as_os_str().to_owned(),
+            resolve_bwrap_path(path).as_os_str().to_owned(),
             path.as_os_str().to_owned(),
         ]),
         PathAccess::Deny => {
@@ -1318,12 +1329,12 @@ fn append_bwrap_required_path_rule(args: &mut Vec<OsString>, path: &Path, access
     match access {
         PathAccess::ReadOnly => args.extend([
             os("--ro-bind"),
-            path.as_os_str().to_owned(),
+            resolve_bwrap_path(path).as_os_str().to_owned(),
             path.as_os_str().to_owned(),
         ]),
         PathAccess::ReadWrite => args.extend([
             os("--bind"),
-            path.as_os_str().to_owned(),
+            resolve_bwrap_path(path).as_os_str().to_owned(),
             path.as_os_str().to_owned(),
         ]),
         PathAccess::Deny => args.extend([os("--tmpfs"), path.as_os_str().to_owned()]),
@@ -1340,7 +1351,7 @@ fn append_bwrap_git_metadata_baseline_rule(args: &mut Vec<OsString>, path: &Path
     append_bwrap_mount_parent_args(args, path);
     args.extend([
         os("--ro-bind"),
-        path.as_os_str().to_owned(),
+        resolve_bwrap_path(path).as_os_str().to_owned(),
         path.as_os_str().to_owned(),
     ]);
 }
@@ -1514,7 +1525,7 @@ mod tests {
     use super::{
         BwrapPermissionedProcessRunnerFactory, BwrapProcessEnvironment, BwrapProcessRunner,
         BwrapSessionPermissions, TokioProcessRunner, bwrap_process_plan,
-        bwrap_process_plan_with_environment, process_current_dir,
+        bwrap_process_plan_with_environment, process_current_dir, resolve_bwrap_path,
     };
     use crate::UnrestrictedPermissionedProcessRunnerFactory;
     use merry_core::{PendingToolCall, ToolCallArguments, ToolCallId, ToolName};
@@ -1601,9 +1612,14 @@ mod tests {
             &["--bind", "/workspace/merry", "/workspace/merry"]
         ));
         if Path::new("/etc/ld.so.cache").exists() {
+            let source = resolve_bwrap_path(Path::new("/etc/ld.so.cache"));
             assert!(contains_sequence(
                 &args,
-                &["--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache"]
+                &[
+                    "--ro-bind",
+                    source.to_str().expect("UTF-8 system path"),
+                    "/etc/ld.so.cache",
+                ]
             ));
         }
         assert!(contains_sequence(
@@ -1923,6 +1939,45 @@ mod tests {
         assert!(contains_sequence(&args, &["--tmpfs", "/home/merry/.ssh"]));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn bwrap_process_plan_mounts_symlinked_path_rules_at_logical_paths() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("temporary path");
+        let real = temp.path().join("real");
+        let link = temp.path().join("link");
+        std::fs::create_dir_all(&real).expect("real directory");
+        symlink(&real, &link).expect("directory symlink");
+        let rule = PathAccessRule::new(
+            link.clone(),
+            PathAccess::ReadWrite,
+            PathAccessRuleSource::PermissionReview,
+        );
+
+        let environment =
+            BwrapProcessEnvironment::new("/custom/bin:/usr/bin", "/home/alice", "/tmp")
+                .expect("environment layout should validate");
+        let plan = bwrap_process_plan_with_environment(
+            &intent(None),
+            Path::new("/workspace/merry"),
+            &environment,
+            true,
+            &[rule],
+            Path::new("/custom/bin/bwrap"),
+        );
+        let args = os_args(&plan.args);
+
+        assert!(contains_sequence(
+            &args,
+            &[
+                "--bind",
+                real.to_str().expect("UTF-8 test path"),
+                link.to_str().expect("UTF-8 test path"),
+            ],
+        ));
+    }
+
     #[test]
     fn bwrap_permissioned_factory_allows_network_only_when_requested() {
         let factory =
@@ -1958,6 +2013,54 @@ mod tests {
 
         assert!(os_args(&plan_without_network.args).contains(&"--unshare-net".to_owned()));
         assert!(!os_args(&plan_with_network.args).contains(&"--unshare-net".to_owned()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bwrap_permissioned_factory_matches_rules_through_symlink_aliases() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("temporary path");
+        let real = temp.path().join("real");
+        let link = temp.path().join("link");
+        std::fs::create_dir_all(&real).expect("real directory");
+        symlink(&real, &link).expect("directory symlink");
+
+        let factory =
+            BwrapPermissionedProcessRunnerFactory::new_at_workspace_root("/workspace/merry")
+                .with_path_rules([PathAccessRule::new(
+                    real.clone(),
+                    PathAccess::ReadWrite,
+                    PathAccessRuleSource::TrustedGlobalConfig,
+                )]);
+        let request = permission_request(json!({
+            "requested": {
+                "paths": [{
+                    "path": link.to_str().expect("UTF-8 test path"),
+                    "access": "rw"
+                }]
+            },
+            "for_action": { "command": "touch", "cwd": "." }
+        }));
+
+        assert!(
+            factory
+                .request_capabilities_are_satisfied(&request)
+                .expect("path capability should be evaluated")
+        );
+
+        let denied_factory =
+            BwrapPermissionedProcessRunnerFactory::new_at_workspace_root("/workspace/merry")
+                .with_path_rules([PathAccessRule::new(
+                    real,
+                    PathAccess::Deny,
+                    PathAccessRuleSource::TrustedGlobalConfig,
+                )]);
+        assert!(
+            !denied_factory
+                .request_capabilities_are_satisfied(&request)
+                .expect("denied path capability should be evaluated")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Resolve host-side symlink components before emitting bubblewrap bind sources.
- Preserve each logical destination while applying the behavior to both outer CLI and per-action sandboxes.
- Allow symlinked product paths and resolve path-policy checks through symlink aliases.
- Add planner, resolver, and live bubblewrap regression coverage.

## Verification

- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p merry-process
- cargo test -p merry-cli sandbox

Full cargo test --all remains blocked by three unchanged Anthropic model fixture tests whose fixture listener fails with PermissionDenied.