### PR TITLE
build(nix): add reproducible development shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ merry-raw-docs/
 # Local agent/tool metadata.
 .agents/
 .codex/
+.direnv/
 .superpowers/
 .worktrees/
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788372231,
+        "narHash": "sha256-7aqErvrAEz/5OcPA5p3M+tVOqeYc4oJXkNIPXfCqxAw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9387b3fcc0c23c86661636da63faabad4235a0a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "Merry development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      forEachSystem =
+        function:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          function (
+            import nixpkgs {
+              inherit system;
+            }
+          )
+        );
+    in
+    {
+      devShells = forEachSystem (
+        pkgs:
+        let
+          shellPackages = [
+            pkgs.cargo
+            pkgs.clippy
+            pkgs.git
+            pkgs.maturin
+            pkgs.nodejs_22
+            pkgs.nixfmt
+            pkgs.pkg-config
+            pkgs.python312
+            pkgs.ripgrep
+            pkgs.rust-analyzer
+            pkgs.rustc
+            pkgs.rustfmt
+            pkgs.stdenv.cc
+            pkgs.uv
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            pkgs.bubblewrap
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = shellPackages;
+
+            CARGO_TERM_COLOR = "always";
+            PYO3_PYTHON = "${pkgs.python312}/bin/python3";
+            RUST_BACKTRACE = "1";
+            UV_PYTHON = "${pkgs.python312}/bin/python3";
+
+            shellHook = ''
+              export PATH="${pkgs.lib.makeBinPath shellPackages}:$PATH"
+              export CC="${pkgs.stdenv.cc}/bin/cc"
+              export CXX="${pkgs.stdenv.cc}/bin/c++"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

- add a flake-based development shell for Rust, Python 3.12, uv, maturin, Node.js 22, and native build tools
- pin `nixpkgs-unstable` and expose shells for Apple Silicon macOS plus ARM64/x86_64 Linux
- include Bubblewrap only on Linux and support automatic activation through direnv

## Verification

- `nix flake check --no-build --all-systems --no-update-lock-file`
- `cargo fmt --all --check`
- `cargo check --locked --all`
