### PR TITLE
feat(llm): add service_tier for OpenAI requests

### DIFF
--- a/crates/merry-cli/src/config/managed_provider.rs
+++ b/crates/merry-cli/src/config/managed_provider.rs
@@ -199,6 +199,7 @@ impl ManagedProviderDefinition {
             reasoning_effort: self
                 .reasoning_effort
                 .map(|effort| effort.as_str().to_owned()),
+            service_tier: None,
             kind: Some(
                 match self.kind {
                     ManagedProviderKind::OpenAiCompatible => "openai-compatible",

--- a/crates/merry-cli/src/config/provider.rs
+++ b/crates/merry-cli/src/config/provider.rs
@@ -2,7 +2,7 @@ use super::{
     ConfigError, MerryConfig, default_true, managed_provider::ProviderAlias,
     resolve_config_relative_path,
 };
-use merry_llm::{ModelName, ModelRetryPolicy, ModelRetryPolicyError, ReasoningEffort};
+use merry_llm::{ModelName, ModelRetryPolicy, ModelRetryPolicyError, ReasoningEffort, ServiceTier};
 use merry_provider_openai::OpenAiProtocol;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt, fs, path::PathBuf};
@@ -64,6 +64,8 @@ impl MerryConfig {
         };
         let reasoning_effort =
             parse_provider_reasoning_effort(alias.as_str(), provider.reasoning_effort.as_deref())?;
+        let service_tier =
+            parse_provider_service_tier(alias.as_str(), provider.service_tier.as_deref())?;
         let protocol = match kind {
             ConfiguredProviderKind::OpenAiCompatible => Some(provider.protocol.unwrap_or_default()),
             ConfiguredProviderKind::Anthropic => None,
@@ -76,6 +78,7 @@ impl MerryConfig {
             kind,
             protocol,
             reasoning_effort,
+            service_tier,
             source,
         })
     }
@@ -109,6 +112,38 @@ impl MerryConfig {
         match default_reasoning_effort {
             Some(reasoning_effort) => Ok(Some(reasoning_effort)),
             None => self.provider_reasoning_effort(alias),
+        }
+    }
+
+    pub(crate) fn provider_service_tier(
+        &self,
+        alias: &str,
+    ) -> Result<Option<ServiceTier>, ConfigError> {
+        Ok(self.provider_profile(alias)?.service_tier())
+    }
+
+    pub(crate) fn effective_provider_service_tier(
+        &self,
+        alias: &str,
+    ) -> Result<Option<ServiceTier>, ConfigError> {
+        let default_service_tier = self
+            .raw
+            .providers
+            .as_ref()
+            .and_then(|providers| providers.default.as_ref())
+            .filter(|default| default.provider == alias)
+            .and_then(|default| default.service_tier.as_deref())
+            .map(ServiceTier::new)
+            .transpose()
+            .map_err(|error| {
+                ConfigError::Invalid(format!(
+                    "providers.default.service_tier is invalid: {error}"
+                ))
+            })?;
+
+        match default_service_tier {
+            Some(service_tier) => Ok(Some(service_tier)),
+            None => self.provider_service_tier(alias),
         }
     }
 
@@ -159,10 +194,12 @@ impl MerryConfig {
             .ok_or_else(|| ConfigError::Invalid("[providers.default] is required".to_owned()))?;
         let provider = self.provider_by_alias(&default.provider)?;
         let reasoning_effort = self.effective_provider_reasoning_effort(&default.provider)?;
+        let service_tier = self.effective_provider_service_tier(&default.provider)?;
         Ok(EffectiveDefaultProviderConfig {
             alias: default.provider.clone(),
             model: default.model.clone(),
             reasoning_effort,
+            service_tier,
             provider,
         })
     }
@@ -196,27 +233,36 @@ impl MerryConfig {
         let api_key = resolve_api_key_source(alias, provider, &self.config_dir, &self.home)?;
         let reasoning_effort =
             parse_provider_reasoning_effort(alias, provider.reasoning_effort.as_deref())?;
+        let service_tier = parse_provider_service_tier(alias, provider.service_tier.as_deref())?;
         match kind {
             "openai-compatible" => Ok(EffectiveProviderConfig::OpenAiCompatible(
                 EffectiveOpenAiProviderConfig {
                     model: None,
                     reasoning_effort,
+                    service_tier,
                     alias: alias.to_owned(),
                     protocol: provider.protocol.unwrap_or_default(),
                     base_url: provider.base_url.clone(),
                     api_key,
                 },
             )),
-            "anthropic" => Ok(EffectiveProviderConfig::Anthropic(
-                EffectiveAnthropicProviderConfig {
-                    alias: alias.to_owned(),
-                    reasoning_effort,
-                    base_url: provider.base_url.clone(),
-                    api_version: provider.api_version.clone(),
-                    default_max_output_tokens: provider.default_max_output_tokens,
-                    api_key,
-                },
-            )),
+            "anthropic" => {
+                if service_tier.is_some() {
+                    return Err(ConfigError::Invalid(format!(
+                        "providers.{alias}.service_tier is only supported for openai-compatible providers"
+                    )));
+                }
+                Ok(EffectiveProviderConfig::Anthropic(
+                    EffectiveAnthropicProviderConfig {
+                        alias: alias.to_owned(),
+                        reasoning_effort,
+                        base_url: provider.base_url.clone(),
+                        api_version: provider.api_version.clone(),
+                        default_max_output_tokens: provider.default_max_output_tokens,
+                        api_key,
+                    },
+                ))
+            }
             other => Err(ConfigError::Invalid(format!(
                 "unsupported provider type {other:?} for [providers.{alias}]"
             ))),
@@ -237,6 +283,7 @@ impl MerryConfig {
         };
         provider.model = Some(default.model);
         provider.reasoning_effort = default.reasoning_effort;
+        provider.service_tier = default.service_tier;
         Ok(provider)
     }
 
@@ -297,11 +344,23 @@ fn parse_provider_reasoning_effort(
         })
 }
 
+fn parse_provider_service_tier(
+    alias: &str,
+    value: Option<&str>,
+) -> Result<Option<ServiceTier>, ConfigError> {
+    value.map(ServiceTier::new).transpose().map_err(|error| {
+        ConfigError::Invalid(format!(
+            "providers.{alias}.service_tier is invalid: {error}"
+        ))
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EffectiveDefaultProviderConfig {
     pub alias: String,
     pub model: String,
     pub reasoning_effort: Option<ReasoningEffort>,
+    pub service_tier: Option<ServiceTier>,
     pub provider: EffectiveProviderConfig,
 }
 
@@ -325,6 +384,7 @@ pub(crate) struct ConfiguredProviderProfile {
     kind: ConfiguredProviderKind,
     protocol: Option<OpenAiProtocol>,
     reasoning_effort: Option<ReasoningEffort>,
+    service_tier: Option<ServiceTier>,
     source: ProviderConfigSource,
 }
 
@@ -353,6 +413,10 @@ impl ConfiguredProviderProfile {
         self.reasoning_effort.as_ref()
     }
 
+    pub(crate) fn service_tier(&self) -> Option<ServiceTier> {
+        self.service_tier
+    }
+
     pub(crate) fn source(&self) -> ProviderConfigSource {
         self.source
     }
@@ -368,6 +432,7 @@ pub enum EffectiveProviderConfig {
 pub struct EffectiveOpenAiProviderConfig {
     pub model: Option<String>,
     pub reasoning_effort: Option<ReasoningEffort>,
+    pub service_tier: Option<ServiceTier>,
     pub alias: String,
     pub protocol: OpenAiProtocol,
     pub base_url: Option<String>,
@@ -380,6 +445,7 @@ impl fmt::Debug for EffectiveOpenAiProviderConfig {
             .debug_struct("EffectiveOpenAiProviderConfig")
             .field("model", &self.model)
             .field("reasoning_effort", &self.reasoning_effort)
+            .field("service_tier", &self.service_tier)
             .field("alias", &self.alias)
             .field("protocol", &self.protocol)
             .field("base_url", &self.base_url)
@@ -475,6 +541,7 @@ pub(super) struct DefaultProviderToml {
     pub(super) provider: String,
     model: String,
     reasoning_effort: Option<String>,
+    service_tier: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -483,6 +550,8 @@ pub(super) struct NamedProviderToml {
     pub(super) display_name: Option<String>,
     pub(super) default_model: Option<String>,
     pub(super) reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) service_tier: Option<String>,
     #[serde(rename = "type")]
     pub(super) kind: Option<String>,
     pub(super) protocol: Option<OpenAiProtocol>,
@@ -885,6 +954,7 @@ api_key = {api_key:?}
         let provider = EffectiveOpenAiProviderConfig {
             model: Some("gpt-test".to_owned()),
             reasoning_effort: Some(ReasoningEffort::new("high").expect("valid effort")),
+            service_tier: Some(ServiceTier::Priority),
             alias: "openai-compatible".to_owned(),
             protocol: OpenAiProtocol::Responses,
             base_url: Some("https://api.example.test/v1".to_owned()),

--- a/crates/merry-cli/src/config/provider.rs
+++ b/crates/merry-cli/src/config/provider.rs
@@ -70,6 +70,14 @@ impl MerryConfig {
             ConfiguredProviderKind::OpenAiCompatible => Some(provider.protocol.unwrap_or_default()),
             ConfiguredProviderKind::Anthropic => None,
         };
+        if let Some(service_tier) = service_tier {
+            validate_service_tier_support(
+                &format!("providers.{alias}.service_tier"),
+                service_tier,
+                kind,
+                protocol,
+            )?;
+        }
 
         Ok(ConfiguredProviderProfile {
             alias,
@@ -141,10 +149,17 @@ impl MerryConfig {
                 ))
             })?;
 
-        match default_service_tier {
-            Some(service_tier) => Ok(Some(service_tier)),
-            None => self.provider_service_tier(alias),
-        }
+        let Some(service_tier) = default_service_tier else {
+            return self.provider_service_tier(alias);
+        };
+        let profile = self.provider_profile(alias)?;
+        validate_service_tier_support(
+            "providers.default.service_tier",
+            service_tier,
+            profile.kind(),
+            profile.protocol(),
+        )?;
+        Ok(Some(service_tier))
     }
 
     pub fn validate_provider_settings_if_present(&self) -> Result<(), ConfigError> {
@@ -234,23 +249,37 @@ impl MerryConfig {
         let reasoning_effort =
             parse_provider_reasoning_effort(alias, provider.reasoning_effort.as_deref())?;
         let service_tier = parse_provider_service_tier(alias, provider.service_tier.as_deref())?;
+        let protocol = provider.protocol.unwrap_or_default();
         match kind {
-            "openai-compatible" => Ok(EffectiveProviderConfig::OpenAiCompatible(
-                EffectiveOpenAiProviderConfig {
-                    model: None,
-                    reasoning_effort,
-                    service_tier,
-                    alias: alias.to_owned(),
-                    protocol: provider.protocol.unwrap_or_default(),
-                    base_url: provider.base_url.clone(),
-                    api_key,
-                },
-            )),
+            "openai-compatible" => {
+                if let Some(service_tier) = service_tier {
+                    validate_service_tier_support(
+                        &format!("providers.{alias}.service_tier"),
+                        service_tier,
+                        ConfiguredProviderKind::OpenAiCompatible,
+                        Some(protocol),
+                    )?;
+                }
+                Ok(EffectiveProviderConfig::OpenAiCompatible(
+                    EffectiveOpenAiProviderConfig {
+                        model: None,
+                        reasoning_effort,
+                        service_tier,
+                        alias: alias.to_owned(),
+                        protocol,
+                        base_url: provider.base_url.clone(),
+                        api_key,
+                    },
+                ))
+            }
             "anthropic" => {
-                if service_tier.is_some() {
-                    return Err(ConfigError::Invalid(format!(
-                        "providers.{alias}.service_tier is only supported for openai-compatible providers"
-                    )));
+                if let Some(service_tier) = service_tier {
+                    validate_service_tier_support(
+                        &format!("providers.{alias}.service_tier"),
+                        service_tier,
+                        ConfiguredProviderKind::Anthropic,
+                        None,
+                    )?;
                 }
                 Ok(EffectiveProviderConfig::Anthropic(
                     EffectiveAnthropicProviderConfig {
@@ -353,6 +382,33 @@ fn parse_provider_service_tier(
             "providers.{alias}.service_tier is invalid: {error}"
         ))
     })
+}
+
+/// Rejects a configured service tier the selected provider cannot carry.
+///
+/// `location` names the setting in the user's config so the message points at
+/// the key that has to change, which differs between `[providers.default]` and
+/// `[providers.<alias>]`.
+fn validate_service_tier_support(
+    location: &str,
+    service_tier: ServiceTier,
+    kind: ConfiguredProviderKind,
+    protocol: Option<OpenAiProtocol>,
+) -> Result<(), ConfigError> {
+    if kind != ConfiguredProviderKind::OpenAiCompatible {
+        return Err(ConfigError::Invalid(format!(
+            "{location} is only supported for openai-compatible providers"
+        )));
+    }
+    if !protocol
+        .unwrap_or_default()
+        .supports_service_tier(service_tier)
+    {
+        return Err(ConfigError::Invalid(format!(
+            "{location} value \"{service_tier}\" requires protocol = \"responses\""
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -812,6 +868,95 @@ api_key = "sk-inline-secret"
         let debug = format!("{provider:?}");
         assert!(debug.contains("Inline(<redacted>)"));
         assert!(!debug.contains("sk-inline-secret"));
+    }
+
+    #[test]
+    fn default_level_service_tier_is_rejected_for_anthropic_providers() {
+        let paths = XdgPaths::from_parts(home(), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "claude"
+model = "claude-sonnet-test"
+service_tier = "priority"
+
+[providers.claude]
+type = "anthropic"
+api_key = "sk-ant-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should exist");
+
+        let error = config
+            .default_provider()
+            .expect_err("an Anthropic default provider must reject a service tier");
+
+        assert!(
+            error.to_string().contains(
+                "providers.default.service_tier is only supported for openai-compatible providers"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn ultrafast_service_tier_requires_the_responses_protocol() {
+        let paths = XdgPaths::from_parts(home(), None, None);
+        let config_text = |protocol: &str, tier_location: &str| {
+            let (default_tier, provider_tier) = match tier_location {
+                "default" => ("service_tier = \"ultrafast\"", ""),
+                _ => ("", "service_tier = \"ultrafast\""),
+            };
+            format!(
+                r#"
+[providers.default]
+provider = "compat"
+model = "gpt-test"
+{default_tier}
+
+[providers.compat]
+type = "openai-compatible"
+protocol = "{protocol}"
+{provider_tier}
+api_key = "sk-test"
+"#
+            )
+        };
+
+        for tier_location in ["default", "named"] {
+            let config = MerryConfig::load_optional_from_text(
+                Some(&config_text("chat_completions", tier_location)),
+                &paths,
+            )
+            .expect("config should parse")
+            .expect("config should exist");
+
+            let error = config
+                .default_provider()
+                .expect_err("ultrafast is a Responses-only tier");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("requires protocol = \"responses\""),
+                "unexpected error for the {tier_location} service_tier: {error}"
+            );
+
+            let default = MerryConfig::load_optional_from_text(
+                Some(&config_text("responses", tier_location)),
+                &paths,
+            )
+            .expect("config should parse")
+            .expect("config should exist")
+            .default_provider()
+            .expect("the Responses protocol accepts ultrafast");
+
+            assert_eq!(default.service_tier, Some(ServiceTier::Ultrafast));
+        }
     }
 
     #[test]

--- a/crates/merry-cli/src/runtime_config.rs
+++ b/crates/merry-cli/src/runtime_config.rs
@@ -425,6 +425,36 @@ api_key = "sk-test"
         );
     }
 
+    #[test]
+    fn default_level_service_tier_is_rejected_for_anthropic_providers() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "anthropic"
+model = "claude-test"
+service_tier = "priority"
+
+[providers.anthropic]
+api_key = "sk-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        let error = generation_config(Some(&config)).expect_err("service tier should be rejected");
+
+        assert!(
+            error.to_string().contains(
+                "providers.default.service_tier is only supported for openai-compatible providers"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
     #[tokio::test]
     async fn configured_runtime_builder_applies_auto_compaction_config() {
         let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);

--- a/crates/merry-cli/src/runtime_config.rs
+++ b/crates/merry-cli/src/runtime_config.rs
@@ -3,7 +3,7 @@ use crate::coding::ActionProcessBackendOptions;
 use crate::config::{self, EffectiveLogSettings, MerryConfig, XdgPaths};
 use crate::sandbox::default_inner_development_path_rules;
 use merry_core::SessionId;
-use merry_llm::{GenerationConfig, ReasoningEffort};
+use merry_llm::{GenerationConfig, ReasoningEffort, ServiceTier};
 use merry_runtime::{
     AutomaticCompactionConfig, PathAccess, PathAccessRule, PathAccessRuleSource, Runtime,
     RuntimeBuilder,
@@ -64,7 +64,20 @@ pub(crate) fn generation_config(
     config: Option<&MerryConfig>,
 ) -> Result<GenerationConfig, config::ConfigError> {
     let reasoning_effort = main_reasoning_effort(config)?;
-    Ok(GenerationConfig::default().with_reasoning_effort(reasoning_effort))
+    let service_tier = main_service_tier(config)?;
+    Ok(GenerationConfig::default()
+        .with_reasoning_effort(reasoning_effort)
+        .with_service_tier(service_tier))
+}
+
+pub(crate) fn main_service_tier(
+    config: Option<&MerryConfig>,
+) -> Result<Option<ServiceTier>, config::ConfigError> {
+    Ok(config
+        .map(MerryConfig::configured_default_provider)
+        .transpose()?
+        .flatten()
+        .and_then(|provider| provider.service_tier))
 }
 
 pub(crate) fn main_reasoning_effort(
@@ -138,7 +151,7 @@ mod tests {
     use crate::testing::ScriptedProvider;
     use merry_llm::{
         FinishReason, GenerationConfig, ModelCapabilities, ModelEvent, ModelName, ModelOutput,
-        ModelResponse,
+        ModelResponse, ServiceTier,
     };
     use merry_runtime::{PathAccessRuleSource, RuntimeModelRole, StepContext, StepInput};
     use std::{fs, path::PathBuf, sync::Arc};
@@ -274,6 +287,141 @@ api_key = "sk-test"
         assert_eq!(
             generation.reasoning_effort().map(|effort| effort.as_str()),
             None
+        );
+    }
+
+    #[test]
+    fn generation_config_uses_provider_default_service_tier_over_named_provider() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "openai-compatible"
+model = "gpt-test"
+service_tier = "priority"
+
+[providers.openai-compatible]
+service_tier = "flex"
+api_key = "sk-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        let generation = generation_config(Some(&config)).expect("generation config should load");
+
+        assert_eq!(generation.service_tier(), Some(ServiceTier::Priority));
+    }
+
+    #[test]
+    fn generation_config_falls_back_to_named_provider_service_tier() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "openai-compatible"
+model = "gpt-test"
+
+[providers.openai-compatible]
+service_tier = "flex"
+api_key = "sk-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        let generation = generation_config(Some(&config)).expect("generation config should load");
+
+        assert_eq!(generation.service_tier(), Some(ServiceTier::Flex));
+    }
+
+    #[test]
+    fn generation_config_omits_service_tier_when_unset() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "openai-compatible"
+model = "gpt-test"
+
+[providers.openai-compatible]
+api_key = "sk-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        let generation = generation_config(Some(&config)).expect("generation config should load");
+
+        assert_eq!(generation.service_tier(), None);
+    }
+
+    #[test]
+    fn invalid_service_tier_is_rejected() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "openai-compatible"
+model = "gpt-test"
+
+[providers.openai-compatible]
+service_tier = "turbo"
+api_key = "sk-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        let error = generation_config(Some(&config)).expect_err("service tier should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("providers.openai-compatible.service_tier is invalid"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn service_tier_is_rejected_for_anthropic_providers() {
+        let paths = XdgPaths::from_parts(PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "anthropic"
+model = "claude-test"
+
+[providers.anthropic]
+service_tier = "priority"
+api_key = "sk-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should be present");
+
+        let error = generation_config(Some(&config)).expect_err("service tier should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("service_tier is only supported for openai-compatible providers"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -13,7 +13,7 @@ use crate::provider_config::{
 };
 use crate::runtime_config::{
     action_process_backend_options, automatic_compaction_config, main_reasoning_effort,
-    main_service_tier, subagents_config,
+    subagents_config,
 };
 use crate::sandbox::ChildHandoff as SandboxChildHandoff;
 use crate::tui::preferences::{CompactionStrategy, TuiPreferences};
@@ -460,12 +460,14 @@ fn generation_config_with_preferences(
     let reasoning_effort = preference_reasoning_effort
         .or(provider_reasoning_effort)
         .or(main_reasoning_effort(merry_config)?);
-    let provider_service_tier = merry_config
+    // The service tier is provider-specific, so the selected provider owns it.
+    // It is never inherited from [providers.default] when that default names a
+    // different provider, which may not accept the tier at all.
+    let service_tier = merry_config
         .zip(selected_provider.as_deref())
         .map(|(config, provider)| config.effective_provider_service_tier(provider))
         .transpose()?
         .flatten();
-    let service_tier = provider_service_tier.or(main_service_tier(merry_config)?);
     Ok(GenerationConfig::default()
         .with_reasoning_effort(reasoning_effort)
         .with_service_tier(service_tier))
@@ -598,6 +600,49 @@ api_key = "sk-alt-test"
         assert_eq!(
             generation.reasoning_effort().map(|effort| effort.as_str()),
             Some("high")
+        );
+    }
+
+    #[test]
+    fn selected_provider_does_not_inherit_the_default_provider_service_tier() {
+        let paths = XdgPaths::from_parts(std::path::PathBuf::from("/home/alice"), None, None);
+        let config = MerryConfig::load_optional_from_text(
+            Some(
+                r#"
+[providers.default]
+provider = "compat"
+model = "gpt-test"
+service_tier = "priority"
+
+[providers.compat]
+type = "openai-compatible"
+api_key = "sk-test"
+
+[providers.alt]
+type = "openai-compatible"
+default_model = "alt-model"
+api_key = "sk-alt-test"
+"#,
+            ),
+            &paths,
+        )
+        .expect("config should parse")
+        .expect("config should exist");
+        let mut preferences = TuiPreferences::default();
+        preferences.provider = Some("alt".to_owned());
+
+        let generation = generation_config_with_preferences(Some(&config), &preferences)
+            .expect("generation config should build");
+
+        assert_eq!(generation.service_tier(), None);
+
+        preferences.provider = Some("compat".to_owned());
+        let generation = generation_config_with_preferences(Some(&config), &preferences)
+            .expect("generation config should build");
+
+        assert_eq!(
+            generation.service_tier(),
+            Some(merry_llm::ServiceTier::Priority)
         );
     }
 

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -13,7 +13,7 @@ use crate::provider_config::{
 };
 use crate::runtime_config::{
     action_process_backend_options, automatic_compaction_config, main_reasoning_effort,
-    subagents_config,
+    main_service_tier, subagents_config,
 };
 use crate::sandbox::ChildHandoff as SandboxChildHandoff;
 use crate::tui::preferences::{CompactionStrategy, TuiPreferences};
@@ -460,7 +460,15 @@ fn generation_config_with_preferences(
     let reasoning_effort = preference_reasoning_effort
         .or(provider_reasoning_effort)
         .or(main_reasoning_effort(merry_config)?);
-    Ok(GenerationConfig::default().with_reasoning_effort(reasoning_effort))
+    let provider_service_tier = merry_config
+        .zip(selected_provider.as_deref())
+        .map(|(config, provider)| config.effective_provider_service_tier(provider))
+        .transpose()?
+        .flatten();
+    let service_tier = provider_service_tier.or(main_service_tier(merry_config)?);
+    Ok(GenerationConfig::default()
+        .with_reasoning_effort(reasoning_effort)
+        .with_service_tier(service_tier))
 }
 
 fn automatic_compaction_config_with_preferences(

--- a/crates/merry-llm/src/lib.rs
+++ b/crates/merry-llm/src/lib.rs
@@ -26,7 +26,7 @@ pub use provider::{ModelEventStream, ModelProvider, ModelProviderFuture, ModelSt
 pub use request::{
     GenerationConfig, ModelInputItem, ModelMessage, ModelMessageRole, ModelName, ModelRequest,
     ModelResponseFormat, ModelStructuredOutputFormat, ParallelToolCalls, ReasoningEffort,
-    RequestContentHash, ToolProfileHash,
+    RequestContentHash, ServiceTier, ToolProfileHash,
 };
 pub use response::{FinishReason, ModelOutput, ModelResponse};
 pub use retry::{

--- a/crates/merry-llm/src/request.rs
+++ b/crates/merry-llm/src/request.rs
@@ -194,6 +194,8 @@ pub struct GenerationConfig {
     parallel_tool_calls: ParallelToolCalls,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning_effort: Option<ReasoningEffort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_tier: Option<ServiceTier>,
 }
 
 impl GenerationConfig {
@@ -216,6 +218,7 @@ impl GenerationConfig {
                 ParallelToolCalls::Disabled
             },
             reasoning_effort: None,
+            service_tier: None,
         })
     }
 
@@ -229,6 +232,13 @@ impl GenerationConfig {
     /// Returns a copy with an optional model reasoning-effort hint.
     pub fn with_reasoning_effort(mut self, reasoning_effort: Option<ReasoningEffort>) -> Self {
         self.reasoning_effort = reasoning_effort;
+        self
+    }
+
+    /// Returns a copy with an optional provider service-tier hint.
+    #[must_use]
+    pub fn with_service_tier(mut self, service_tier: Option<ServiceTier>) -> Self {
+        self.service_tier = service_tier;
         self
     }
 
@@ -275,6 +285,12 @@ impl GenerationConfig {
     pub fn reasoning_effort(&self) -> Option<&ReasoningEffort> {
         self.reasoning_effort.as_ref()
     }
+
+    /// Optional provider service-tier hint (for example OpenAI `service_tier`).
+    #[must_use]
+    pub fn service_tier(&self) -> Option<ServiceTier> {
+        self.service_tier
+    }
 }
 
 #[derive(Deserialize)]
@@ -287,6 +303,8 @@ struct GenerationConfigWire {
     allow_parallel_tool_calls: Option<bool>,
     #[serde(default)]
     reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default)]
+    service_tier: Option<ServiceTier>,
 }
 
 impl<'de> Deserialize<'de> for GenerationConfig {
@@ -313,7 +331,8 @@ impl<'de> Deserialize<'de> for GenerationConfig {
         Ok(Self::new(wire.max_output_tokens, false)
             .map_err(de::Error::custom)?
             .with_parallel_tool_calls(parallel_tool_calls)
-            .with_reasoning_effort(wire.reasoning_effort))
+            .with_reasoning_effort(wire.reasoning_effort)
+            .with_service_tier(wire.service_tier))
     }
 }
 
@@ -323,6 +342,7 @@ impl Default for GenerationConfig {
             max_output_tokens: None,
             parallel_tool_calls: ParallelToolCalls::Auto,
             reasoning_effort: None,
+            service_tier: None,
         }
     }
 }
@@ -400,6 +420,97 @@ impl<'de> Deserialize<'de> for ReasoningEffort {
     {
         let value = String::deserialize(deserializer)?;
         Self::try_from(value).map_err(de::Error::custom)
+    }
+}
+
+/// Provider service tier selecting request processing priority and pricing.
+///
+/// Values mirror the OpenAI `service_tier` request field. Providers that do
+/// not support service tiers ignore the value.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    /// Lowest-latency processing.
+    Ultrafast,
+    /// Let the provider choose the tier based on account settings.
+    Auto,
+    /// Standard processing tier.
+    Default,
+    /// Fast processing tier.
+    Fast,
+    /// Flexible, lower-cost processing with higher latency.
+    Flex,
+    /// Priority processing.
+    Priority,
+    /// Scale tier processing.
+    Scale,
+}
+
+impl ServiceTier {
+    /// All supported service tiers in display order.
+    pub const ALL: [Self; 7] = [
+        Self::Ultrafast,
+        Self::Auto,
+        Self::Default,
+        Self::Fast,
+        Self::Flex,
+        Self::Priority,
+        Self::Scale,
+    ];
+
+    /// Parses a service tier from its wire identifier.
+    pub fn new(value: &str) -> Result<Self, ModelError> {
+        Self::ALL
+            .into_iter()
+            .find(|tier| tier.as_str() == value)
+            .ok_or_else(|| {
+                ModelError::invalid_request(format!(
+                    "ServiceTier {value:?} is not supported; expected one of {}",
+                    Self::ALL
+                        .iter()
+                        .map(|tier| tier.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ))
+            })
+    }
+
+    /// Returns the wire identifier for this tier.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ultrafast => "ultrafast",
+            Self::Auto => "auto",
+            Self::Default => "default",
+            Self::Fast => "fast",
+            Self::Flex => "flex",
+            Self::Priority => "priority",
+            Self::Scale => "scale",
+        }
+    }
+}
+
+impl fmt::Display for ServiceTier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ServiceTier {
+    type Err = ModelError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for ServiceTier {
+    type Error = ModelError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
     }
 }
 

--- a/crates/merry-llm/tests/protocol.rs
+++ b/crates/merry-llm/tests/protocol.rs
@@ -11,7 +11,7 @@ use merry_llm::{
     ModelProviderFuture, ModelRequest, ModelResponse, ModelResponseFormat, ModelStreamContext,
     ModelStructuredOutputFormat, ModelToolBatchContinuation, ModelToolCall, ModelToolCallBatch,
     ModelToolCallId, ModelToolContinuation, ModelToolResult, ModelToolResultContent,
-    ParallelToolCalls, ReasoningEffort, ToolArguments, Usage,
+    ParallelToolCalls, ReasoningEffort, ServiceTier, ToolArguments, Usage,
 };
 use schemars::{JsonSchema, Schema};
 use serde::{Serialize, de::DeserializeOwned};
@@ -306,6 +306,63 @@ fn generation_parallel_tool_calls_resolve_against_provider_capabilities() {
             "max_output_tokens": null,
             "parallel_tool_calls": "auto"
         })
+    );
+}
+
+#[test]
+fn service_tier_parses_supported_identifiers_and_rejects_unknown_values() {
+    for tier in ServiceTier::ALL {
+        assert_eq!(
+            ServiceTier::new(tier.as_str()).expect("tier is valid"),
+            tier
+        );
+        assert_eq!(tier.to_string(), tier.as_str());
+    }
+    assert_eq!(
+        ServiceTier::ALL.map(ServiceTier::as_str),
+        [
+            "ultrafast",
+            "auto",
+            "default",
+            "fast",
+            "flex",
+            "priority",
+            "scale"
+        ]
+    );
+    let error = ServiceTier::new("turbo").expect_err("unknown tier must be rejected");
+    assert!(
+        error.to_string().contains("turbo"),
+        "unexpected error: {error}"
+    );
+    assert!(ServiceTier::new("Priority").is_err());
+}
+
+#[test]
+fn generation_config_carries_optional_service_tier() {
+    let generation = GenerationConfig::default().with_service_tier(Some(ServiceTier::Flex));
+    assert_eq!(generation.service_tier(), Some(ServiceTier::Flex));
+    assert_eq!(
+        serde_json::to_value(&generation).expect("generation should serialize"),
+        json!({
+            "max_output_tokens": null,
+            "parallel_tool_calls": "auto",
+            "service_tier": "flex"
+        })
+    );
+    assert_json_round_trip(&generation);
+    let parsed: GenerationConfig = serde_json::from_value(json!({
+        "max_output_tokens": null,
+        "service_tier": "priority"
+    }))
+    .expect("generation should deserialize");
+    assert_eq!(parsed.service_tier(), Some(ServiceTier::Priority));
+    assert!(
+        serde_json::from_value::<GenerationConfig>(json!({
+            "max_output_tokens": null,
+            "service_tier": "turbo"
+        }))
+        .is_err()
     );
 }
 

--- a/crates/merry-provider-openai/src/chat_completions/render.rs
+++ b/crates/merry-provider-openai/src/chat_completions/render.rs
@@ -55,6 +55,10 @@ pub(crate) fn render_chat_request(request: &ModelRequest) -> Result<Value, OpenA
             .generation()
             .reasoning_effort()
             .map(|effort| effort.as_str()),
+        service_tier: request
+            .generation()
+            .service_tier()
+            .map(|tier| tier.as_str()),
         response_format,
         tools,
         tool_choice: has_tools.then_some("auto"),

--- a/crates/merry-provider-openai/src/chat_completions/render.rs
+++ b/crates/merry-provider-openai/src/chat_completions/render.rs
@@ -2,7 +2,7 @@ use super::wire::{
     ChatContentPart, ChatImageUrl, ChatJsonSchema, ChatMessage, ChatRequest, ChatResponseFormat,
     ChatStreamOptions, ChatTool, ChatToolCall, ChatToolCallFunction, ChatToolFunction,
 };
-use crate::{OpenAiProviderError, image::png_data_url};
+use crate::{OpenAiProtocol, OpenAiProviderError, image::png_data_url};
 use merry_llm::{
     ModelContentPart, ModelInputItem, ModelMessageRole, ModelRequest, ModelResponseFormat,
 };
@@ -41,6 +41,17 @@ pub(crate) fn render_chat_request(request: &ModelRequest) -> Result<Value, OpenA
             },
         },
     });
+    let service_tier = match request.generation().service_tier() {
+        Some(service_tier)
+            if !OpenAiProtocol::ChatCompletions.supports_service_tier(service_tier) =>
+        {
+            return Err(OpenAiProviderError::invalid_request(format!(
+                "service_tier \"{service_tier}\" is not supported by the Chat Completions \
+                 protocol; it requires the Responses protocol"
+            )));
+        }
+        service_tier => service_tier.map(|tier| tier.as_str()),
+    };
     let has_tools = !tools.is_empty();
     let wire = ChatRequest {
         model: request.model().as_str(),
@@ -55,10 +66,7 @@ pub(crate) fn render_chat_request(request: &ModelRequest) -> Result<Value, OpenA
             .generation()
             .reasoning_effort()
             .map(|effort| effort.as_str()),
-        service_tier: request
-            .generation()
-            .service_tier()
-            .map(|tier| tier.as_str()),
+        service_tier,
         response_format,
         tools,
         tool_choice: has_tools.then_some("auto"),

--- a/crates/merry-provider-openai/src/chat_completions/wire.rs
+++ b/crates/merry-provider-openai/src/chat_completions/wire.rs
@@ -14,6 +14,8 @@ pub(crate) struct ChatRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) reasoning_effort: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) service_tier: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) response_format: Option<ChatResponseFormat<'a>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) tools: Vec<ChatTool<'a>>,

--- a/crates/merry-provider-openai/src/config.rs
+++ b/crates/merry-provider-openai/src/config.rs
@@ -2,7 +2,7 @@
 
 use crate::OpenAiProviderError;
 use merry_core::ProviderName;
-use merry_llm::ModelCapabilities;
+use merry_llm::{ModelCapabilities, ServiceTier};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -18,6 +18,25 @@ pub enum OpenAiProtocol {
     Responses,
     /// OpenAI Chat Completions API at `/chat/completions`.
     ChatCompletions,
+}
+
+impl OpenAiProtocol {
+    /// Returns whether a request on this protocol may carry `service_tier`.
+    ///
+    /// The `ultrafast` tier is exposed by the OpenAI Responses API only; Chat
+    /// Completions rejects it, so it is not a portable openai-compatible tier.
+    #[must_use]
+    pub const fn supports_service_tier(self, service_tier: ServiceTier) -> bool {
+        match service_tier {
+            ServiceTier::Ultrafast => matches!(self, Self::Responses),
+            ServiceTier::Auto
+            | ServiceTier::Default
+            | ServiceTier::Fast
+            | ServiceTier::Flex
+            | ServiceTier::Priority
+            | ServiceTier::Scale => true,
+        }
+    }
 }
 
 /// OpenAI-compatible provider configuration.

--- a/crates/merry-provider-openai/src/lib.rs
+++ b/crates/merry-provider-openai/src/lib.rs
@@ -88,12 +88,12 @@ mod tests {
         .expect("valid model request")
     }
 
-    fn request_with_service_tier() -> ModelRequest {
+    fn request_with_service_tier(service_tier: ServiceTier) -> ModelRequest {
         ModelRequest::new(
             ModelName::new("gpt-5.1").expect("valid model name"),
             vec![message(ModelMessageRole::User, "Hello")],
             Vec::new(),
-            GenerationConfig::default().with_service_tier(Some(ServiceTier::Priority)),
+            GenerationConfig::default().with_service_tier(Some(service_tier)),
         )
         .expect("valid model request")
     }
@@ -386,10 +386,22 @@ mod tests {
 
     #[test]
     fn rendered_request_with_service_tier_uses_responses_service_tier_field() {
-        let rendered = crate::render::render_responses_request(&request_with_service_tier())
-            .expect("request should render");
+        let rendered = crate::render::render_responses_request(&request_with_service_tier(
+            ServiceTier::Priority,
+        ))
+        .expect("request should render");
 
         assert_eq!(rendered["service_tier"], json!("priority"));
+    }
+
+    #[test]
+    fn responses_protocol_renders_the_ultrafast_service_tier() {
+        let rendered = crate::render::render_responses_request(&request_with_service_tier(
+            ServiceTier::Ultrafast,
+        ))
+        .expect("request should render");
+
+        assert_eq!(rendered["service_tier"], json!("ultrafast"));
     }
 
     #[test]
@@ -402,11 +414,41 @@ mod tests {
 
     #[test]
     fn rendered_chat_request_with_service_tier_uses_service_tier_field() {
-        let rendered =
-            crate::chat_completions::render::render_chat_request(&request_with_service_tier())
-                .expect("request should render");
+        let rendered = crate::chat_completions::render::render_chat_request(
+            &request_with_service_tier(ServiceTier::Priority),
+        )
+        .expect("request should render");
 
         assert_eq!(rendered["service_tier"], json!("priority"));
+    }
+
+    #[test]
+    fn chat_completions_protocol_rejects_the_ultrafast_service_tier() {
+        let error = crate::chat_completions::render::render_chat_request(
+            &request_with_service_tier(ServiceTier::Ultrafast),
+        )
+        .expect_err("ultrafast is a Responses-only tier");
+
+        assert!(
+            matches!(&error, OpenAiProviderError::InvalidRequest { .. }),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.to_string().contains("ultrafast"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn only_the_responses_protocol_supports_the_ultrafast_service_tier() {
+        for tier in ServiceTier::ALL {
+            assert!(OpenAiProtocol::Responses.supports_service_tier(tier));
+            assert_eq!(
+                OpenAiProtocol::ChatCompletions.supports_service_tier(tier),
+                tier != ServiceTier::Ultrafast,
+                "unexpected Chat Completions support for {tier}"
+            );
+        }
     }
 
     #[test]

--- a/crates/merry-provider-openai/src/lib.rs
+++ b/crates/merry-provider-openai/src/lib.rs
@@ -23,7 +23,8 @@ mod tests {
         FinishReason, GenerationConfig, ModelContent, ModelEvent, ModelMessage, ModelMessageRole,
         ModelName, ModelOutput, ModelRequest, ModelResponseFormat, ModelStructuredOutputFormat,
         ModelToolCall, ModelToolCallId, ModelToolContinuation, ModelToolResult,
-        ModelToolResultContent, ProviderErrorKind, ReasoningEffort, ToolArguments, Usage,
+        ModelToolResultContent, ProviderErrorKind, ReasoningEffort, ServiceTier, ToolArguments,
+        Usage,
     };
     use serde_json::{Value, json};
 
@@ -83,6 +84,16 @@ mod tests {
             GenerationConfig::default().with_reasoning_effort(Some(
                 ReasoningEffort::new("high").expect("valid reasoning effort"),
             )),
+        )
+        .expect("valid model request")
+    }
+
+    fn request_with_service_tier() -> ModelRequest {
+        ModelRequest::new(
+            ModelName::new("gpt-5.1").expect("valid model name"),
+            vec![message(ModelMessageRole::User, "Hello")],
+            Vec::new(),
+            GenerationConfig::default().with_service_tier(Some(ServiceTier::Priority)),
         )
         .expect("valid model request")
     }
@@ -371,6 +382,31 @@ mod tests {
         assert!(!object.contains_key("tools"));
         assert!(!object.contains_key("tool_choice"));
         assert!(!object.contains_key("max_output_tokens"));
+    }
+
+    #[test]
+    fn rendered_request_with_service_tier_uses_responses_service_tier_field() {
+        let rendered = crate::render::render_responses_request(&request_with_service_tier())
+            .expect("request should render");
+
+        assert_eq!(rendered["service_tier"], json!("priority"));
+    }
+
+    #[test]
+    fn rendered_request_without_service_tier_omits_service_tier_field() {
+        let rendered = crate::render::render_responses_request(&request_without_tools())
+            .expect("request should render");
+
+        assert!(rendered.get("service_tier").is_none());
+    }
+
+    #[test]
+    fn rendered_chat_request_with_service_tier_uses_service_tier_field() {
+        let rendered =
+            crate::chat_completions::render::render_chat_request(&request_with_service_tier())
+                .expect("request should render");
+
+        assert_eq!(rendered["service_tier"], json!("priority"));
     }
 
     #[test]

--- a/crates/merry-provider-openai/src/render.rs
+++ b/crates/merry-provider-openai/src/render.rs
@@ -55,6 +55,10 @@ pub(crate) fn render_responses_request_with_prompt_cache_key(
             .map(|effort| ResponsesReasoning {
                 effort: effort.as_str(),
             }),
+        service_tier: request
+            .generation()
+            .service_tier()
+            .map(|tier| tier.as_str()),
         text: render_response_format(request.response_format())?,
         tool_choice: if tools.is_empty() { None } else { Some("auto") },
         tools,

--- a/crates/merry-provider-openai/src/wire.rs
+++ b/crates/merry-provider-openai/src/wire.rs
@@ -17,6 +17,8 @@ pub(crate) struct ResponsesRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) reasoning: Option<ResponsesReasoning<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) service_tier: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) text: Option<ResponsesText<'a>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) tools: Vec<ResponsesTool<'a>>,

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -154,8 +154,10 @@ model = "gpt-4.1-mini"
 # are also accepted.
 # reasoning_effort = "medium"
 # Optional. Sent as the OpenAI `service_tier` request field (Responses and Chat
-# Completions). Supported values: ultrafast, auto, default, fast, flex,
-# priority, scale. Leave unset to omit the field.
+# Completions), and accepted for openai-compatible providers only. Supported
+# values: ultrafast, auto, default, fast, flex, priority, scale. The ultrafast
+# tier is Responses-only and requires protocol = "responses". Leave unset to
+# omit the field.
 # service_tier = "default"
 
 [providers.retry]
@@ -188,6 +190,7 @@ base_url = "https://api.openai.com/v1"
 # The value may be any provider-supported reasoning identifier.
 # reasoning_effort = "medium"
 # Optional provider-specific service tier (openai-compatible providers only).
+# The ultrafast tier additionally requires protocol = "responses".
 # service_tier = "default"
 # Prefer api_key_file for local sandboxed smoke runs so the key stays in the
 # mounted config directory instead of argv or process environment.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -153,6 +153,10 @@ model = "gpt-4.1-mini"
 # low, medium, high, xhigh, max, and ultra; custom provider-supported values
 # are also accepted.
 # reasoning_effort = "medium"
+# Optional. Sent as the OpenAI `service_tier` request field (Responses and Chat
+# Completions). Supported values: ultrafast, auto, default, fast, flex,
+# priority, scale. Leave unset to omit the field.
+# service_tier = "default"
 
 [providers.retry]
 # Provider-neutral retry policy for transient model setup or stream failures.
@@ -183,6 +187,8 @@ base_url = "https://api.openai.com/v1"
 # Optional provider-specific default used when this provider is selected in TUI.
 # The value may be any provider-supported reasoning identifier.
 # reasoning_effort = "medium"
+# Optional provider-specific service tier (openai-compatible providers only).
+# service_tier = "default"
 # Prefer api_key_file for local sandboxed smoke runs so the key stays in the
 # mounted config directory instead of argv or process environment.
 api_key_file = "secrets/openai.key"


### PR DESCRIPTION
## Summary

- Add a provider-neutral `ServiceTier` enum (`ultrafast`, `auto`, `default`, `fast`, `flex`, `priority`, `scale`) carried on `GenerationConfig` via `with_service_tier` / `service_tier()`. It serializes only when set, so existing JSON is unchanged.
- Render the top-level `service_tier` field in OpenAI Responses and Chat Completions requests when present; omit it otherwise.
- Accept a `service_tier` key on `[providers.default]` and `[providers.<alias>]`. The default-table value wins over the named provider value, mirroring `reasoning_effort`. Both the batch runtime and the TUI runtime apply it. Setting it on an Anthropic provider is rejected with a config error.
- Document the key and supported values in `examples/config.toml`.

## Testing

- `cargo check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo fmt --all --check` are clean.
- New tests: enum parsing/display/JSON round-trip (merry-llm), rendered Responses and Chat Completions requests include or omit the field (merry-provider-openai), and config resolution for default override, named fallback, unset, invalid value, and Anthropic rejection (merry-cli).
- All merry-llm, merry-provider-openai, and merry-cli unit tests pass. Pre-existing environment-only failures (bwrap TMPDIR, missing `rg`) reproduce on `main`.

Not included: a TUI picker for service tier. The setting is config-file only for now.

https://claude.ai/code/session_014G8j9FZEoUJgmKSL9SWQwW
