### PR TITLE
fix(mcp): support offline resume and session recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,14 +1639,21 @@ dependencies = [
 name = "merry-mcp"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "futures-util",
+ "jsonschema",
  "merry-core",
+ "merry-llm",
  "merry-runtime",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,38 @@ provider = "openai-compatible"
 model = "gpt-4.1-mini"
 ```
 
+### MCP Availability
+
+Configured HTTP MCP servers are optional at startup: connection, authentication,
+and remote-protocol failures produce visible TUI warnings or headless stderr
+warnings while Merry continues. Invalid local configuration still fails validation.
+Discovery allows up to four concurrent servers, five seconds per server, and ten
+seconds overall. Headless JSONL output remains machine-readable.
+
+Each session freezes its external tool definitions, bindings, and order before
+the first model request. Resume restores that catalog even when a server is
+offline. Available executors may reconnect on use after a five-second cooldown.
+If an MCP endpoint returns HTTP 404 for an existing transport session, Merry
+treats that session as expired, rebuilds it on a later use, and does not replay
+the failed call;
+known-unavailable tools return recorded failures rather than leaving unresolved
+calls. Timed-out tool calls are not replayed: their side effects may be unknown.
+Authentication failures require correcting credentials and resuming the session;
+they are not retried on every tool invocation.
+
+New tools and incompatible definitions require a new session. Removing a server,
+narrowing its allowlist, or changing its endpoint disables affected saved tools
+without deleting their provider-visible definitions. A session that first starts
+without any known definitions does not silently gain tools after reconnecting.
+This prevents connectivity-induced prompt-prefix changes, not provider cache
+expiration or changes to other parts of the prompt.
+
+Session state uses format 4 and requires an external tool catalog, even when it
+is empty. Other formats are rejected without migration; Merry is not yet released
+and does not support historical session formats. Start a new session if a saved
+session uses an unsupported format. Catalogs do not store authentication headers
+or MCP transport session IDs.
+
 ## Use The CLI
 
 ```bash

--- a/crates/merry-cli/src/coding/mod.rs
+++ b/crates/merry-cli/src/coding/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use runtime::build_headless_coding;
 pub(crate) use runtime::{CodingRuntimeOptions, build_coding_runtime, resume_headless_coding};
 pub(crate) use runtime::{
     HeadlessCodingRuntimeInput, build_headless_coding_with_policy_composition,
-    resume_headless_coding_composition_with_policy,
+    resume_headless_coding_composition_with_loaded_session,
 };
 pub(crate) use sandbox::{coding_agent_process_admission, coding_agent_requires_sandbox_error};
 

--- a/crates/merry-cli/src/coding/runtime.rs
+++ b/crates/merry-cli/src/coding/runtime.rs
@@ -7,8 +7,10 @@ use merry::profiles::{
 };
 use merry_llm::{ModelName, ModelProvider, ModelRetryPolicy};
 #[cfg(test)]
+use merry_runtime::FileSessionStore;
+#[cfg(test)]
 use merry_runtime::Runtime;
-use merry_runtime::{AutomaticCompactionConfig, FileSessionStore, RegisteredTool};
+use merry_runtime::{AutomaticCompactionConfig, LoadedSession, RegisteredTool};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -68,7 +70,8 @@ pub(crate) fn build_headless_coding_with_policy_composition(
         .map_err(CodingRuntimeError::from)
 }
 
-pub(crate) async fn resume_headless_coding_composition_with_policy(
+#[cfg(test)]
+async fn resume_headless_coding_composition_with_policy(
     input: HeadlessCodingRuntimeInput<'_>,
     store: FileSessionStore,
     permission: CodingPermissionPolicy,
@@ -76,6 +79,17 @@ pub(crate) async fn resume_headless_coding_composition_with_policy(
     build_coding_runtime_from_headless_input(input, permission)?
         .resume_from_store_without_automatic_savepoints(store)
         .await
+        .map_err(CodingRuntimeError::from)
+}
+
+pub(crate) fn resume_headless_coding_composition_with_loaded_session(
+    input: HeadlessCodingRuntimeInput<'_>,
+    loaded: LoadedSession,
+    permission: CodingPermissionPolicy,
+) -> Result<SharedCodingRuntime, CodingRuntimeError> {
+    build_coding_runtime_from_headless_input(input, permission)?
+        .with_loaded_session(loaded)
+        .build()
         .map_err(CodingRuntimeError::from)
 }
 

--- a/crates/merry-cli/src/mcp_tools.rs
+++ b/crates/merry-cli/src/mcp_tools.rs
@@ -1,25 +1,110 @@
 use crate::{cli_error::CliError, config::MerryConfig};
+use merry_core::SessionToolCatalog;
+use merry_mcp::{McpFailureKind, McpServerDiagnostic, McpServerIssue};
 use merry_runtime::RegisteredTool;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+pub(crate) enum McpSession<'a> {
+    New,
+    Resumed { catalog: &'a SessionToolCatalog },
+}
+
+pub(crate) struct ConfiguredMcpTools {
+    pub(crate) tools: Vec<RegisteredTool>,
+    pub(crate) warnings: Vec<McpServerDiagnostic>,
+}
+
+impl ConfiguredMcpTools {
+    fn new(tools: Vec<RegisteredTool>, warnings: Vec<McpServerDiagnostic>) -> Self {
+        Self { tools, warnings }
+    }
+}
 
 /// Discovers trusted MCP tools from user config and returns runtime tools.
 pub(crate) async fn discover_configured_mcp_tools(
     config: Option<&MerryConfig>,
-) -> Result<Vec<RegisteredTool>, CliError> {
-    let Some(config) = config else {
-        return Ok(Vec::new());
-    };
+    session: McpSession<'_>,
+) -> Result<ConfiguredMcpTools, CliError> {
     let servers = config
-        .mcp_servers()
-        .map_err(|error| CliError::Unexpected(error.to_string()))?;
-    if servers.is_empty() {
-        return Ok(Vec::new());
+        .map(MerryConfig::mcp_servers)
+        .transpose()
+        .map_err(crate::cli_error::unexpected)?
+        .unwrap_or_default();
+    let discovery = match session {
+        McpSession::New => merry_mcp::discover_mcp_tools(&servers).await,
+        McpSession::Resumed { catalog } => merry_mcp::restore_mcp_tools(&servers, catalog).await,
     }
-
-    let registrations = merry_mcp::discover_mcp_tools(&servers)
-        .await
-        .map_err(|error| CliError::Unexpected(error.to_string()))?;
-    Ok(registrations
-        .into_iter()
-        .map(|registration| registration.tool)
-        .collect())
+    .map_err(crate::cli_error::unexpected)?;
+    let (registrations, warnings) = discovery.into_parts();
+    for warning in &warnings {
+        tracing::warn!(event = "mcp.startup.degraded", diagnostic = %format_mcp_warning(warning), "MCP startup requires attention");
+    }
+    Ok(ConfiguredMcpTools::new(
+        registrations
+            .into_iter()
+            .map(|registration| registration.tool)
+            .collect(),
+        warnings,
+    ))
 }
+
+pub(crate) fn format_mcp_warning(diagnostic: &McpServerDiagnostic) -> String {
+    let detail = match diagnostic.issue() {
+        McpServerIssue::Unavailable { stage, failure } => {
+            format!("{stage:?}: {}", format_mcp_failure(*failure))
+        }
+        McpServerIssue::NotConfigured => {
+            "server is no longer configured; execution disabled".to_owned()
+        }
+        McpServerIssue::EndpointChanged => {
+            "endpoint identity changed; execution disabled".to_owned()
+        }
+        McpServerIssue::ToolsDisallowed => "current allowlist disables saved tools".to_owned(),
+        McpServerIssue::CatalogChanged => {
+            "catalog changed; incompatible tools disabled and new tools omitted".to_owned()
+        }
+        McpServerIssue::NotInSessionCatalog => {
+            "server omitted from this session's frozen catalog".to_owned()
+        }
+    };
+    let suffix = if diagnostic.retained_tools() == 0 {
+        "Merry continues; no tools loaded from this server. Start a new session after resolving the issue.".to_owned()
+    } else {
+        format!(
+            "Merry continues; {} saved tool definitions retained, affected tools unavailable. Definitions will not change on reconnect.",
+            diagnostic.retained_tools()
+        )
+    };
+    format!("MCP {}: {detail}. {suffix}", diagnostic.server_id())
+}
+
+fn format_mcp_failure(failure: McpFailureKind) -> String {
+    match failure {
+        McpFailureKind::Timeout => "request timed out".to_owned(),
+        McpFailureKind::Connection => "could not connect".to_owned(),
+        McpFailureKind::SessionExpired => "MCP session expired".to_owned(),
+        McpFailureKind::Authentication => {
+            "authentication or authorization rejected; check credentials".to_owned()
+        }
+        McpFailureKind::Http(status) => format!("HTTP {status}"),
+        McpFailureKind::Protocol => "invalid or unsupported MCP response".to_owned(),
+        McpFailureKind::InvalidToolDefinition => "invalid tool definition".to_owned(),
+        McpFailureKind::ResponseTooLarge => "response exceeded the size limit".to_owned(),
+        McpFailureKind::Transport => "transport failed".to_owned(),
+    }
+}
+
+pub(crate) async fn write_startup_warnings(
+    writer: &mut (impl AsyncWrite + Unpin),
+    warnings: &[McpServerDiagnostic],
+) -> std::io::Result<()> {
+    for warning in warnings {
+        writer
+            .write_all(format!("Warning: {}\n", format_mcp_warning(warning)).as_bytes())
+            .await?;
+    }
+    writer.flush().await
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/merry-cli/src/mcp_tools/tests.rs
+++ b/crates/merry-cli/src/mcp_tools/tests.rs
@@ -1,0 +1,122 @@
+use super::*;
+use crate::config::XdgPaths;
+use merry_core::{SessionId, ToolSourceId};
+use merry_mcp::{McpDiscoveryStage, McpFailureKind, McpServerIssue};
+use merry_runtime::{FileSessionStore, LoadedSession, Runtime, RuntimeError};
+
+#[tokio::test]
+async fn a_new_session_without_mcp_has_no_warnings_or_tools() {
+    let result = discover_configured_mcp_tools(None, McpSession::New)
+        .await
+        .unwrap();
+    assert!(result.tools.is_empty());
+    assert!(result.warnings.is_empty());
+}
+
+#[tokio::test]
+async fn resume_uses_the_empty_saved_catalog_instead_of_new_configured_servers() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path().join("sessions"));
+    let id = SessionId::new("empty-saved").unwrap();
+    Runtime::builder(id.clone())
+        .build()
+        .unwrap()
+        .save_session_to(store.clone())
+        .await
+        .unwrap();
+    let paths = XdgPaths::from_parts(temp.path().to_path_buf(), None, None);
+    let config = MerryConfig::load_optional_from_text(
+        Some("[mcp.new]\nurl = 'http://127.0.0.1:9/mcp'"),
+        &paths,
+    )
+    .unwrap()
+    .unwrap();
+    let loaded = LoadedSession::load(&store, &id).await.unwrap();
+    let result = discover_configured_mcp_tools(
+        Some(&config),
+        McpSession::Resumed {
+            catalog: loaded.external_tool_catalog(),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(result.tools.is_empty());
+    assert_eq!(
+        result.warnings[0].issue(),
+        &McpServerIssue::NotInSessionCatalog
+    );
+}
+
+#[tokio::test]
+async fn unsupported_session_format_fails_without_discovery_or_migration() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = SessionId::new("unsupported-format").unwrap();
+    Runtime::builder(id.clone())
+        .build()
+        .unwrap()
+        .save_session_to(store.clone())
+        .await
+        .unwrap();
+    let path = temp.path().join(id.as_str()).join("state.json");
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+    document["format_version"] = serde_json::json!(3);
+    document
+        .as_object_mut()
+        .unwrap()
+        .remove("external_tool_catalog");
+    let bytes = serde_json::to_vec(&document).unwrap();
+    tokio::fs::write(&path, &bytes).await.unwrap();
+    let error = LoadedSession::load(&store, &id)
+        .await
+        .err()
+        .expect("unsupported formats must fail");
+    assert!(
+        matches!(error, RuntimeError::SessionStore { source } if source.to_string().contains("session document format version 3 is not supported"))
+    );
+    assert_eq!(tokio::fs::read(&path).await.unwrap(), bytes);
+}
+
+#[tokio::test]
+async fn corrupt_resume_state_does_not_fall_back_to_discovery() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = SessionId::new("corrupt").unwrap();
+    tokio::fs::create_dir(temp.path().join(id.as_str()))
+        .await
+        .unwrap();
+    tokio::fs::write(temp.path().join(id.as_str()).join("state.json"), b"broken")
+        .await
+        .unwrap();
+    let error = LoadedSession::load(&store, &id)
+        .await
+        .err()
+        .expect("corrupt state must fail");
+    assert!(matches!(error, RuntimeError::SessionStore { .. }));
+}
+
+#[tokio::test]
+async fn warning_writer_reports_the_server_and_retained_count_and_observes_io_errors() {
+    let warnings = vec![McpServerDiagnostic::new(
+        ToolSourceId::new("offline").unwrap(),
+        McpServerIssue::Unavailable {
+            stage: McpDiscoveryStage::Initialize,
+            failure: McpFailureKind::Timeout,
+        },
+        2,
+    )];
+    let mut bytes = Vec::new();
+    write_startup_warnings(&mut bytes, &warnings).await.unwrap();
+    let rendered = String::from_utf8(bytes).unwrap();
+    assert!(rendered.starts_with("Warning: MCP offline:"));
+    assert!(rendered.contains("2 saved tool definitions retained"));
+    assert!(rendered.contains("Merry continues"));
+    let (mut writer, reader) = tokio::io::duplex(16);
+    drop(reader);
+    assert!(
+        write_startup_warnings(&mut writer, &warnings)
+            .await
+            .is_err()
+    );
+}

--- a/crates/merry-cli/src/run.rs
+++ b/crates/merry-cli/src/run.rs
@@ -3,11 +3,11 @@ use crate::coding::{
     CodingPermissionPolicy, CodingTrustMode, HeadlessCodingRuntimeInput, ProcessExecutionMode,
     action_process_runner_for_mode, build_headless_coding_with_policy_composition,
     coding_agent_process_admission, coding_agent_requires_sandbox_error,
-    resume_headless_coding_composition_with_policy,
+    resume_headless_coding_composition_with_loaded_session,
 };
 use crate::config::MerryConfig;
 use crate::headless_review::{HeadlessPermissionReviewer, ReviewInputChannel};
-use crate::mcp_tools::discover_configured_mcp_tools;
+use crate::mcp_tools::{McpSession, discover_configured_mcp_tools, write_startup_warnings};
 use crate::provider_config::{
     RuntimePrimaryProviderConfig, RuntimeProviderBundle, runtime_provider_bundle_from_config,
 };
@@ -21,7 +21,7 @@ use crate::tui::session_list::{TuiSessionMetadata, TuiSessionStore, now_unix_ms}
 use merry_core::{ErrorInfo, RuntimeEvent, SessionId, ToolCallResultStatus};
 use merry_runtime::{
     AgentLoopBlockedReason, AgentLoopConfig, AgentLoopResult, AgentLoopStatus, FileSessionStore,
-    Runtime, SessionReservation, StepContext, StepInput,
+    LoadedSession, Runtime, SessionReservation, StepContext, StepInput,
 };
 use std::{env, future::Future};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
@@ -228,14 +228,31 @@ pub(crate) async fn run(
         process_execution_mode,
     )?;
     let headless_metadata = headless_session_metadata(&session_store, &session, &root).await?;
-    let extra_tools = discover_configured_mcp_tools(merry_config).await?;
+    let loaded_session = match &session {
+        RunSession::New(_) => None,
+        RunSession::Resumed(id) => Some(
+            LoadedSession::load(&session_store, id)
+                .await
+                .map_err(|error| unexpected(format!("could not resume session {id}: {error}")))?,
+        ),
+    };
+    let mcp_session =
+        loaded_session
+            .as_ref()
+            .map_or(McpSession::New, |loaded| McpSession::Resumed {
+                catalog: loaded.external_tool_catalog(),
+            });
+    let mcp = discover_configured_mcp_tools(merry_config, mcp_session).await?;
+    write_startup_warnings(&mut tokio::io::stderr(), &mcp.warnings)
+        .await
+        .map_err(unexpected)?;
     let runtime_input = HeadlessCodingRuntimeInput {
         session_id: session.id().as_str(),
         root: &root,
         provider,
         model,
         process_backend: backend,
-        extra_tools,
+        extra_tools: mcp.tools,
         allow_hidden_workspace_paths: false,
         automatic_compaction: automatic_compaction_config(merry_config).map_err(unexpected)?,
         retry_policy,
@@ -263,20 +280,20 @@ pub(crate) async fn run(
         Some(headless_reviewer.source()),
     )
     .map_err(unexpected)?;
-    let coding_runtime = match &session {
-        RunSession::New(_) => {
-            build_headless_coding_with_policy_composition(runtime_input, permission_policy)?
-        }
-        RunSession::Resumed(id) => resume_headless_coding_composition_with_policy(
+    let coding_runtime = match loaded_session {
+        None => build_headless_coding_with_policy_composition(runtime_input, permission_policy)?,
+        Some(loaded) => resume_headless_coding_composition_with_loaded_session(
             runtime_input,
-            session_store.clone(),
+            loaded,
             permission_policy,
-        )
-        .await
-        .map_err(|error| unexpected(format!("could not resume session {id}: {error}")))?,
+        )?,
     };
     let loop_config = coding_runtime.loop_config();
     let runtime = coding_runtime.into_runtime();
+    runtime
+        .save_session_to(session_store.clone())
+        .await
+        .map_err(unexpected)?;
     let input = StepInput::user_text(&task).map_err(unexpected)?;
     let context = StepContext::default()
         .with_generation_config(generation_config(merry_config).map_err(unexpected)?);

--- a/crates/merry-cli/src/tui/mcp_tests.rs
+++ b/crates/merry-cli/src/tui/mcp_tests.rs
@@ -1,0 +1,34 @@
+use super::{
+    keymap::Keymap, project_mcp_startup_warnings, render::render_to_text, state::TuiState,
+    theme::TuiTheme,
+};
+use merry_core::ToolSourceId;
+use merry_mcp::{McpDiscoveryStage, McpFailureKind, McpServerDiagnostic, McpServerIssue};
+
+#[test]
+fn mcp_warnings_remain_visible_in_the_tui_after_startup() {
+    let mut state = TuiState::new(
+        std::path::PathBuf::from("workspace"),
+        "fixture".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    let warning = McpServerDiagnostic::new(
+        ToolSourceId::new("offline").unwrap(),
+        McpServerIssue::Unavailable {
+            stage: McpDiscoveryStage::Initialize,
+            failure: McpFailureKind::Connection,
+        },
+        2,
+    );
+    project_mcp_startup_warnings(&mut state, &[warning]);
+    let first_frame = render_to_text(&state, 120, 35);
+    assert!(first_frame.contains("MCP startup warning"));
+    assert!(first_frame.contains("MCP offline:"));
+    let wrapped_text = first_frame.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        wrapped_text.contains("2 saved tool definitions retained"),
+        "{first_frame}"
+    );
+    assert_eq!(render_to_text(&state, 120, 35), first_frame);
+}

--- a/crates/merry-cli/src/tui/mod.rs
+++ b/crates/merry-cli/src/tui/mod.rs
@@ -63,6 +63,8 @@ mod tool_error;
 #[cfg(test)]
 mod history_tests;
 #[cfg(test)]
+mod mcp_tests;
+#[cfg(test)]
 mod plan_tests;
 #[cfg(test)]
 mod slash_stop_tests;
@@ -183,6 +185,7 @@ pub(crate) async fn run(
             }
         }
     }
+    project_mcp_startup_warnings(&mut state, &session.startup_warnings);
     controller::run_controller(
         terminal,
         session,
@@ -192,6 +195,15 @@ pub(crate) async fn run(
         provider_management,
     )
     .await
+}
+
+fn project_mcp_startup_warnings(state: &mut TuiState, warnings: &[merry_mcp::McpServerDiagnostic]) {
+    for warning in warnings {
+        state.push_timeline_item(state::TimelineItem::Diagnostic {
+            title: "MCP startup warning".to_owned(),
+            body: crate::mcp_tools::format_mcp_warning(warning),
+        });
+    }
 }
 
 fn has_runtime_selection(config: Option<&MerryConfig>, preferences: &TuiPreferences) -> bool {

--- a/crates/merry-cli/src/tui/runtime.rs
+++ b/crates/merry-cli/src/tui/runtime.rs
@@ -2,10 +2,10 @@ use crate::cli_error::{CliError, debug_openai_usage_error, unexpected};
 use crate::coding::{
     CodingPermissionPolicy, CodingTrustMode, HeadlessCodingRuntimeInput, ProcessExecutionMode,
     action_process_runner_for_mode, build_headless_coding_with_policy_composition,
-    coding_agent_process_admission, resume_headless_coding_composition_with_policy,
+    coding_agent_process_admission, resume_headless_coding_composition_with_loaded_session,
 };
 use crate::config::MerryConfig;
-use crate::mcp_tools::discover_configured_mcp_tools;
+use crate::mcp_tools::{McpSession, discover_configured_mcp_tools};
 use crate::provider_config::{
     RuntimePrimaryProviderConfig, RuntimeProviderBundle,
     runtime_primary_provider_from_config_with_override,
@@ -21,11 +21,13 @@ use crate::tui::session_list::{TuiSessionMetadata, TuiSessionStore, now_unix_ms}
 use crate::tui::session_picker::SessionPickerSelection;
 use merry_core::SessionId;
 use merry_llm::GenerationConfig;
+use merry_mcp::McpServerDiagnostic;
 use merry_runtime::{
     AgentLoopControl, AgentLoopInput, AutomaticCompactionConfig, ChannelPermissionAdmissionSource,
     InteractivePrimaryModel, InteractiveRunEventStream, InteractiveSettingsUpdate,
-    InteractiveSubagentSettings, PermissionReviewRequest, Runtime, SessionReservation,
-    SessionTranscriptItem, SkillMetadata, StepContext, SubagentActivityReceiver,
+    InteractiveSubagentSettings, LoadedSession, PermissionReviewRequest, Runtime,
+    SessionReservation, SessionTranscriptItem, SkillMetadata, StepContext,
+    SubagentActivityReceiver,
 };
 use std::{collections::VecDeque, env, num::NonZeroU64, path::PathBuf, sync::Arc};
 use tokio::sync::mpsc;
@@ -36,6 +38,7 @@ pub(crate) struct TuiRuntimeSession {
     pub(crate) reasoning_effort_label: Option<String>,
     pub(crate) metadata: TuiSessionMetadata,
     pub(crate) resumed: bool,
+    pub(crate) startup_warnings: Vec<McpServerDiagnostic>,
     runtime: Runtime,
     session_store: TuiSessionStore,
     pub(crate) stream: InteractiveRunEventStream,
@@ -103,7 +106,25 @@ pub(crate) async fn start_tui_runtime_session(
     )?;
     let (permission_source, permission_requests) = ChannelPermissionAdmissionSource::channel(8);
     let permission_source = Arc::new(permission_source);
-    let extra_tools = discover_configured_mcp_tools(merry_config).await?;
+    let state_store = session_store.session_state_store();
+    let loaded_session = if should_resume {
+        Some(
+            LoadedSession::load(&state_store, &session_id)
+                .await
+                .map_err(|error| {
+                    unexpected(format!("could not resume session {session_id}: {error}"))
+                })?,
+        )
+    } else {
+        None
+    };
+    let mcp_session =
+        loaded_session
+            .as_ref()
+            .map_or(McpSession::New, |loaded| McpSession::Resumed {
+                catalog: loaded.external_tool_catalog(),
+            });
+    let mcp = discover_configured_mcp_tools(merry_config, mcp_session).await?;
     let subagents = subagents_config(merry_config)
         .map_err(unexpected)?
         .with_overrides(
@@ -117,7 +138,7 @@ pub(crate) async fn start_tui_runtime_session(
         provider,
         model,
         process_backend: backend,
-        extra_tools,
+        extra_tools: mcp.tools,
         allow_hidden_workspace_paths: false,
         automatic_compaction: automatic_compaction_config_with_preferences(
             merry_config,
@@ -148,18 +169,20 @@ pub(crate) async fn start_tui_runtime_session(
         Some(permission_source),
     )
     .map_err(unexpected)?;
-    let coding_runtime = if should_resume {
-        resume_headless_coding_composition_with_policy(
+    let coding_runtime = match loaded_session {
+        Some(loaded) => resume_headless_coding_composition_with_loaded_session(
             runtime_input,
-            session_store.session_state_store(),
+            loaded,
             permission_policy,
-        )
-        .await?
-    } else {
-        build_headless_coding_with_policy_composition(runtime_input, permission_policy)?
+        )?,
+        None => build_headless_coding_with_policy_composition(runtime_input, permission_policy)?,
     };
     let loop_config = coding_runtime.loop_config();
     let runtime = coding_runtime.into_runtime();
+    runtime
+        .save_session_to(state_store)
+        .await
+        .map_err(unexpected)?;
     let skills = runtime.skills().await;
     let interactive = runtime
         .start_interactive_agent_run(
@@ -186,6 +209,7 @@ pub(crate) async fn start_tui_runtime_session(
         reasoning_effort_label,
         metadata,
         resumed: should_resume,
+        startup_warnings: mcp.warnings,
         runtime,
         session_store,
         stream,

--- a/crates/merry-cli/tests/run_cli.rs
+++ b/crates/merry-cli/tests/run_cli.rs
@@ -18,6 +18,43 @@ api_key = \"sk-offline-not-used\"
 ";
 
 #[test]
+fn mcp_outage_warns_on_stderr_but_reaches_the_runtime_and_preserves_jsonl_output() {
+    let temp = tempfile::tempdir().unwrap();
+    write_xdg_config(
+        &temp,
+        &format!(
+            "{OFFLINE_PROVIDER_CONFIG}\n[providers.retry]\nenabled = false\n[mcp.offline]\nurl = 'http://127.0.0.1:9/mcp'\n"
+        ),
+    );
+    let output = merry_without_openai_env_and_xdg(&temp)
+        .args([
+            "--no-sandbox",
+            "run",
+            "--events-jsonl",
+            "--session-id",
+            "mcp-outage",
+            "continue without MCP",
+        ])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("Warning: MCP offline:"), "{stderr}");
+    assert!(stderr.contains("Merry continues"), "{stderr}");
+    let events = support::parse_jsonl(&output.stdout);
+    assert!(
+        events.iter().any(|event| event["type"] == "step_started"),
+        "{events:?}"
+    );
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(session_state_path(&temp, "mcp-outage")).unwrap())
+            .unwrap();
+    assert_eq!(
+        state["external_tool_catalog"]["entries"],
+        serde_json::json!([])
+    );
+}
+
+#[test]
 fn run_refuses_a_whitespace_only_stdin_task_before_emitting_events() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     write_xdg_config(&temp, OFFLINE_PROVIDER_CONFIG);

--- a/crates/merry-coding/src/runtime.rs
+++ b/crates/merry-coding/src/runtime.rs
@@ -15,9 +15,9 @@ use merry_llm::{ModelName, ModelProvider, ModelRetryPolicy};
 use merry_process::ProcessBackend;
 use merry_runtime::{
     AgentLoopConfig, AgentLoopConfigError, AutomaticCompactionConfig, ChildRuntimeFactory,
-    FileSessionStore, PermissionAdmissionSource, PermissionReviewMode, RegisteredTool, Runtime,
-    RuntimeBuilder, RuntimeError, RuntimeModelRole, SkillCatalog, SkillError, SubagentConfig,
-    SubagentError, SubagentManager, subagent_registered_tools,
+    FileSessionStore, LoadedSession, PermissionAdmissionSource, PermissionReviewMode,
+    RegisteredTool, Runtime, RuntimeBuilder, RuntimeError, RuntimeModelRole, SkillCatalog,
+    SkillError, SubagentConfig, SubagentError, SubagentManager, subagent_registered_tools,
 };
 use merry_tool_workspace::WorkspaceToolLimits;
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
@@ -480,6 +480,7 @@ pub struct CodingRuntimeBuilder {
     input: CodingRuntimeInput,
     variant: CodingRuntimeVariant,
     permission: CodingPermissionPolicy,
+    loaded_session: Option<LoadedSession>,
 }
 
 impl CodingRuntimeBuilder {
@@ -490,6 +491,7 @@ impl CodingRuntimeBuilder {
             input,
             variant: CodingRuntimeVariant::FullCoding,
             permission: CodingPermissionPolicy::default(),
+            loaded_session: None,
         }
     }
 
@@ -505,6 +507,7 @@ impl CodingRuntimeBuilder {
             input,
             variant: CodingRuntimeVariant::ReadOnlyCommandGeneration,
             permission: CodingPermissionPolicy::default(),
+            loaded_session: None,
         }
     }
 
@@ -512,6 +515,13 @@ impl CodingRuntimeBuilder {
     #[must_use]
     pub fn permission_policy(mut self, policy: CodingPermissionPolicy) -> Self {
         self.permission = policy;
+        self
+    }
+
+    /// Installs an already loaded session without performing another store read.
+    #[must_use]
+    pub fn with_loaded_session(mut self, loaded: LoadedSession) -> Self {
+        self.loaded_session = Some(loaded);
         self
     }
 
@@ -554,6 +564,7 @@ impl CodingRuntimeBuilder {
             input,
             variant,
             permission,
+            loaded_session,
         } = self;
         let CodingRuntimeInput {
             session_id,
@@ -673,6 +684,9 @@ impl CodingRuntimeBuilder {
             .apply_to(runtime_builder)
             .map_err(|source| CodingRuntimeBuildError::RuntimeProfileApply { source })?;
         runtime_builder = policy.apply_to(runtime_builder);
+        if let Some(loaded_session) = loaded_session {
+            runtime_builder = runtime_builder.with_loaded_session(loaded_session);
+        }
 
         Ok((runtime_builder, profile))
     }

--- a/crates/merry-core/src/id.rs
+++ b/crates/merry-core/src/id.rs
@@ -201,6 +201,10 @@ define_id!(PlanDirectiveId, "PlanDirectiveId");
 define_id!(PlanApprovalRequirementId, "PlanApprovalRequirementId");
 define_id!(TrajectoryRecordId, "TrajectoryRecordId");
 define_id!(ProviderName, "ProviderName");
+define_id!(ToolAdapterId, "ToolAdapterId");
+define_id!(ToolSourceId, "ToolSourceId");
+define_id!(ToolBindingName, "ToolBindingName", 1024);
+define_id!(ToolSourceFingerprint, "ToolSourceFingerprint");
 define_id!(ToolCallBatchId, "ToolCallBatchId");
 define_id!(ToolCallId, "ToolCallId", MAX_TOOL_CALL_ID_LEN);
 

--- a/crates/merry-core/src/lib.rs
+++ b/crates/merry-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod runtime_event;
 pub mod schema;
 pub mod subagent_activity;
 pub mod tool;
+pub mod tool_catalog;
 pub mod trajectory;
 pub mod usage;
 
@@ -21,7 +22,8 @@ pub use evidence::{EvidenceLocator, EvidenceRef};
 pub use id::{
     ArtifactId, PlanApprovalRequirementId, PlanAttemptId, PlanBindingId, PlanDirectiveId, PlanId,
     PlanLeaseId, PlanNodeId, ProviderName, SessionId, SkillId, SubagentId, SubagentTaskId,
-    ToolCallBatchId, ToolCallId, ToolName, TrajectoryRecordId,
+    ToolAdapterId, ToolBindingName, ToolCallBatchId, ToolCallId, ToolName, ToolSourceFingerprint,
+    ToolSourceId, TrajectoryRecordId,
 };
 pub use journal::{RuntimeJournalEvent, RuntimeJournalPayload};
 pub use plan::{
@@ -44,6 +46,7 @@ pub use tool::{
     PendingToolCall, PendingToolCallBatch, TOOL_CANCELLED_BY_USER_CODE, ToolCallArguments,
     ToolCallResult, ToolCallResultStatus, ToolSpec,
 };
+pub use tool_catalog::{ExternalToolBinding, SessionToolCatalog, SessionToolCatalogEntry};
 pub use trajectory::{
     TrajectoryEvent, TrajectoryLane, TrajectoryPayload, TrajectoryPayloadKind,
     TrajectoryPromptBlock, TrajectoryPromptSnapshot, TrajectoryRecord, TrajectoryRecordDetails,

--- a/crates/merry-core/src/tool_catalog.rs
+++ b/crates/merry-core/src/tool_catalog.rs
@@ -1,0 +1,157 @@
+//! Versioned, provider-neutral external tool identities and session catalogs.
+
+use crate::{
+    CoreError, ToolAdapterId, ToolBindingName, ToolSourceFingerprint, ToolSourceId, ToolSpec,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// An adapter's stable operation identity, without credentials or transport state.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalToolBinding {
+    adapter: ToolAdapterId,
+    source: ToolSourceId,
+    operation: ToolBindingName,
+    source_fingerprint: ToolSourceFingerprint,
+}
+
+impl ExternalToolBinding {
+    /// Binds an operation to a source identity; the fingerprint must not contain secrets.
+    #[must_use]
+    pub fn new(
+        adapter: ToolAdapterId,
+        source: ToolSourceId,
+        operation: ToolBindingName,
+        source_fingerprint: ToolSourceFingerprint,
+    ) -> Self {
+        Self {
+            adapter,
+            source,
+            operation,
+            source_fingerprint,
+        }
+    }
+
+    /// Returns the adapter namespace responsible for rebinding the operation.
+    #[must_use]
+    pub fn adapter(&self) -> &ToolAdapterId {
+        &self.adapter
+    }
+
+    /// Returns the configured, non-secret source identity.
+    #[must_use]
+    pub fn source(&self) -> &ToolSourceId {
+        &self.source
+    }
+
+    /// Returns the adapter-native operation name, not a provider wire type.
+    #[must_use]
+    pub fn operation(&self) -> &ToolBindingName {
+        &self.operation
+    }
+
+    /// Returns the opaque source fingerprint used to detect retargeting.
+    #[must_use]
+    pub fn source_fingerprint(&self) -> &ToolSourceFingerprint {
+        &self.source_fingerprint
+    }
+}
+
+/// One frozen provider-visible definition and its separate execution binding.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionToolCatalogEntry {
+    spec: ToolSpec,
+    binding: ExternalToolBinding,
+}
+
+impl SessionToolCatalogEntry {
+    /// Creates an entry from validated specification and binding values.
+    #[must_use]
+    pub fn new(spec: ToolSpec, binding: ExternalToolBinding) -> Self {
+        Self { spec, binding }
+    }
+
+    /// Returns the exact provider-visible definition saved by this session.
+    #[must_use]
+    pub fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    /// Returns the identity an adapter must check before executing this tool.
+    #[must_use]
+    pub fn binding(&self) -> &ExternalToolBinding {
+        &self.binding
+    }
+}
+
+/// Ordered external tool definitions pinned to a session, including an empty catalog.
+///
+/// Availability never changes this value. An empty catalog explicitly means that
+/// the session has no external tools; persisted sessions must contain a catalog.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "StoredCatalog")]
+pub struct SessionToolCatalog {
+    format_version: u32,
+    entries: Vec<SessionToolCatalogEntry>,
+}
+
+impl SessionToolCatalog {
+    /// Validates unique provider names and source bindings while retaining input order.
+    pub fn new(entries: Vec<SessionToolCatalogEntry>) -> Result<Self, CoreError> {
+        let mut names = BTreeSet::new();
+        let mut bindings = BTreeSet::new();
+        for entry in &entries {
+            if !names.insert(entry.spec().name()) || !bindings.insert(entry.binding()) {
+                return Err(CoreError::InvalidToolSpec {
+                    reason: "external tool catalog contains duplicate names or bindings",
+                });
+            }
+        }
+        Ok(Self {
+            format_version: 1,
+            entries,
+        })
+    }
+
+    /// Returns entries in their frozen registration order.
+    #[must_use]
+    pub fn entries(&self) -> &[SessionToolCatalogEntry] {
+        &self.entries
+    }
+}
+
+impl Default for SessionToolCatalog {
+    fn default() -> Self {
+        Self {
+            format_version: 1,
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredCatalog {
+    format_version: u32,
+    entries: Vec<SessionToolCatalogEntry>,
+}
+
+impl TryFrom<StoredCatalog> for SessionToolCatalog {
+    type Error = CoreError;
+
+    fn try_from(stored: StoredCatalog) -> Result<Self, Self::Error> {
+        if stored.format_version != 1 {
+            return Err(CoreError::InvalidToolSpec {
+                reason: "unsupported external tool catalog version",
+            });
+        }
+
+        Self::new(stored.entries)
+    }
+}
+
+#[cfg(test)]
+#[path = "tool_catalog_tests.rs"]
+mod tests;

--- a/crates/merry-core/src/tool_catalog_tests.rs
+++ b/crates/merry-core/src/tool_catalog_tests.rs
@@ -1,0 +1,60 @@
+use super::*;
+use crate::{ToolInputSchema, ToolName};
+use schemars::Schema;
+use serde_json::json;
+
+fn entry(name: &str, operation: &str) -> SessionToolCatalogEntry {
+    SessionToolCatalogEntry::new(
+        ToolSpec::new(
+            ToolName::new(name).unwrap(),
+            "Stable tool",
+            ToolInputSchema::new(Schema::try_from(json!({"type":"object"})).unwrap()).unwrap(),
+        )
+        .unwrap(),
+        ExternalToolBinding::new(
+            ToolAdapterId::new("adapter").unwrap(),
+            ToolSourceId::new("source").unwrap(),
+            ToolBindingName::new(operation).unwrap(),
+            ToolSourceFingerprint::new("endpoint-fingerprint").unwrap(),
+        ),
+    )
+}
+
+#[test]
+fn catalog_round_trip_preserves_definitions_bindings_and_order() {
+    let catalog =
+        SessionToolCatalog::new(vec![entry("zeta", "last"), entry("alpha", "first")]).unwrap();
+    let bytes = serde_json::to_vec(&catalog).unwrap();
+    let restored: SessionToolCatalog = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(catalog, restored);
+    assert_eq!(restored.entries()[0].spec().name().as_str(), "zeta");
+    assert_eq!(serde_json::to_vec(&restored).unwrap(), bytes);
+}
+
+#[test]
+fn catalog_rejects_duplicate_names_and_duplicate_bindings() {
+    assert!(SessionToolCatalog::new(vec![entry("same", "one"), entry("same", "two")]).is_err());
+    assert!(SessionToolCatalog::new(vec![entry("one", "same"), entry("two", "same")]).is_err());
+}
+
+#[test]
+fn catalog_decode_rejects_unknown_fields_versions_and_invalid_identities() {
+    let value =
+        serde_json::to_value(SessionToolCatalog::new(vec![entry("lookup", "lookup")]).unwrap())
+            .unwrap();
+    let mut unknown = value.clone();
+    unknown["credentials"] = json!("must-not-be-accepted");
+    assert!(serde_json::from_value::<SessionToolCatalog>(unknown).is_err());
+    let mut future = value.clone();
+    future["format_version"] = json!(99);
+    assert!(serde_json::from_value::<SessionToolCatalog>(future).is_err());
+    let mut invalid = value;
+    invalid["entries"][0]["binding"]["source"] = json!("bad\nsource");
+    assert!(serde_json::from_value::<SessionToolCatalog>(invalid).is_err());
+    let empty = SessionToolCatalog::default();
+    assert_eq!(
+        serde_json::from_value::<SessionToolCatalog>(serde_json::to_value(&empty).unwrap())
+            .unwrap(),
+        empty
+    );
+}

--- a/crates/merry-mcp/Cargo.toml
+++ b/crates/merry-mcp/Cargo.toml
@@ -5,15 +5,25 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+futures-util.workspace = true
+jsonschema.workspace = true
 merry-core = { path = "../merry-core", version = "0.1.0" }
 merry-runtime = { path = "../merry-runtime", version = "0.1.0" }
 reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+merry-llm = { path = "../merry-llm", version = "0.1.0", features = ["test-utils"] }
+tempfile.workspace = true
+tokio = { workspace = true, features = ["net", "test-util"] }
+tokio-util.workspace = true
 
 [lints]
 workspace = true

--- a/crates/merry-mcp/src/adapter.rs
+++ b/crates/merry-mcp/src/adapter.rs
@@ -1,147 +1,129 @@
 use crate::{
-    McpError, McpResult, McpServerConfig,
-    client::McpHttpClient,
-    map_mcp_tool_names,
-    protocol::{McpTool, ToolsCallResult},
+    connection::{McpConnection, ToolUnavailable},
+    diagnostics::{McpFailureKind, McpServerIssue},
+    protocol::ToolsCallResult,
 };
-use merry_core::{ErrorInfo, PendingToolCall, ToolInputSchema, ToolName, ToolSpec};
+use merry_core::{ErrorInfo, PendingToolCall, SessionToolCatalogEntry};
 use merry_runtime::{
     RegisteredTool, ToolActionKind, ToolExecutionContext, ToolExecutionError, ToolExecutionOutcome,
     ToolExecutor, ToolExecutorFuture,
 };
-use schemars::Schema;
-use serde_json::{Map, Value, json};
-use std::{collections::BTreeSet, sync::Arc};
+use serde_json::{Value, json};
+use std::sync::Arc;
 
 /// A registered MCP tool plus its provider-visible Merry name mapping.
 #[derive(Debug)]
 pub struct McpToolRegistration {
     pub tool: RegisteredTool,
-    pub server_id: String,
-    pub raw_tool_name: String,
 }
 
-/// Discovers tools exposed by configured MCP servers.
-pub async fn discover_mcp_tools(
-    servers: &[McpServerConfig],
-) -> McpResult<Vec<McpToolRegistration>> {
-    let mut registrations = Vec::new();
-    for server in servers {
-        let client = Arc::new(McpHttpClient::new(server.clone())?);
-        client.initialize().await?;
-        let tools = filter_allowed_tools(client.list_tools().await?.tools, server.tools());
-        let raw_names = tools
-            .iter()
-            .map(|tool| tool.name.as_str())
-            .collect::<Vec<_>>();
-        let mappings = map_mcp_tool_names(server.id(), &raw_names)?;
-
-        for (tool, mapping) in tools.into_iter().zip(mappings) {
-            let spec = mcp_tool_to_spec(server.id(), &tool, mapping.merry_name.clone())?;
-            let executor = Arc::new(McpToolExecutor {
-                client: Arc::clone(&client),
-                server_id: server.id().to_owned(),
-                raw_tool_name: mapping.raw_name.clone(),
-            });
-            registrations.push(McpToolRegistration {
-                tool: RegisteredTool::new(spec, executor, ToolActionKind::TrustedExternal),
-                server_id: server.id().to_owned(),
-                raw_tool_name: mapping.raw_name,
-            });
+impl McpToolRegistration {
+    pub(crate) fn new(entry: SessionToolCatalogEntry, binding: McpExecutionBinding) -> Self {
+        let executor = Arc::new(McpToolExecutor {
+            entry: entry.clone(),
+            binding,
+        });
+        Self {
+            tool: RegisteredTool::new(
+                entry.spec().clone(),
+                executor,
+                ToolActionKind::TrustedExternal,
+            )
+            .with_external_binding(entry.binding().clone()),
         }
     }
-    Ok(registrations)
 }
 
-fn filter_allowed_tools(tools: Vec<McpTool>, allowlist: Option<&[String]>) -> Vec<McpTool> {
-    let Some(allowlist) = allowlist else {
-        return tools;
-    };
-    let allowed = allowlist
-        .iter()
-        .map(String::as_str)
-        .collect::<BTreeSet<_>>();
-    tools
-        .into_iter()
-        .filter(|tool| allowed.contains(tool.name.as_str()))
-        .collect()
-}
-
-fn mcp_tool_to_spec(server_id: &str, tool: &McpTool, merry_name: ToolName) -> McpResult<ToolSpec> {
-    let normalized_schema = normalize_mcp_input_schema(tool.input_schema.clone());
-    let schema =
-        Schema::try_from(normalized_schema).map_err(|error| McpError::InvalidToolSchema {
-            server_id: server_id.to_owned(),
-            tool_name: tool.name.clone(),
-            message: error.to_string(),
-        })?;
-    let input_schema =
-        ToolInputSchema::new(schema).map_err(|error| McpError::InvalidToolSchema {
-            server_id: server_id.to_owned(),
-            tool_name: tool.name.clone(),
-            message: error.to_string(),
-        })?;
-    ToolSpec::new(
-        merry_name,
-        tool.description
-            .as_deref()
-            .unwrap_or("MCP tool exposed by a configured server"),
-        input_schema,
-    )
-    .map_err(|error| McpError::InvalidToolSchema {
-        server_id: server_id.to_owned(),
-        tool_name: tool.name.clone(),
-        message: error.to_string(),
-    })
-}
-
-fn normalize_mcp_input_schema(schema: Value) -> Value {
-    let mut object = match schema {
-        Value::Object(object) => object,
-        _ => Map::new(),
-    };
-
-    object
-        .entry("type")
-        .or_insert_with(|| Value::String("object".to_owned()));
-    if !matches!(object.get("properties"), Some(Value::Object(_))) {
-        object.insert("properties".to_owned(), Value::Object(Map::new()));
-    }
-
-    Value::Object(object)
+pub(crate) enum McpExecutionBinding {
+    Connection(Arc<McpConnection>),
+    Disabled(McpServerIssue),
 }
 
 struct McpToolExecutor {
-    client: Arc<McpHttpClient>,
-    server_id: String,
-    raw_tool_name: String,
+    entry: SessionToolCatalogEntry,
+    binding: McpExecutionBinding,
 }
 
 impl ToolExecutor for McpToolExecutor {
     fn execute<'a>(
         &'a self,
         call: PendingToolCall,
-        _context: ToolExecutionContext,
+        context: ToolExecutionContext,
     ) -> ToolExecutorFuture<'a> {
         Box::pin(async move {
+            if context.cancellation_token().is_cancelled() {
+                return Err(ToolExecutionError::Cancelled);
+            }
+            let connection = match &self.binding {
+                McpExecutionBinding::Connection(connection) => connection,
+                McpExecutionBinding::Disabled(reason) => {
+                    return unavailable_outcome(
+                        "mcp_tool_unavailable",
+                        &format!(
+                            "MCP tool {} is disabled: {reason:?}. Start a new session after correcting configuration.",
+                            call.name()
+                        ),
+                    );
+                }
+            };
+            let client = tokio::select! {
+                biased;
+                () = context.cancellation_token().cancelled() => return Err(ToolExecutionError::Cancelled),
+                result = connection.client_for(&self.entry) => match result {
+                    Ok(client) => client,
+                    Err(ToolUnavailable::Discovery(failure)) => return unavailable_outcome("mcp_server_unavailable", &format!("MCP {} is unavailable: {}. This tool was not executed; use another tool or retry after the connection is restored.", self.entry.binding().source(), failure.kind)),
+                    Err(ToolUnavailable::DefinitionChanged) => return unavailable_outcome("mcp_tool_definition_changed", "The MCP tool definition no longer matches this session. The tool was not executed. Start a new session to load the new catalog."),
+                },
+            };
             let arguments = Value::Object(call.arguments().as_object().clone());
-            let result = self
-                .client
-                .call_tool(&self.raw_tool_name, arguments)
-                .await
-                .map_err(|source| ToolExecutionError::Infrastructure {
-                    message: format!(
-                        "MCP tool `{}` on server `{}` failed: {source}",
-                        self.raw_tool_name, self.server_id
-                    ),
-                })?;
+            let result = tokio::select! {
+                biased;
+                () = context.cancellation_token().cancelled() => return Err(ToolExecutionError::Cancelled),
+                result = client.call_tool(self.entry.binding().operation().as_str(), arguments) => result,
+            };
+            let result = match result {
+                Ok(result) => result,
+                Err(error) => {
+                    let failure = McpFailureKind::from_error(&error);
+                    connection.record_call_failure(&client, &error).await;
+                    if matches!(
+                        failure,
+                        McpFailureKind::Connection | McpFailureKind::SessionExpired
+                    ) || failure == McpFailureKind::Authentication
+                    {
+                        return unavailable_outcome(
+                            "mcp_server_unavailable",
+                            &format!(
+                                "MCP {}: {failure}. The tool could not be invoked.",
+                                self.entry.binding().source()
+                            ),
+                        );
+                    }
+                    return unavailable_outcome(
+                        "mcp_tool_outcome_unknown",
+                        &format!(
+                            "MCP {}: {failure}. The request may have executed but no valid result was received. Do not automatically repeat this operation; verify its effects first.",
+                            self.entry.binding().source()
+                        ),
+                    );
+                }
+            };
             Ok(mcp_call_result_to_outcome(
-                &self.server_id,
-                &self.raw_tool_name,
+                self.entry.binding().source().as_str(),
+                self.entry.binding().operation().as_str(),
                 result,
             ))
         })
     }
+}
+
+fn unavailable_outcome(
+    code: &str,
+    message: &str,
+) -> Result<ToolExecutionOutcome, ToolExecutionError> {
+    let diagnostic = ErrorInfo::new(code, message)
+        .map_err(|_| ToolExecutionError::infrastructure("invalid MCP diagnostic"))?;
+    Ok(ToolExecutionOutcome::failed_text(message, diagnostic))
 }
 
 fn mcp_call_result_to_outcome(
@@ -211,24 +193,6 @@ mod tests {
     use crate::protocol::{McpContent, ToolsCallResult};
     use merry_core::ToolCallResultStatus;
     use merry_runtime::ArtifactContent;
-    use serde_json::json;
-
-    #[test]
-    fn normalizes_object_schema_without_properties() {
-        let schema = normalize_mcp_input_schema(json!({ "type": "object" }));
-
-        assert_eq!(schema["properties"], json!({}));
-    }
-
-    #[test]
-    fn normalizes_null_properties_to_empty_object() {
-        let schema = normalize_mcp_input_schema(json!({
-            "type": "object",
-            "properties": null
-        }));
-
-        assert_eq!(schema["properties"], json!({}));
-    }
 
     #[test]
     fn converts_text_result_to_successful_outcome() {

--- a/crates/merry-mcp/src/catalog.rs
+++ b/crates/merry-mcp/src/catalog.rs
@@ -1,0 +1,122 @@
+use crate::{McpError, McpResult, protocol::McpTool};
+use merry_core::{
+    ExternalToolBinding, SessionToolCatalog, SessionToolCatalogEntry, ToolAdapterId,
+    ToolBindingName, ToolInputSchema, ToolSourceFingerprint, ToolSourceId, ToolSpec,
+};
+use schemars::Schema;
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+
+pub(crate) const MCP_ADAPTER_ID: &str = "mcp";
+
+pub(crate) fn mcp_catalog(catalog: &SessionToolCatalog) -> McpResult<SessionToolCatalog> {
+    SessionToolCatalog::new(
+        catalog
+            .entries()
+            .iter()
+            .filter(|entry| entry.binding().adapter().as_str() == MCP_ADAPTER_ID)
+            .cloned()
+            .collect(),
+    )
+    .map_err(McpError::from)
+}
+
+pub(crate) fn filter_allowed_tools(
+    tools: Vec<McpTool>,
+    allowlist: Option<&[String]>,
+) -> Vec<McpTool> {
+    let Some(allowlist) = allowlist else {
+        return tools;
+    };
+    let allowed = allowlist
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    tools
+        .into_iter()
+        .filter(|tool| allowed.contains(tool.name.as_str()))
+        .collect()
+}
+
+pub(crate) fn mcp_tool_to_catalog_entry(
+    server_id: &str,
+    fingerprint: &ToolSourceFingerprint,
+    tool: &McpTool,
+    merry_name: merry_core::ToolName,
+) -> McpResult<SessionToolCatalogEntry> {
+    let spec = mcp_tool_to_spec(server_id, tool, merry_name)?;
+    let binding = ExternalToolBinding::new(
+        ToolAdapterId::new(MCP_ADAPTER_ID)?,
+        ToolSourceId::new(server_id)?,
+        ToolBindingName::new(&tool.name)?,
+        fingerprint.clone(),
+    );
+    Ok(SessionToolCatalogEntry::new(spec, binding))
+}
+
+fn mcp_tool_to_spec(
+    server_id: &str,
+    tool: &McpTool,
+    merry_name: merry_core::ToolName,
+) -> McpResult<ToolSpec> {
+    if !tool.input_schema.is_object()
+        || tool
+            .input_schema
+            .get("type")
+            .is_some_and(|kind| kind != "object")
+    {
+        return Err(McpError::InvalidToolSchema {
+            server_id: server_id.to_owned(),
+            tool_name: tool.name.clone(),
+            message: "tool input must be an object schema".to_owned(),
+        });
+    }
+    let normalized_schema = normalize_mcp_input_schema(tool.input_schema.clone());
+    jsonschema::options()
+        .build(&normalized_schema)
+        .map_err(|_| McpError::InvalidToolSchema {
+            server_id: server_id.to_owned(),
+            tool_name: tool.name.clone(),
+            message: "tool schema cannot be compiled".to_owned(),
+        })?;
+    let schema =
+        Schema::try_from(normalized_schema).map_err(|error| McpError::InvalidToolSchema {
+            server_id: server_id.to_owned(),
+            tool_name: tool.name.clone(),
+            message: error.to_string(),
+        })?;
+    let input_schema =
+        ToolInputSchema::new(schema).map_err(|error| McpError::InvalidToolSchema {
+            server_id: server_id.to_owned(),
+            tool_name: tool.name.clone(),
+            message: error.to_string(),
+        })?;
+    ToolSpec::new(
+        merry_name,
+        tool.description
+            .as_deref()
+            .unwrap_or("MCP tool exposed by a configured server"),
+        input_schema,
+    )
+    .map_err(|error| McpError::InvalidToolSchema {
+        server_id: server_id.to_owned(),
+        tool_name: tool.name.clone(),
+        message: error.to_string(),
+    })
+}
+
+fn normalize_mcp_input_schema(schema: Value) -> Value {
+    let mut object = match schema {
+        Value::Object(object) => object,
+        _ => Map::new(),
+    };
+
+    object
+        .entry("type")
+        .or_insert_with(|| Value::String("object".to_owned()));
+    if !matches!(object.get("properties"), Some(Value::Object(_))) {
+        object.insert("properties".to_owned(), Value::Object(Map::new()));
+    }
+
+    Value::Object(object)
+}

--- a/crates/merry-mcp/src/client.rs
+++ b/crates/merry-mcp/src/client.rs
@@ -16,10 +16,10 @@ use std::{
 };
 
 const DEFAULT_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 
 /// Minimal Streamable HTTP MCP client.
-#[derive(Debug)]
 pub(crate) struct McpHttpClient {
     server: McpServerConfig,
     http: reqwest::Client,
@@ -29,7 +29,9 @@ pub(crate) struct McpHttpClient {
 
 impl McpHttpClient {
     pub(crate) fn new(server: McpServerConfig) -> Result<Self, McpError> {
+        server.validated_identity()?;
         let http = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .timeout(DEFAULT_TOOL_TIMEOUT)
             .build()
             .map_err(|source| McpError::Http {
@@ -50,8 +52,11 @@ impl McpHttpClient {
         self.send_notification(JsonRpcRequest::initialized()).await
     }
 
-    pub(crate) async fn list_tools(&self) -> Result<ToolsListResult, McpError> {
-        let request = JsonRpcRequest::tools_list(self.next_request_id());
+    pub(crate) async fn list_tools(
+        &self,
+        cursor: Option<&str>,
+    ) -> Result<ToolsListResult, McpError> {
+        let request = JsonRpcRequest::tools_list(self.next_request_id(), cursor);
         self.send_json_rpc(request).await
     }
 
@@ -65,19 +70,14 @@ impl McpHttpClient {
     }
 
     async fn send_notification(&self, request: JsonRpcRequest) -> Result<(), McpError> {
-        self.base_request()
+        let request_had_session = self.has_session_id()?;
+        self.base_request()?
             .json(&request)
             .send()
             .await
-            .map_err(|source| McpError::Http {
-                server_id: self.server.id().to_owned(),
-                source,
-            })?
+            .map_err(|source| self.map_http_error(source, request_had_session))?
             .error_for_status()
-            .map_err(|source| McpError::Http {
-                server_id: self.server.id().to_owned(),
-                source,
-            })?;
+            .map_err(|source| self.map_http_error(source, request_had_session))?;
         Ok(())
     }
 
@@ -85,20 +85,15 @@ impl McpHttpClient {
     where
         T: DeserializeOwned,
     {
+        let request_had_session = self.has_session_id()?;
         let response = self
-            .base_request()
+            .base_request()?
             .json(&request)
             .send()
             .await
-            .map_err(|source| McpError::Http {
-                server_id: self.server.id().to_owned(),
-                source,
-            })?
+            .map_err(|source| self.map_http_error(source, request_had_session))?
             .error_for_status()
-            .map_err(|source| McpError::Http {
-                server_id: self.server.id().to_owned(),
-                source,
-            })?;
+            .map_err(|source| self.map_http_error(source, request_had_session))?;
 
         if let Some(session_id) = response.headers().get("Mcp-Session-Id")
             && let Ok(session_id) = session_id.to_str()
@@ -106,8 +101,9 @@ impl McpHttpClient {
             *self
                 .session_id
                 .lock()
-                .expect("MCP session id mutex should not be poisoned") =
-                Some(session_id.to_owned());
+                .map_err(|_| McpError::TransportState {
+                    server_id: self.server.id().to_owned(),
+                })? = Some(session_id.to_owned());
         }
 
         let content_type = response
@@ -122,39 +118,66 @@ impl McpHttpClient {
             .as_deref()
             .is_none_or(|value| value.starts_with("application/json"));
 
-        let response = if is_sse {
-            let body = response.text().await.map_err(|source| McpError::Http {
+        if !is_sse && !is_json {
+            return Err(McpError::UnsupportedContentType {
                 server_id: self.server.id().to_owned(),
-                source,
+                content_type: None,
+            });
+        }
+        let body = self.read_bounded_body(response).await?;
+        let response = if is_sse {
+            let body = String::from_utf8(body).map_err(|_| McpError::InvalidJson {
+                server_id: self.server.id().to_owned(),
+                message: "response is not UTF-8".to_owned(),
             })?;
             parse_sse_json_rpc_response::<T>(&body).map_err(|source| McpError::InvalidJson {
                 server_id: self.server.id().to_owned(),
                 message: source.to_string(),
             })?
-        } else if is_json {
-            response
-                .json::<JsonRpcResponse<T>>()
-                .await
-                .map_err(|source| McpError::Http {
-                    server_id: self.server.id().to_owned(),
-                    source,
-                })?
         } else {
-            return Err(McpError::UnsupportedContentType {
-                server_id: self.server.id().to_owned(),
-                content_type,
-            });
+            serde_json::from_slice::<JsonRpcResponse<T>>(&body).map_err(|_| {
+                McpError::InvalidJson {
+                    server_id: self.server.id().to_owned(),
+                    message: "invalid JSON-RPC response".to_owned(),
+                }
+            })?
         };
 
         response.into_result().map_err(|error| McpError::JsonRpc {
             server_id: self.server.id().to_owned(),
             code: error.code,
-            message: error.message,
-            data: error.data.map(|data| data.to_string()),
+            message: "server returned a JSON-RPC error".to_owned(),
+            data: None,
         })
     }
 
-    fn base_request(&self) -> reqwest::RequestBuilder {
+    async fn read_bounded_body(
+        &self,
+        mut response: reqwest::Response,
+    ) -> Result<Vec<u8>, McpError> {
+        let oversized = || McpError::ResponseTooLarge {
+            server_id: self.server.id().to_owned(),
+        };
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_RESPONSE_BYTES as u64)
+        {
+            return Err(oversized());
+        }
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(|source| McpError::Http {
+            server_id: self.server.id().to_owned(),
+            source: source.without_url(),
+        })? {
+            if chunk.len() > MAX_RESPONSE_BYTES.saturating_sub(body.len()) {
+                return Err(oversized());
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(body)
+    }
+
+    fn base_request(&self) -> Result<reqwest::RequestBuilder, McpError> {
         let mut builder = self
             .http
             .post(self.server.url())
@@ -171,16 +194,53 @@ impl McpHttpClient {
         if let Some(session_id) = self
             .session_id
             .lock()
-            .expect("MCP session id mutex should not be poisoned")
+            .map_err(|_| McpError::TransportState {
+                server_id: self.server.id().to_owned(),
+            })?
             .clone()
         {
             builder = builder.header("Mcp-Session-Id", session_id);
         }
 
-        builder
+        Ok(builder)
+    }
+
+    fn has_session_id(&self) -> Result<bool, McpError> {
+        Ok(self
+            .session_id
+            .lock()
+            .map_err(|_| McpError::TransportState {
+                server_id: self.server.id().to_owned(),
+            })?
+            .is_some())
+    }
+
+    fn map_http_error(&self, source: reqwest::Error, request_had_session: bool) -> McpError {
+        if request_had_session
+            && source.status().is_some_and(|status| status.as_u16() == 404)
+            && let Ok(mut session_id) = self.session_id.lock()
+        {
+            *session_id = None;
+            return McpError::SessionExpired {
+                server_id: self.server.id().to_owned(),
+            };
+        }
+        McpError::Http {
+            server_id: self.server.id().to_owned(),
+            source: source.without_url(),
+        }
     }
 
     fn next_request_id(&self) -> u64 {
         self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl std::fmt::Debug for McpHttpClient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpHttpClient")
+            .field("server", &self.server)
+            .finish_non_exhaustive()
     }
 }

--- a/crates/merry-mcp/src/config.rs
+++ b/crates/merry-mcp/src/config.rs
@@ -1,5 +1,5 @@
 /// Trusted HTTP MCP server configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct McpServerConfig {
     id: String,
     url: String,
@@ -8,6 +8,63 @@ pub struct McpServerConfig {
 }
 
 impl McpServerConfig {
+    pub(crate) fn validated_identity(
+        &self,
+    ) -> Result<(merry_core::ToolSourceId, merry_core::ToolSourceFingerprint), crate::McpError>
+    {
+        use reqwest::header::{HeaderName, HeaderValue};
+        use sha2::{Digest, Sha256};
+
+        let source = merry_core::ToolSourceId::new(&self.id)?;
+        crate::map_mcp_tool_names(&self.id, &[])?;
+        let url =
+            reqwest::Url::parse(&self.url).map_err(|_| crate::McpError::InvalidConfiguration {
+                reason: "MCP endpoint must be a valid absolute HTTP(S) URL",
+            })?;
+        if !matches!(url.scheme(), "http" | "https")
+            || url.host_str().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(crate::McpError::InvalidConfiguration {
+                reason: "MCP endpoint must use HTTP(S), without userinfo or fragments; use headers for authentication",
+            });
+        }
+        for (name, value) in &self.headers {
+            let header = HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+                crate::McpError::InvalidConfiguration {
+                    reason: "invalid MCP HTTP header name",
+                }
+            })?;
+            HeaderValue::from_str(value).map_err(|_| crate::McpError::InvalidConfiguration {
+                reason: "invalid MCP HTTP header value",
+            })?;
+            if matches!(
+                header.as_str(),
+                "host"
+                    | "content-length"
+                    | "transfer-encoding"
+                    | "mcp-session-id"
+                    | "mcp-protocol-version"
+            ) {
+                return Err(crate::McpError::InvalidConfiguration {
+                    reason: "MCP headers must not override transport-owned headers",
+                });
+            }
+        }
+        if let Some(tools) = &self.tools {
+            for name in tools {
+                merry_core::ToolBindingName::new(name)?;
+            }
+        }
+        let fingerprint = merry_core::ToolSourceFingerprint::new(&format!(
+            "{:x}",
+            Sha256::digest(url.as_str().as_bytes())
+        ))?;
+        Ok((source, fingerprint))
+    }
+
     /// Creates a builder for one trusted HTTP MCP server.
     #[must_use]
     pub fn builder(id: impl Into<String>, url: impl Into<String>) -> McpServerConfigBuilder {
@@ -45,12 +102,30 @@ impl McpServerConfig {
 }
 
 /// Builder for [`McpServerConfig`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct McpServerConfigBuilder {
     id: String,
     url: String,
     headers: Vec<(String, String)>,
     tools: Option<Vec<String>>,
+}
+
+impl std::fmt::Debug for McpServerConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpServerConfig")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for McpServerConfigBuilder {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpServerConfigBuilder")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl McpServerConfigBuilder {

--- a/crates/merry-mcp/src/connection.rs
+++ b/crates/merry-mcp/src/connection.rs
@@ -1,0 +1,255 @@
+use crate::{
+    McpError, McpServerConfig,
+    catalog::{filter_allowed_tools, mcp_tool_to_catalog_entry},
+    client::McpHttpClient,
+    diagnostics::{McpDiscoveryStage, McpFailureKind},
+    map_mcp_tool_names,
+};
+use merry_core::{SessionToolCatalogEntry, ToolBindingName, ToolSourceFingerprint, ToolSourceId};
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use tokio::{sync::Mutex, time::Instant};
+
+pub(crate) const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const RECONNECT_COOLDOWN: Duration = Duration::from_secs(5);
+const MAX_TOOLS: usize = 1024;
+const MAX_PAGES: usize = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DiscoveryFailure {
+    pub(crate) stage: McpDiscoveryStage,
+    pub(crate) kind: McpFailureKind,
+}
+
+#[derive(Debug)]
+struct ReadyConnection {
+    client: Arc<McpHttpClient>,
+    entries: Vec<SessionToolCatalogEntry>,
+}
+
+#[derive(Debug)]
+enum ConnectionState {
+    Disconnected {
+        failure: Option<DiscoveryFailure>,
+        retry_at: Instant,
+    },
+    Ready(ReadyConnection),
+}
+
+#[derive(Debug)]
+pub(crate) struct McpConnection {
+    config: McpServerConfig,
+    source: ToolSourceId,
+    fingerprint: ToolSourceFingerprint,
+    state: Mutex<ConnectionState>,
+}
+
+#[derive(Debug)]
+pub(crate) enum ToolUnavailable {
+    Discovery(DiscoveryFailure),
+    DefinitionChanged,
+}
+
+impl McpConnection {
+    pub(crate) fn new(config: McpServerConfig) -> Result<Self, McpError> {
+        let (source, fingerprint) = config.validated_identity()?;
+        Ok(Self {
+            config,
+            source,
+            fingerprint,
+            state: Mutex::new(ConnectionState::Disconnected {
+                failure: None,
+                retry_at: Instant::now(),
+            }),
+        })
+    }
+
+    pub(crate) fn source(&self) -> &ToolSourceId {
+        &self.source
+    }
+
+    pub(crate) fn fingerprint(&self) -> &ToolSourceFingerprint {
+        &self.fingerprint
+    }
+
+    pub(crate) fn allows(&self, name: &ToolBindingName) -> bool {
+        self.config
+            .tools()
+            .is_none_or(|allowed| allowed.iter().any(|raw| raw == name.as_str()))
+    }
+
+    pub(crate) async fn discover(
+        &self,
+        deadline: Instant,
+    ) -> Result<Vec<SessionToolCatalogEntry>, DiscoveryFailure> {
+        let mut state = self.state.lock().await;
+        if Instant::now() >= deadline {
+            let failure = DiscoveryFailure {
+                stage: McpDiscoveryStage::Initialize,
+                kind: McpFailureKind::Timeout,
+            };
+            *state = ConnectionState::Disconnected {
+                failure: Some(failure),
+                retry_at: Instant::now() + RECONNECT_COOLDOWN,
+            };
+            return Err(failure);
+        }
+        self.refresh(&mut state, deadline).await?;
+        state
+            .as_ready()
+            .map(|ready| ready.entries.clone())
+            .ok_or(DiscoveryFailure {
+                stage: McpDiscoveryStage::ListTools,
+                kind: McpFailureKind::Transport,
+            })
+    }
+
+    pub(crate) async fn client_for(
+        &self,
+        expected: &SessionToolCatalogEntry,
+    ) -> Result<Arc<McpHttpClient>, ToolUnavailable> {
+        let mut state = self.state.lock().await;
+        if let ConnectionState::Disconnected { failure, retry_at } = &*state {
+            if let Some(failure) = *failure
+                && (!failure.kind.retryable() || Instant::now() < *retry_at)
+            {
+                return Err(ToolUnavailable::Discovery(failure));
+            }
+            self.refresh(&mut state, Instant::now() + DISCOVERY_TIMEOUT)
+                .await
+                .map_err(ToolUnavailable::Discovery)?;
+        }
+        let ready = state.as_ready().ok_or(ToolUnavailable::DefinitionChanged)?;
+        if !ready
+            .entries
+            .iter()
+            .any(|live| definition_matches(live, expected))
+        {
+            return Err(ToolUnavailable::DefinitionChanged);
+        }
+        Ok(Arc::clone(&ready.client))
+    }
+
+    pub(crate) async fn record_call_failure(&self, client: &Arc<McpHttpClient>, error: &McpError) {
+        let mut state = self.state.lock().await;
+        if state
+            .as_ready()
+            .is_some_and(|ready| Arc::ptr_eq(&ready.client, client))
+        {
+            *state = ConnectionState::Disconnected {
+                failure: Some(DiscoveryFailure {
+                    stage: McpDiscoveryStage::Initialize,
+                    kind: McpFailureKind::from_error(error),
+                }),
+                retry_at: Instant::now() + RECONNECT_COOLDOWN,
+            };
+        }
+    }
+
+    async fn refresh(
+        &self,
+        state: &mut ConnectionState,
+        deadline: Instant,
+    ) -> Result<(), DiscoveryFailure> {
+        let mut stage = McpDiscoveryStage::Initialize;
+        let result =
+            tokio::time::timeout_at(deadline.min(Instant::now() + DISCOVERY_TIMEOUT), async {
+                let client = Arc::new(McpHttpClient::new(self.config.clone())?);
+                client.initialize().await?;
+                stage = McpDiscoveryStage::ListTools;
+                let entries = self.list_entries(&client).await?;
+                Ok::<_, McpError>(ReadyConnection { client, entries })
+            })
+            .await;
+        let failure = match result {
+            Ok(Ok(ready)) => {
+                *state = ConnectionState::Ready(ready);
+                return Ok(());
+            }
+            Ok(Err(error)) => DiscoveryFailure {
+                stage,
+                kind: McpFailureKind::from_error(&error),
+            },
+            Err(_) => DiscoveryFailure {
+                stage,
+                kind: McpFailureKind::Timeout,
+            },
+        };
+        *state = ConnectionState::Disconnected {
+            failure: Some(failure),
+            retry_at: Instant::now() + RECONNECT_COOLDOWN,
+        };
+        Err(failure)
+    }
+
+    async fn list_entries(
+        &self,
+        client: &McpHttpClient,
+    ) -> Result<Vec<SessionToolCatalogEntry>, McpError> {
+        let mut tools = Vec::new();
+        let mut cursor = None;
+        let mut seen_cursors = BTreeSet::new();
+        loop {
+            let page = client.list_tools(cursor.as_deref()).await?;
+            tools.extend(page.tools);
+            if tools.len() > MAX_TOOLS {
+                return Err(McpError::ResponseTooLarge {
+                    server_id: self.source.to_string(),
+                });
+            }
+            cursor = page.next_cursor;
+            let Some(next) = &cursor else {
+                break;
+            };
+            if !seen_cursors.insert(next.clone()) || seen_cursors.len() >= MAX_PAGES {
+                return Err(McpError::InvalidJson {
+                    server_id: self.source.to_string(),
+                    message: "invalid or excessive tool pagination".to_owned(),
+                });
+            }
+        }
+        let mut tools = filter_allowed_tools(tools, self.config.tools());
+        tools.sort_by(|left, right| left.name.cmp(&right.name));
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>();
+        if names.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(McpError::InvalidJson {
+                server_id: self.source.to_string(),
+                message: "duplicate tool names".to_owned(),
+            });
+        }
+        let mappings = map_mcp_tool_names(self.source.as_str(), &names)?;
+        tools
+            .into_iter()
+            .zip(mappings)
+            .map(|(tool, mapping)| {
+                mcp_tool_to_catalog_entry(
+                    self.source.as_str(),
+                    &self.fingerprint,
+                    &tool,
+                    mapping.merry_name,
+                )
+            })
+            .collect()
+    }
+}
+
+impl ConnectionState {
+    fn as_ready(&self) -> Option<&ReadyConnection> {
+        match self {
+            Self::Ready(ready) => Some(ready),
+            Self::Disconnected { .. } => None,
+        }
+    }
+}
+
+pub(crate) fn definition_matches(
+    live: &SessionToolCatalogEntry,
+    saved: &SessionToolCatalogEntry,
+) -> bool {
+    live.binding() == saved.binding()
+        && live.spec().description() == saved.spec().description()
+        && live.spec().input_schema() == saved.spec().input_schema()
+}

--- a/crates/merry-mcp/src/diagnostics.rs
+++ b/crates/merry-mcp/src/diagnostics.rs
@@ -1,0 +1,144 @@
+use crate::McpError;
+use merry_core::ToolSourceId;
+use std::fmt;
+
+/// Discovery phase reported without exposing requests, credentials, or response bodies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpDiscoveryStage {
+    /// Initialize and acknowledge the transport session.
+    Initialize,
+    /// Retrieve and validate the complete tool catalog.
+    ListTools,
+}
+
+/// Safe failure categories for user-visible MCP diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpFailureKind {
+    /// A bounded operation exceeded its deadline.
+    Timeout,
+    /// A connection could not be established.
+    Connection,
+    /// The remote endpoint no longer recognizes the MCP transport session.
+    SessionExpired,
+    /// The endpoint rejected authentication or authorization.
+    Authentication,
+    /// The endpoint returned an unsuccessful HTTP status.
+    Http(u16),
+    /// The endpoint did not return a valid supported MCP response.
+    Protocol,
+    /// One or more tool definitions are invalid.
+    InvalidToolDefinition,
+    /// A response exceeded the adapter's size limit.
+    ResponseTooLarge,
+    /// Transport failed without a more specific safe classification.
+    Transport,
+}
+
+impl McpFailureKind {
+    pub(crate) fn from_error(error: &McpError) -> Self {
+        match error {
+            McpError::Http { source, .. } if source.is_timeout() => Self::Timeout,
+            McpError::Http { source, .. } if source.is_connect() => Self::Connection,
+            McpError::Http { source, .. } => match source.status().map(|status| status.as_u16()) {
+                Some(401 | 403) => Self::Authentication,
+                Some(status) => Self::Http(status),
+                None if source.is_decode() => Self::Protocol,
+                None => Self::Transport,
+            },
+            McpError::SessionExpired { .. } => Self::SessionExpired,
+            McpError::InvalidToolSchema { .. }
+            | McpError::InvalidToolName { .. }
+            | McpError::Core(_) => Self::InvalidToolDefinition,
+            McpError::ResponseTooLarge { .. } => Self::ResponseTooLarge,
+            McpError::TransportState { .. } => Self::Transport,
+            _ => Self::Protocol,
+        }
+    }
+
+    pub(crate) fn retryable(self) -> bool {
+        matches!(
+            self,
+            Self::Timeout
+                | Self::Connection
+                | Self::SessionExpired
+                | Self::Transport
+                | Self::Http(429 | 500..=599)
+        )
+    }
+}
+
+impl fmt::Display for McpFailureKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => formatter.write_str("request timed out"),
+            Self::Connection => formatter.write_str("could not connect"),
+            Self::SessionExpired => formatter.write_str("MCP session expired"),
+            Self::Authentication => {
+                formatter.write_str("authentication or authorization rejected; check credentials")
+            }
+            Self::Http(status) => write!(formatter, "HTTP {status}"),
+            Self::Protocol => formatter.write_str("invalid or unsupported MCP response"),
+            Self::InvalidToolDefinition => formatter.write_str("invalid tool definition"),
+            Self::ResponseTooLarge => formatter.write_str("response exceeded the size limit"),
+            Self::Transport => formatter.write_str("transport failed"),
+        }
+    }
+}
+
+/// A server-level condition which does not prevent the application from starting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpServerIssue {
+    /// Startup discovery failed at the given stage.
+    Unavailable {
+        stage: McpDiscoveryStage,
+        failure: McpFailureKind,
+    },
+    /// The source was removed from the current configuration.
+    NotConfigured,
+    /// The saved source identity no longer matches the configured endpoint.
+    EndpointChanged,
+    /// Current configuration revoked access to saved tools.
+    ToolsDisallowed,
+    /// Existing definitions changed or tools were added; the saved surface stays fixed.
+    CatalogChanged,
+    /// A configured source has no definitions in this session's catalog.
+    NotInSessionCatalog,
+}
+
+/// A retained, safe startup diagnostic; tool counts distinguish missing and frozen definitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerDiagnostic {
+    server_id: ToolSourceId,
+    issue: McpServerIssue,
+    retained_tools: usize,
+}
+
+impl McpServerDiagnostic {
+    /// Creates a safe diagnostic from a validated identity and structured failure.
+    #[must_use]
+    pub fn new(server_id: ToolSourceId, issue: McpServerIssue, retained_tools: usize) -> Self {
+        Self {
+            server_id,
+            issue,
+            retained_tools,
+        }
+    }
+
+    /// Returns the non-secret configured server identity.
+    #[must_use]
+    pub fn server_id(&self) -> &ToolSourceId {
+        &self.server_id
+    }
+
+    /// Returns the condition that requires attention.
+    #[must_use]
+    pub fn issue(&self) -> &McpServerIssue {
+        &self.issue
+    }
+
+    /// Returns how many provider-visible definitions were retained for this server.
+    #[must_use]
+    pub fn retained_tools(&self) -> usize {
+        self.retained_tools
+    }
+}

--- a/crates/merry-mcp/src/discovery.rs
+++ b/crates/merry-mcp/src/discovery.rs
@@ -1,0 +1,284 @@
+use crate::{
+    McpError, McpResult, McpServerConfig,
+    adapter::{McpExecutionBinding, McpToolRegistration},
+    catalog::mcp_catalog,
+    connection::{DiscoveryFailure, McpConnection, STARTUP_TIMEOUT, definition_matches},
+    diagnostics::{McpDiscoveryStage, McpFailureKind, McpServerDiagnostic, McpServerIssue},
+};
+use futures_util::{StreamExt, stream};
+use merry_core::{SessionToolCatalog, ToolSourceId};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+use tokio::time::Instant;
+
+/// Partial discovery results. Network and remote-protocol failures are diagnostics,
+/// not an instruction for the application to exit.
+#[derive(Debug)]
+pub struct McpDiscovery {
+    registrations: Vec<McpToolRegistration>,
+    diagnostics: Vec<McpServerDiagnostic>,
+}
+
+impl McpDiscovery {
+    fn new(registrations: Vec<McpToolRegistration>, diagnostics: Vec<McpServerDiagnostic>) -> Self {
+        Self {
+            registrations,
+            diagnostics,
+        }
+    }
+
+    /// Returns registered tools in deterministic or restored session order.
+    #[must_use]
+    pub fn registrations(&self) -> &[McpToolRegistration] {
+        &self.registrations
+    }
+
+    /// Returns safe diagnostics which the caller must present to the user.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[McpServerDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Transfers executors and diagnostics to the application surface.
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<McpToolRegistration>, Vec<McpServerDiagnostic>) {
+        (self.registrations, self.diagnostics)
+    }
+}
+
+/// Discovers a new catalog with bounded concurrency and a ten-second startup budget.
+///
+/// Local configuration errors are fatal before network IO. A remote failure only
+/// omits that server's tools and emits a diagnostic. Dropping this future cancels
+/// discovery; no background task is spawned.
+pub async fn discover_mcp_tools(servers: &[McpServerConfig]) -> McpResult<McpDiscovery> {
+    prepare(servers, None).await
+}
+
+/// Rebinds the exact saved catalog, retaining offline and revoked definitions.
+///
+/// Only sources still authorized by the current configuration may connect.
+/// New sources and tools are not added. Matching cached definitions may reconnect
+/// on later execution attempts after a cooldown, without replaying any tool call.
+pub async fn restore_mcp_tools(
+    servers: &[McpServerConfig],
+    catalog: &SessionToolCatalog,
+) -> McpResult<McpDiscovery> {
+    prepare(servers, Some(catalog)).await
+}
+
+async fn prepare(
+    servers: &[McpServerConfig],
+    catalog: Option<&SessionToolCatalog>,
+) -> McpResult<McpDiscovery> {
+    let mut connections = BTreeMap::new();
+    for config in servers {
+        let connection = Arc::new(McpConnection::new(config.clone())?);
+        if connections
+            .insert(connection.source().clone(), connection)
+            .is_some()
+        {
+            return Err(McpError::InvalidConfiguration {
+                reason: "duplicate MCP server ids",
+            });
+        }
+    }
+    let mcp_catalog = catalog.map(mcp_catalog).transpose()?;
+    let catalog = mcp_catalog.as_ref();
+
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    let selected = connections
+        .values()
+        .filter(|connection| {
+            catalog.is_none_or(|catalog| {
+                catalog.entries().iter().any(|entry| {
+                    entry.binding().source() == connection.source()
+                        && entry.binding().source_fingerprint() == connection.fingerprint()
+                        && connection.allows(entry.binding().operation())
+                })
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut results = stream::iter(selected)
+        .map(|connection| async move {
+            (
+                connection.source().clone(),
+                connection.discover(deadline).await,
+            )
+        })
+        .buffer_unordered(4)
+        .collect::<BTreeMap<_, _>>()
+        .await;
+
+    if catalog.is_none() {
+        let mut owners = BTreeMap::new();
+        let mut conflicts = BTreeSet::new();
+        for (source, result) in &results {
+            if let Ok(entries) = result {
+                for entry in entries {
+                    if let Some(owner) = owners.insert(entry.spec().name().clone(), source.clone())
+                    {
+                        conflicts.insert(owner);
+                        conflicts.insert(source.clone());
+                    }
+                }
+            }
+        }
+        for source in conflicts {
+            results.insert(
+                source,
+                Err(DiscoveryFailure {
+                    stage: McpDiscoveryStage::ListTools,
+                    kind: McpFailureKind::InvalidToolDefinition,
+                }),
+            );
+        }
+    }
+
+    let mut registrations = Vec::new();
+    let mut diagnostics = Vec::new();
+    for (source, result) in &results {
+        if let Err(failure) = result {
+            push_diagnostic(
+                &mut diagnostics,
+                source,
+                McpServerIssue::Unavailable {
+                    stage: failure.stage,
+                    failure: failure.kind,
+                },
+                catalog,
+            );
+        }
+    }
+    if let Some(catalog) = catalog {
+        for entry in catalog.entries() {
+            let source = entry.binding().source();
+            let binding = match connections.get(source) {
+                None => disabled(
+                    &mut diagnostics,
+                    source,
+                    McpServerIssue::NotConfigured,
+                    catalog,
+                ),
+                Some(connection)
+                    if entry.binding().source_fingerprint() != connection.fingerprint() =>
+                {
+                    disabled(
+                        &mut diagnostics,
+                        source,
+                        McpServerIssue::EndpointChanged,
+                        catalog,
+                    )
+                }
+                Some(connection) if !connection.allows(entry.binding().operation()) => disabled(
+                    &mut diagnostics,
+                    source,
+                    McpServerIssue::ToolsDisallowed,
+                    catalog,
+                ),
+                Some(connection) => {
+                    if let Some(Ok(live)) = results.get(source)
+                        && !live.iter().any(|live| definition_matches(live, entry))
+                    {
+                        push_diagnostic(
+                            &mut diagnostics,
+                            source,
+                            McpServerIssue::CatalogChanged,
+                            Some(catalog),
+                        );
+                    }
+                    McpExecutionBinding::Connection(Arc::clone(connection))
+                }
+            };
+            registrations.push(McpToolRegistration::new(entry.clone(), binding));
+        }
+        for source in connections.keys() {
+            if !catalog
+                .entries()
+                .iter()
+                .any(|entry| entry.binding().source() == source)
+            {
+                push_diagnostic(
+                    &mut diagnostics,
+                    source,
+                    McpServerIssue::NotInSessionCatalog,
+                    Some(catalog),
+                );
+            }
+        }
+        for (source, live) in &results {
+            if let Ok(live) = live
+                && live.iter().any(|entry| {
+                    !catalog
+                        .entries()
+                        .iter()
+                        .any(|saved| saved.binding() == entry.binding())
+                })
+            {
+                push_diagnostic(
+                    &mut diagnostics,
+                    source,
+                    McpServerIssue::CatalogChanged,
+                    Some(catalog),
+                );
+            }
+        }
+    } else {
+        let mut entries = Vec::new();
+        for (source, result) in results {
+            if let Ok(discovered) = result {
+                let connection =
+                    connections
+                        .get(&source)
+                        .ok_or(McpError::InvalidConfiguration {
+                            reason: "discovered MCP source has no configured binding",
+                        })?;
+                for entry in discovered {
+                    entries.push(entry.clone());
+                    registrations.push(McpToolRegistration::new(
+                        entry,
+                        McpExecutionBinding::Connection(Arc::clone(connection)),
+                    ));
+                }
+            }
+        }
+        SessionToolCatalog::new(entries)?;
+    }
+    diagnostics.sort_by(|left, right| left.server_id().cmp(right.server_id()));
+    Ok(McpDiscovery::new(registrations, diagnostics))
+}
+
+fn disabled(
+    diagnostics: &mut Vec<McpServerDiagnostic>,
+    source: &ToolSourceId,
+    issue: McpServerIssue,
+    catalog: &SessionToolCatalog,
+) -> McpExecutionBinding {
+    push_diagnostic(diagnostics, source, issue.clone(), Some(catalog));
+    McpExecutionBinding::Disabled(issue)
+}
+
+fn push_diagnostic(
+    diagnostics: &mut Vec<McpServerDiagnostic>,
+    source: &ToolSourceId,
+    issue: McpServerIssue,
+    catalog: Option<&SessionToolCatalog>,
+) {
+    if diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.server_id() == source && diagnostic.issue() == &issue)
+    {
+        return;
+    }
+    let count = catalog.map_or(0, |catalog| {
+        catalog
+            .entries()
+            .iter()
+            .filter(|entry| entry.binding().source() == source)
+            .count()
+    });
+    diagnostics.push(McpServerDiagnostic::new(source.clone(), issue, count));
+}

--- a/crates/merry-mcp/src/error.rs
+++ b/crates/merry-mcp/src/error.rs
@@ -6,6 +6,18 @@ pub type McpResult<T> = Result<T, McpError>;
 /// Errors produced by MCP discovery and tool execution.
 #[derive(Debug, Error)]
 pub enum McpError {
+    /// A local configuration boundary failed before any discovery request.
+    #[error("invalid MCP configuration: {reason}")]
+    InvalidConfiguration { reason: &'static str },
+    /// A validated Merry contract could not be constructed.
+    #[error(transparent)]
+    Core(#[from] merry_core::CoreError),
+    /// An HTTP response exceeded the adapter's memory bound.
+    #[error("MCP response exceeded the size limit for server {server_id}")]
+    ResponseTooLarge { server_id: String },
+    /// Transport state became unavailable.
+    #[error("MCP transport state unavailable for server {server_id}")]
+    TransportState { server_id: String },
     /// HTTP transport failure.
     #[error("MCP HTTP request failed for server {server_id}: {source}")]
     Http {
@@ -13,6 +25,9 @@ pub enum McpError {
         #[source]
         source: reqwest::Error,
     },
+    /// The remote endpoint no longer recognizes the MCP transport session.
+    #[error("MCP session expired for server {server_id}")]
+    SessionExpired { server_id: String },
     /// JSON-RPC application-level error.
     #[error("MCP server {server_id} returned JSON-RPC error {code}: {message}")]
     JsonRpc {

--- a/crates/merry-mcp/src/lib.rs
+++ b/crates/merry-mcp/src/lib.rs
@@ -5,13 +5,22 @@
 //! only Merry [`merry_core::ToolSpec`] values.
 
 mod adapter;
+mod catalog;
 mod client;
 mod config;
+mod connection;
+mod diagnostics;
+mod discovery;
 mod error;
 mod name_map;
 mod protocol;
 
-pub use adapter::{McpToolRegistration, discover_mcp_tools};
+pub use adapter::McpToolRegistration;
 pub use config::{McpServerConfig, McpServerConfigBuilder};
+pub use diagnostics::{McpDiscoveryStage, McpFailureKind, McpServerDiagnostic, McpServerIssue};
+pub use discovery::{McpDiscovery, discover_mcp_tools, restore_mcp_tools};
 pub use error::{McpError, McpResult};
 pub use name_map::{McpToolNameMapping, map_mcp_tool_names};
+
+#[cfg(test)]
+mod tests;

--- a/crates/merry-mcp/src/protocol.rs
+++ b/crates/merry-mcp/src/protocol.rs
@@ -35,12 +35,12 @@ impl JsonRpcRequest {
         }
     }
 
-    pub(crate) fn tools_list(id: u64) -> Self {
+    pub(crate) fn tools_list(id: u64, cursor: Option<&str>) -> Self {
         Self {
             jsonrpc: "2.0",
             id: Some(id),
             method: "tools/list",
-            params: None,
+            params: cursor.map(|cursor| json!({ "cursor": cursor })),
         }
     }
 
@@ -66,12 +66,7 @@ impl<T> JsonRpcResponse<T> {
         match (self.result, self.error) {
             (Some(result), None) => Ok(result),
             (None, Some(error)) => Err(error),
-            (Some(result), Some(_)) => Ok(result),
-            (None, None) => Err(JsonRpcError {
-                code: -32603,
-                message: "JSON-RPC response contained neither result nor error".to_owned(),
-                data: None,
-            }),
+            (Some(_), Some(_)) | (None, None) => Err(JsonRpcError { code: -32603 }),
         }
     }
 }
@@ -80,14 +75,14 @@ impl<T> JsonRpcResponse<T> {
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct JsonRpcError {
     pub(crate) code: i64,
-    pub(crate) message: String,
-    pub(crate) data: Option<Value>,
 }
 
 /// `tools/list` response payload.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ToolsListResult {
     pub(crate) tools: Vec<McpTool>,
+    #[serde(default, rename = "nextCursor")]
+    pub(crate) next_cursor: Option<String>,
 }
 
 /// MCP tool descriptor.

--- a/crates/merry-mcp/src/tests/execution.rs
+++ b/crates/merry-mcp/src/tests/execution.rs
@@ -1,0 +1,211 @@
+use super::support::*;
+use crate::{discover_mcp_tools, restore_mcp_tools};
+use merry_core::ToolCallResultStatus;
+use merry_runtime::{FileSessionStore, RuntimeError, ToolExecutionContext};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn offline_tools_resolve_failure_then_reconnect_without_changing_definitions() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let server = Server::start(Mode::Online, vec![tool("read")]).await;
+    let config = server.config("server");
+    let original = runtime(
+        "online",
+        discover_mcp_tools(std::slice::from_ref(&config))
+            .await
+            .unwrap(),
+        &text_provider(),
+    );
+    let catalog = original.external_tool_catalog().await;
+    server.set_mode(Mode::Status(503));
+    let report = restore_mcp_tools(&[config], &catalog).await.unwrap();
+    let provider = call_provider(catalog.entries()[0].spec().name(), 2);
+    let runtime = runtime("recover", report, &provider);
+    let call = next_call(&runtime).await;
+    let events = runtime
+        .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+        .await
+        .unwrap();
+    let result = resolved(&events);
+    assert_eq!(result.status(), ToolCallResultStatus::Failed);
+    assert_eq!(
+        result.diagnostic().unwrap().code(),
+        "mcp_server_unavailable"
+    );
+    assert!(runtime.pending_tool_calls().await.is_empty());
+    runtime
+        .read_artifact_content(result.artifact().id())
+        .await
+        .expect("failed tool result has a readable durable artifact");
+    runtime.save_session_to(store).await.unwrap();
+    assert_eq!(server.calls(), 0);
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(5)).await;
+    tokio::time::resume();
+    server.set_mode(Mode::Online);
+    let call = next_call(&runtime).await;
+    let events = runtime
+        .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+        .await
+        .unwrap();
+    assert_eq!(resolved(&events).status(), ToolCallResultStatus::Succeeded);
+    assert_eq!(server.calls(), 1);
+    let requests = provider.recorded_requests();
+    assert_eq!(requests[0].tools(), requests[1].tools());
+    assert_eq!(
+        requests[0].stable_prefix_hash(),
+        requests[1].stable_prefix_hash()
+    );
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn authentication_failure_is_not_retried_on_each_tool_call() {
+    let server = Server::start(Mode::Online, vec![tool("read")]).await;
+    let original = runtime(
+        "auth-origin",
+        discover_mcp_tools(&[server.config("server")])
+            .await
+            .unwrap(),
+        &text_provider(),
+    );
+    let catalog = original.external_tool_catalog().await;
+    server.set_mode(Mode::Status(401));
+    let report = restore_mcp_tools(&[server.config("server")], &catalog)
+        .await
+        .unwrap();
+    let requests_before = server.requests();
+    server.set_mode(Mode::Online);
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::time::resume();
+    let runtime = runtime(
+        "auth-blocked",
+        report,
+        &call_provider(catalog.entries()[0].spec().name(), 2),
+    );
+    for _attempt in 0..2 {
+        let call = next_call(&runtime).await;
+        let events = runtime
+            .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+            .await
+            .unwrap();
+        assert_eq!(
+            resolved(&events).diagnostic().unwrap().code(),
+            "mcp_server_unavailable"
+        );
+    }
+    assert_eq!(server.requests(), requests_before);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn expired_mcp_session_reconnects_without_replaying_the_failed_call() {
+    let server = Server::start(Mode::Online, vec![tool("read")]).await;
+    let config = server.config("server");
+    let report = discover_mcp_tools(std::slice::from_ref(&config))
+        .await
+        .unwrap();
+    let name = report.registrations()[0].tool.spec().name().clone();
+    let provider = call_provider(&name, 2);
+    let runtime = runtime("expired-session", report, &provider);
+    server.expire_session();
+
+    let call = next_call(&runtime).await;
+    let events = runtime
+        .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+        .await
+        .unwrap();
+    assert_eq!(
+        resolved(&events).diagnostic().unwrap().code(),
+        "mcp_server_unavailable"
+    );
+    assert_eq!(server.calls(), 1);
+
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(5)).await;
+    tokio::time::resume();
+    let call = next_call(&runtime).await;
+    let events = runtime
+        .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+        .await
+        .unwrap();
+    assert_eq!(resolved(&events).status(), ToolCallResultStatus::Succeeded);
+    assert_eq!(server.calls(), 2);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn call_timeout_records_unknown_outcome_without_replaying_side_effects() {
+    let mut server = Server::start(Mode::Online, vec![tool("write")]).await;
+    let report = discover_mcp_tools(&[server.config("server")])
+        .await
+        .unwrap();
+    let name = report.registrations()[0].tool.spec().name().clone();
+    let runtime = runtime("unknown-outcome", report, &call_provider(&name, 1));
+    let call = next_call(&runtime).await;
+    server.set_mode(Mode::StallCall);
+    let owned_runtime = runtime.clone();
+    let owned_call = call.clone();
+    let execution = tokio::spawn(async move {
+        owned_runtime
+            .execute_tool_call(
+                &owned_call,
+                ToolExecutionContext::new(CancellationToken::new()),
+            )
+            .await
+    });
+    server.wait_for("tools/call").await;
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(60)).await;
+    tokio::time::resume();
+    let events = execution.await.unwrap().unwrap();
+    assert_eq!(
+        resolved(&events).diagnostic().unwrap().code(),
+        "mcp_tool_outcome_unknown"
+    );
+    assert!(runtime.pending_tool_calls().await.is_empty());
+    assert!(
+        runtime
+            .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+            .await
+            .is_err()
+    );
+    assert_eq!(server.calls(), 1);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn cancellation_propagates_and_stops_in_flight_tool_execution() {
+    let mut server = Server::start(Mode::Online, vec![tool("write")]).await;
+    let report = discover_mcp_tools(&[server.config("server")])
+        .await
+        .unwrap();
+    let name = report.registrations()[0].tool.spec().name().clone();
+    let runtime = runtime("cancel-call", report, &call_provider(&name, 1));
+    let call = next_call(&runtime).await;
+    server.set_mode(Mode::StallCall);
+    let token = CancellationToken::new();
+    let owned_token = token.clone();
+    let owned_runtime = runtime.clone();
+    let execution = tokio::spawn(async move {
+        owned_runtime
+            .execute_tool_call(&call, ToolExecutionContext::new(owned_token))
+            .await
+    });
+    server.wait_for("tools/call").await;
+    token.cancel();
+    assert!(matches!(
+        execution.await.unwrap(),
+        Err(RuntimeError::ToolExecutionCancelled { .. })
+    ));
+    assert_eq!(server.calls(), 1);
+    assert_eq!(runtime.pending_tool_calls().await.len(), 1);
+    runtime
+        .abandon_pending_tool_calls("test cancellation settled")
+        .await
+        .unwrap();
+    server.stop().await;
+}

--- a/crates/merry-mcp/src/tests/mod.rs
+++ b/crates/merry-mcp/src/tests/mod.rs
@@ -1,0 +1,4 @@
+mod execution;
+mod resume;
+mod startup;
+mod support;

--- a/crates/merry-mcp/src/tests/resume.rs
+++ b/crates/merry-mcp/src/tests/resume.rs
@@ -1,0 +1,253 @@
+use super::support::*;
+use crate::{McpServerConfig, McpServerIssue, discover_mcp_tools, restore_mcp_tools};
+use merry_core::{
+    ExternalToolBinding, SessionId, SessionToolCatalog, SessionToolCatalogEntry, ToolAdapterId,
+    ToolBindingName, ToolCallResultStatus, ToolSourceFingerprint, ToolSourceId,
+};
+use merry_llm::ModelName;
+use merry_runtime::{FileSessionStore, LoadedSession, Runtime, ToolExecutionContext};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn offline_resume_restores_saved_request_tools_and_stable_prefix() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = SessionId::new("offline-resume").unwrap();
+    let server = Server::start(Mode::Online, vec![tool("zeta"), tool("alpha")]).await;
+    let config = server.config("server");
+    let provider = text_provider();
+    let original = runtime(
+        id.as_str(),
+        discover_mcp_tools(std::slice::from_ref(&config))
+            .await
+            .unwrap(),
+        &provider,
+    );
+    step(&original).await;
+    original.save_session_to(store.clone()).await.unwrap();
+    let loaded = LoadedSession::load(&store, &id).await.unwrap();
+    let catalog = loaded.external_tool_catalog().clone();
+    server.set_mode(Mode::Status(503));
+    let discovery = restore_mcp_tools(&[config], &catalog).await.unwrap();
+    assert_eq!(discovery.diagnostics()[0].retained_tools(), 2);
+    let builder = Runtime::builder(id).fully_trusted_tools().model_provider(
+        Arc::new(provider.clone()),
+        ModelName::new("fixture").unwrap(),
+    );
+    let resumed = discovery
+        .into_parts()
+        .0
+        .into_iter()
+        .fold(builder, |builder, registration| {
+            builder.register_tool(registration.tool)
+        })
+        .resume_from_store(store)
+        .await
+        .unwrap();
+    step(&resumed).await;
+    let requests = provider.recorded_requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].tools(), requests[1].tools());
+    assert_eq!(
+        requests[0].stable_prefix_hash(),
+        requests[1].stable_prefix_hash()
+    );
+    assert_eq!(resumed.external_tool_catalog().await, catalog);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn initially_empty_catalog_does_not_gain_tools_after_recovery() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let server = Server::start(Mode::Status(503), vec![tool("late")]).await;
+    let config = server.config("server");
+    let original = runtime(
+        "empty-recovery",
+        discover_mcp_tools(std::slice::from_ref(&config))
+            .await
+            .unwrap(),
+        &text_provider(),
+    );
+    original.save_session_to(store.clone()).await.unwrap();
+    let loaded = LoadedSession::load(&store, original.session_id())
+        .await
+        .unwrap();
+    let catalog = loaded.external_tool_catalog().clone();
+    assert!(catalog.entries().is_empty());
+    server.set_mode(Mode::Online);
+    let requests = server.requests();
+    let restored = restore_mcp_tools(&[config], &catalog).await.unwrap();
+    assert!(restored.registrations().is_empty());
+    assert!(matches!(
+        restored.diagnostics()[0].issue(),
+        McpServerIssue::NotInSessionCatalog
+    ));
+    assert_eq!(server.requests(), requests);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn restore_ignores_catalog_entries_owned_by_other_adapters() {
+    let server = Server::start(Mode::Online, vec![tool("read")]).await;
+    let config = server.config("server");
+    let discovered = discover_mcp_tools(std::slice::from_ref(&config))
+        .await
+        .unwrap();
+    let mcp_entry = discovered.registrations()[0]
+        .tool
+        .external_binding()
+        .cloned()
+        .map(|binding| {
+            SessionToolCatalogEntry::new(discovered.registrations()[0].tool.spec().clone(), binding)
+        })
+        .unwrap();
+    let other_entry = SessionToolCatalogEntry::new(
+        merry_core::ToolSpec::new(
+            merry_core::ToolName::new("other_tool").unwrap(),
+            "Other adapter tool",
+            discovered.registrations()[0]
+                .tool
+                .spec()
+                .input_schema()
+                .clone(),
+        )
+        .unwrap(),
+        ExternalToolBinding::new(
+            ToolAdapterId::new("other").unwrap(),
+            ToolSourceId::new("other-source").unwrap(),
+            ToolBindingName::new("other_operation").unwrap(),
+            ToolSourceFingerprint::new("other-fingerprint").unwrap(),
+        ),
+    );
+    let catalog = SessionToolCatalog::new(vec![mcp_entry, other_entry]).unwrap();
+    server.set_mode(Mode::Status(503));
+    let restored = restore_mcp_tools(&[config], &catalog).await.unwrap();
+    assert_eq!(restored.registrations().len(), 1);
+    assert_eq!(restored.diagnostics()[0].retained_tools(), 1);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn changed_definition_is_retained_but_never_executed_and_new_tools_are_omitted() {
+    let server = Server::start(Mode::Online, vec![tool("read")]).await;
+    let config = server.config("server");
+    let original = runtime(
+        "original",
+        discover_mcp_tools(std::slice::from_ref(&config))
+            .await
+            .unwrap(),
+        &text_provider(),
+    );
+    let catalog = original.external_tool_catalog().await;
+    let mut changed = tool("read");
+    changed["inputSchema"] = serde_json::json!({"type":"object","properties":{"path":{"type":"string"}},"required":["path"]});
+    server.set_tools(vec![changed, tool("new")]);
+    let report = restore_mcp_tools(&[config], &catalog).await.unwrap();
+    assert_eq!(report.registrations().len(), 1);
+    assert_eq!(
+        report.registrations()[0].tool.spec(),
+        catalog.entries()[0].spec()
+    );
+    assert!(matches!(
+        report.diagnostics()[0].issue(),
+        McpServerIssue::CatalogChanged
+    ));
+    let provider = call_provider(catalog.entries()[0].spec().name(), 1);
+    let runtime = runtime("changed", report, &provider);
+    let call = next_call(&runtime).await;
+    let events = runtime
+        .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+        .await
+        .unwrap();
+    assert_eq!(resolved(&events).status(), ToolCallResultStatus::Failed);
+    assert_eq!(
+        resolved(&events).diagnostic().unwrap().code(),
+        "mcp_tool_definition_changed"
+    );
+    assert!(runtime.pending_tool_calls().await.is_empty());
+    assert_eq!(server.calls(), 0);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn removed_servers_changed_endpoints_and_revoked_allowlists_never_execute() {
+    let first = Server::start(Mode::Online, vec![tool("read")]).await;
+    let other = Server::start(Mode::Online, vec![tool("read")]).await;
+    let original = runtime(
+        "original-grant",
+        discover_mcp_tools(&[first.config("server")]).await.unwrap(),
+        &text_provider(),
+    );
+    let catalog = original.external_tool_catalog().await;
+    for (configs, expected) in [
+        (vec![], McpServerIssue::NotConfigured),
+        (
+            vec![other.config("server")],
+            McpServerIssue::EndpointChanged,
+        ),
+        (
+            vec![
+                McpServerConfig::builder("server", first.url())
+                    .tools(Vec::<String>::new())
+                    .build(),
+            ],
+            McpServerIssue::ToolsDisallowed,
+        ),
+    ] {
+        let report = restore_mcp_tools(&configs, &catalog).await.unwrap();
+        assert_eq!(report.registrations().len(), 1);
+        assert_eq!(report.diagnostics()[0].issue(), &expected);
+        let runtime = runtime(
+            "revoked",
+            report,
+            &call_provider(catalog.entries()[0].spec().name(), 1),
+        );
+        let call = next_call(&runtime).await;
+        let events = runtime
+            .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+            .await
+            .unwrap();
+        assert_eq!(resolved(&events).status(), ToolCallResultStatus::Failed);
+    }
+    assert_eq!(first.calls(), 0);
+    assert_eq!(other.requests(), 0);
+    first.stop().await;
+    other.stop().await;
+}
+
+#[tokio::test]
+async fn a_new_name_collision_does_not_rename_the_saved_tool() {
+    let server = Server::start(Mode::Online, vec![tool("read.file")]).await;
+    let original = runtime(
+        "name-origin",
+        discover_mcp_tools(&[server.config("server")])
+            .await
+            .unwrap(),
+        &text_provider(),
+    );
+    let catalog: SessionToolCatalog = original.external_tool_catalog().await;
+    server.set_tools(vec![tool("read/file"), tool("read.file")]);
+    let report = restore_mcp_tools(&[server.config("server")], &catalog)
+        .await
+        .unwrap();
+    assert_eq!(report.registrations().len(), 1);
+    assert_eq!(
+        report.registrations()[0].tool.spec(),
+        catalog.entries()[0].spec()
+    );
+    let runtime = runtime(
+        "collision",
+        report,
+        &call_provider(catalog.entries()[0].spec().name(), 1),
+    );
+    let call = next_call(&runtime).await;
+    let events = runtime
+        .execute_tool_call(&call, ToolExecutionContext::new(CancellationToken::new()))
+        .await
+        .unwrap();
+    assert_eq!(resolved(&events).status(), ToolCallResultStatus::Succeeded);
+    assert_eq!(server.calls(), 1);
+    server.stop().await;
+}

--- a/crates/merry-mcp/src/tests/startup.rs
+++ b/crates/merry-mcp/src/tests/startup.rs
@@ -1,0 +1,239 @@
+use super::support::*;
+use crate::{McpError, McpFailureKind, McpServerConfig, McpServerIssue, discover_mcp_tools};
+use std::time::Duration;
+
+#[tokio::test]
+async fn partial_and_total_outages_are_nonfatal_and_keep_healthy_tools() {
+    let healthy = Server::start(Mode::Online, vec![tool("zeta"), tool("alpha")]).await;
+    let offline = Server::start(Mode::Status(503), vec![]).await;
+    let report = discover_mcp_tools(&[offline.config("offline"), healthy.config("healthy")])
+        .await
+        .unwrap();
+    assert_eq!(
+        report
+            .registrations()
+            .iter()
+            .map(|registration| {
+                registration
+                    .tool
+                    .external_binding()
+                    .expect("MCP registrations have an external binding")
+                    .operation()
+                    .as_str()
+            })
+            .collect::<Vec<_>>(),
+        ["alpha", "zeta"]
+    );
+    assert_eq!(report.diagnostics().len(), 1);
+    assert_eq!(report.diagnostics()[0].server_id().as_str(), "offline");
+    assert_eq!(report.diagnostics()[0].retained_tools(), 0);
+    let report = discover_mcp_tools(&[offline.config("offline")])
+        .await
+        .unwrap();
+    assert!(report.registrations().is_empty());
+    assert!(matches!(
+        report.diagnostics()[0].issue(),
+        McpServerIssue::Unavailable {
+            failure: McpFailureKind::Http(503),
+            ..
+        }
+    ));
+    healthy.stop().await;
+    offline.stop().await;
+}
+
+#[tokio::test]
+async fn tool_order_is_stable_even_when_pages_and_discovery_order_change() {
+    let first = Server::start(Mode::Paginated, vec![tool("zeta"), tool("alpha")]).await;
+    let second = Server::start(Mode::Online, vec![tool("lookup")]).await;
+    let before = discover_mcp_tools(&[second.config("second"), first.config("first")])
+        .await
+        .unwrap();
+    first.set_tools(vec![tool("alpha"), tool("zeta")]);
+    let after = discover_mcp_tools(&[first.config("first"), second.config("second")])
+        .await
+        .unwrap();
+    let specs = |report: &crate::McpDiscovery| {
+        report
+            .registrations()
+            .iter()
+            .map(|registration| registration.tool.spec().clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(specs(&before), specs(&after));
+    assert_eq!(before.registrations().len(), 3);
+    assert!(before.diagnostics().is_empty());
+    first.stop().await;
+    second.stop().await;
+}
+
+#[tokio::test]
+async fn invalid_configuration_is_fatal_before_any_server_is_contacted() {
+    let healthy = Server::start(Mode::Online, vec![tool("read")]).await;
+    let bad = McpServerConfig::builder("bad", "not-an-endpoint?secret-query-value").build();
+    let error = discover_mcp_tools(&[healthy.config("first"), bad])
+        .await
+        .unwrap_err();
+    assert!(matches!(error, McpError::InvalidConfiguration { .. }));
+    assert!(!error.to_string().contains("secret-query-value"));
+    assert_eq!(healthy.requests(), 0);
+    let bad = McpServerConfig::builder("bad", healthy.url())
+        .header("Authorization", "secret-query-value\ninvalid")
+        .build();
+    assert!(discover_mcp_tools(&[bad]).await.is_err());
+    assert_eq!(healthy.requests(), 0);
+    healthy.stop().await;
+}
+
+#[tokio::test]
+async fn conflicting_server_tool_names_do_not_abort_other_servers() {
+    let first = Server::start(Mode::Online, vec![tool("b_c")]).await;
+    let second = Server::start(Mode::Online, vec![tool("c")]).await;
+    let healthy = Server::start(Mode::Online, vec![tool("read")]).await;
+    let report = discover_mcp_tools(&[
+        first.config("a"),
+        second.config("a_b"),
+        healthy.config("healthy"),
+    ])
+    .await
+    .unwrap();
+    assert_eq!(report.registrations().len(), 1);
+    assert_eq!(
+        report.registrations()[0]
+            .tool
+            .external_binding()
+            .expect("MCP registrations have an external binding")
+            .source()
+            .as_str(),
+        "healthy"
+    );
+    assert_eq!(report.diagnostics().len(), 2);
+    assert!(report.diagnostics().iter().all(|diagnostic| matches!(
+        diagnostic.issue(),
+        McpServerIssue::Unavailable {
+            failure: McpFailureKind::InvalidToolDefinition,
+            ..
+        }
+    )));
+    first.stop().await;
+    second.stop().await;
+    healthy.stop().await;
+}
+
+#[tokio::test]
+async fn stalled_startup_times_out_without_discarding_other_servers() {
+    let mut stalled = Server::start(Mode::StallInitialize, vec![]).await;
+    let healthy = Server::start(Mode::Online, vec![tool("lookup")]).await;
+    let configs = vec![
+        stalled.config("a"),
+        stalled.config("b"),
+        stalled.config("c"),
+        stalled.config("d"),
+        healthy.config("z-healthy"),
+    ];
+    let discovery = tokio::spawn(async move { discover_mcp_tools(&configs).await });
+    for _request in 0..4 {
+        stalled.wait_for("initialize").await;
+    }
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(5)).await;
+    tokio::time::resume();
+    let report = discovery.await.unwrap().unwrap();
+    assert_eq!(report.registrations().len(), 1);
+    assert_eq!(report.diagnostics().len(), 4);
+    assert!(matches!(
+        report.diagnostics()[0].issue(),
+        McpServerIssue::Unavailable {
+            failure: McpFailureKind::Timeout,
+            ..
+        }
+    ));
+    stalled.stop().await;
+    healthy.stop().await;
+}
+
+#[tokio::test]
+async fn dropping_discovery_stops_the_handshake_without_detached_producers() {
+    let mut server = Server::start(Mode::StallInitialize, vec![]).await;
+    let config = server.config("cancelled");
+    let discovery = tokio::spawn(async move { discover_mcp_tools(&[config]).await });
+    server.wait_for("initialize").await;
+    discovery.abort();
+    assert!(discovery.await.unwrap_err().is_cancelled());
+    assert_eq!(server.requests(), 1);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn the_total_startup_budget_prevents_contacting_queued_servers_after_expiry() {
+    let mut server = Server::start(Mode::StallInitialize, vec![]).await;
+    let configs = (0..12)
+        .map(|index| server.config(&format!("server-{index:02}")))
+        .collect::<Vec<_>>();
+    let discovery = tokio::spawn(async move { discover_mcp_tools(&configs).await });
+    for _request in 0..4 {
+        server.wait_for("initialize").await;
+    }
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::time::resume();
+    let report = discovery.await.unwrap().unwrap();
+    assert!(report.registrations().is_empty());
+    assert_eq!(report.diagnostics().len(), 12);
+    assert_eq!(server.requests(), 4);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn untrusted_remote_failures_are_bounded_and_diagnostics_are_redacted() {
+    for (mode, expected) in [
+        (Mode::InvalidJson, McpFailureKind::Protocol),
+        (Mode::RpcSecret, McpFailureKind::Protocol),
+        (Mode::Status(401), McpFailureKind::Authentication),
+        (Mode::Oversized, McpFailureKind::ResponseTooLarge),
+    ] {
+        let server = Server::start(mode, vec![]).await;
+        let config = McpServerConfig::builder(
+            "redacted",
+            format!("{}?token=secret-query-value", server.url()),
+        )
+        .header("Authorization", "Bearer secret-query-value")
+        .build();
+        assert!(!format!("{config:?}").contains("secret-query-value"));
+        let report = discover_mcp_tools(&[config]).await.unwrap();
+        assert!(report.registrations().is_empty());
+        assert!(
+            matches!(report.diagnostics()[0].issue(), McpServerIssue::Unavailable { failure, .. } if *failure == expected)
+        );
+        assert!(!format!("{:?}", report).contains("secret-query-value"));
+        server.stop().await;
+    }
+}
+
+#[tokio::test]
+async fn redirects_are_not_followed_and_invalid_schemas_disable_only_their_server() {
+    let target = Server::start(Mode::Online, vec![tool("read")]).await;
+    let redirect = Server::start(Mode::Redirect(target.url()), vec![]).await;
+    let report = discover_mcp_tools(&[redirect.config("redirect")])
+        .await
+        .unwrap();
+    assert!(report.registrations().is_empty());
+    assert_eq!(target.requests(), 0);
+    let mut invalid = tool("invalid");
+    invalid["inputSchema"] = serde_json::json!({"type":"object","required":42});
+    let invalid = Server::start(Mode::Online, vec![invalid]).await;
+    let report = discover_mcp_tools(&[invalid.config("invalid"), target.config("target")])
+        .await
+        .unwrap();
+    assert_eq!(report.registrations().len(), 1);
+    assert!(matches!(
+        report.diagnostics()[0].issue(),
+        McpServerIssue::Unavailable {
+            failure: McpFailureKind::InvalidToolDefinition,
+            ..
+        }
+    ));
+    invalid.stop().await;
+    redirect.stop().await;
+    target.stop().await;
+}

--- a/crates/merry-mcp/src/tests/support.rs
+++ b/crates/merry-mcp/src/tests/support.rs
@@ -1,0 +1,288 @@
+use crate::{McpDiscovery, McpServerConfig};
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use futures_util::StreamExt;
+use merry_core::{
+    RuntimeJournalEvent, RuntimeJournalPayload, SessionId, ToolCallId, ToolCallResult, ToolName,
+};
+use merry_llm::{
+    FinishReason, ModelEvent, ModelName, ModelOutput, ModelResponse, ModelToolCall,
+    ModelToolCallId, ToolArguments, testing::FakeModelProvider,
+};
+use merry_runtime::{Runtime, StepContext, StepInput};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+use tokio::{net::TcpListener, sync::mpsc, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+pub(super) enum Mode {
+    Online,
+    Status(u16),
+    StallInitialize,
+    StallCall,
+    InvalidJson,
+    RpcSecret,
+    Oversized,
+    Redirect(String),
+    Paginated,
+}
+
+#[derive(Clone)]
+struct Settings {
+    mode: Mode,
+    tools: Vec<Value>,
+}
+
+struct ServerState {
+    settings: Mutex<Settings>,
+    events: mpsc::Sender<String>,
+    calls: AtomicUsize,
+    requests: AtomicUsize,
+    expire_session: AtomicBool,
+    shutdown: CancellationToken,
+}
+
+pub(super) struct Server {
+    address: SocketAddr,
+    state: Arc<ServerState>,
+    events: mpsc::Receiver<String>,
+    handle: Option<JoinHandle<std::io::Result<()>>>,
+}
+
+impl Server {
+    pub(super) async fn start(mode: Mode, tools: Vec<Value>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (sender, events) = mpsc::channel(128);
+        let state = Arc::new(ServerState {
+            settings: Mutex::new(Settings { mode, tools }),
+            events: sender,
+            calls: AtomicUsize::new(0),
+            requests: AtomicUsize::new(0),
+            expire_session: AtomicBool::new(false),
+            shutdown: CancellationToken::new(),
+        });
+        let app = Router::new()
+            .route("/mcp", post(handle))
+            .with_state(Arc::clone(&state));
+        let shutdown = state.shutdown.clone();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown.cancelled_owned())
+                .await
+        });
+        Self {
+            address,
+            state,
+            events,
+            handle: Some(handle),
+        }
+    }
+
+    pub(super) fn config(&self, id: &str) -> McpServerConfig {
+        McpServerConfig::builder(id, self.url()).build()
+    }
+    pub(super) fn url(&self) -> String {
+        format!("http://{}/mcp", self.address)
+    }
+    pub(super) fn calls(&self) -> usize {
+        self.state.calls.load(Ordering::SeqCst)
+    }
+    pub(super) fn requests(&self) -> usize {
+        self.state.requests.load(Ordering::SeqCst)
+    }
+    pub(super) fn set_mode(&self, mode: Mode) {
+        self.state.settings.lock().unwrap().mode = mode;
+    }
+    pub(super) fn set_tools(&self, tools: Vec<Value>) {
+        self.state.settings.lock().unwrap().tools = tools;
+    }
+    pub(super) fn expire_session(&self) {
+        self.state.expire_session.store(true, Ordering::SeqCst);
+    }
+    pub(super) async fn wait_for(&mut self, method: &str) {
+        loop {
+            let observed =
+                tokio::time::timeout(std::time::Duration::from_secs(10), self.events.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            if observed == method {
+                return;
+            }
+        }
+    }
+    pub(super) async fn stop(mut self) {
+        self.state.shutdown.cancel();
+        self.handle.take().unwrap().await.unwrap().unwrap();
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.state.shutdown.cancel();
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct WireRequest {
+    id: Option<u64>,
+    method: String,
+    params: Option<Value>,
+}
+
+async fn handle(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Json(request): Json<WireRequest>,
+) -> Response {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+    let _ = state.events.try_send(request.method.clone());
+    if request.method == "tools/call" {
+        state.calls.fetch_add(1, Ordering::SeqCst);
+    }
+    if request.method == "tools/call"
+        && state.expire_session.swap(false, Ordering::SeqCst)
+        && headers.contains_key("mcp-session-id")
+    {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let settings = state.settings.lock().unwrap().clone();
+    match &settings.mode {
+        Mode::Status(status) => return StatusCode::from_u16(*status).unwrap().into_response(),
+        Mode::StallInitialize if request.method == "initialize" => { state.shutdown.cancelled().await; return StatusCode::SERVICE_UNAVAILABLE.into_response(); }
+        Mode::StallCall if request.method == "tools/call" => { state.shutdown.cancelled().await; return StatusCode::SERVICE_UNAVAILABLE.into_response(); }
+        Mode::InvalidJson => return ([("content-type", "application/json")], "not-json secret-query-value").into_response(),
+        Mode::RpcSecret => return Json(json!({"jsonrpc":"2.0", "id":request.id, "error":{"code":-32603,"message":"secret-query-value", "data":{"credential":"secret-query-value"}}})).into_response(),
+        Mode::Oversized => return ([("content-type", "application/json")], "x".repeat(crate::client::MAX_RESPONSE_BYTES + 1)).into_response(),
+        Mode::Redirect(target) => return (StatusCode::TEMPORARY_REDIRECT, [("location", target)]).into_response(),
+        _ => {}
+    }
+    let result = match request.method.as_str() {
+        "initialize" => {
+            json!({"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"fixture","version":"1"}})
+        }
+        "notifications/initialized" => return StatusCode::ACCEPTED.into_response(),
+        "tools/list" if matches!(settings.mode, Mode::Paginated) => {
+            if request
+                .params
+                .as_ref()
+                .and_then(|params| params.get("cursor"))
+                .is_some()
+            {
+                json!({"tools": settings.tools.iter().skip(1).collect::<Vec<_>>()})
+            } else {
+                json!({"tools": settings.tools.iter().take(1).collect::<Vec<_>>(),"nextCursor":"next"})
+            }
+        }
+        "tools/list" => json!({"tools":settings.tools}),
+        "tools/call" => json!({"content":[{"type":"text","text":"done"}],"isError":false}),
+        _ => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    let mut response =
+        Json(json!({"jsonrpc":"2.0","id":request.id,"result":result})).into_response();
+    if request.method == "initialize" {
+        response.headers_mut().insert(
+            "Mcp-Session-Id",
+            HeaderValue::from_static("fixture-session"),
+        );
+    }
+    response
+}
+
+pub(super) fn tool(name: &str) -> Value {
+    json!({"name":name,"description":format!("Tool {name}"),"inputSchema":{"type":"object","properties":{}}})
+}
+
+pub(super) fn text_provider() -> FakeModelProvider {
+    FakeModelProvider::new(vec![Ok(ModelEvent::Completed {
+        response: ModelResponse::new(vec![ModelOutput::text("done")], FinishReason::Stop, None),
+    })])
+}
+
+pub(super) fn call_provider(name: &ToolName, count: usize) -> FakeModelProvider {
+    FakeModelProvider::new_turns(
+        (0..count)
+            .map(|index| {
+                vec![Ok(ModelEvent::Completed {
+                    response: ModelResponse::new(
+                        vec![ModelOutput::tool_call(ModelToolCall::new(
+                            ModelToolCallId::new(&format!("call-{index}")).unwrap(),
+                            name.clone(),
+                            ToolArguments::new(Default::default()),
+                        ))],
+                        FinishReason::ToolCalls,
+                        None,
+                    ),
+                })]
+            })
+            .collect(),
+    )
+}
+
+pub(super) fn runtime(id: &str, discovery: McpDiscovery, provider: &FakeModelProvider) -> Runtime {
+    let builder = Runtime::builder(SessionId::new(id).unwrap())
+        .fully_trusted_tools()
+        .model_provider(
+            Arc::new(provider.clone()),
+            ModelName::new("fixture").unwrap(),
+        );
+    discovery
+        .into_parts()
+        .0
+        .into_iter()
+        .fold(builder, |builder, registration| {
+            builder.register_tool(registration.tool)
+        })
+        .build()
+        .unwrap()
+}
+
+pub(super) async fn step(runtime: &Runtime) {
+    let events = runtime
+        .step(
+            StepInput::user_text("continue").unwrap(),
+            StepContext::default(),
+        )
+        .unwrap()
+        .collect::<Vec<_>>()
+        .await;
+    assert!(!events.is_empty());
+}
+
+pub(super) async fn next_call(runtime: &Runtime) -> ToolCallId {
+    step(runtime).await;
+    runtime
+        .pending_tool_calls()
+        .await
+        .first()
+        .unwrap()
+        .id()
+        .clone()
+}
+
+pub(super) fn resolved(events: &[RuntimeJournalEvent]) -> &ToolCallResult {
+    events
+        .iter()
+        .find_map(|event| match &event.payload {
+            RuntimeJournalPayload::ToolCallResolved { result } => Some(result),
+            _ => None,
+        })
+        .expect("tool call resolves durably")
+}

--- a/crates/merry-runtime/src/error.rs
+++ b/crates/merry-runtime/src/error.rs
@@ -185,6 +185,12 @@ pub enum RuntimeError {
         name: ToolName,
     },
 
+    /// A resumed session was constructed with a different external tool catalog.
+    #[error(
+        "external tool catalog differs from the saved session; restore its definitions and bind unavailable tools instead of removing or replacing them"
+    )]
+    ExternalToolCatalogMismatch,
+
     /// Runtime-reserved provider-visible tool name was registered by an application.
     #[error("tool name {name} is reserved by the runtime")]
     ReservedToolName {
@@ -419,6 +425,7 @@ impl RuntimeError {
             }
             Self::ToolCallAlreadyResolved { .. } => "tool_call_already_resolved",
             Self::DuplicateToolRegistration { .. } => "duplicate_tool_registration",
+            Self::ExternalToolCatalogMismatch => "external_tool_catalog_mismatch",
             Self::ReservedToolName { .. } => "reserved_tool_name",
             Self::InvalidToolInputSchema { .. } => "invalid_tool_input_schema",
             Self::BridgeToolsNotAllowed { .. } => "bridge_tools_not_allowed",

--- a/crates/merry-runtime/src/lib.rs
+++ b/crates/merry-runtime/src/lib.rs
@@ -64,6 +64,7 @@ mod token_estimate;
 mod tool;
 mod tool_admission;
 mod tool_api;
+mod tool_catalog;
 mod tool_input_validation;
 mod trajectory;
 mod trajectory_replay;
@@ -169,6 +170,7 @@ pub use tool::{
 };
 pub use tool_admission::ToolAdmission;
 pub use tool_api::{Tool, ToolBuildError};
+pub use tool_catalog::LoadedSession;
 pub use user_input::{
     MAX_USER_IMAGE_DIMENSION, MAX_USER_IMAGE_PIXELS, MAX_USER_IMAGE_PNG_BYTES,
     MAX_USER_IMAGE_TOTAL_PNG_BYTES, MAX_USER_IMAGES, StepInput, UserImageInput, UserMessageInput,

--- a/crates/merry-runtime/src/runtime.rs
+++ b/crates/merry-runtime/src/runtime.rs
@@ -976,6 +976,7 @@ mod tests {
     mod provider_step_turn_lifecycle;
     mod rolling_compaction;
     mod session_resume;
+    mod tool_catalog;
     mod tool_execution;
     mod tool_submit_cancellation;
     mod uncertainty_review;

--- a/crates/merry-runtime/src/runtime/builder.rs
+++ b/crates/merry-runtime/src/runtime/builder.rs
@@ -3,8 +3,9 @@ use super::checkpoint_ref_tool::merry_read_checkpoint_ref_tool;
 use super::{AcceptedLocalWorkspaceProcessRunner, Runtime, RuntimeInner};
 use crate::{
     AcceptedLocalWorkspaceProcessAdmission, CitationCompactionPolicy, CompactedCheckpoint,
-    FileSessionStore, ProcessRunner, ProjectRules, PromptProfile, RuntimeCapabilities,
-    RuntimeError, RuntimeModelRole, RuntimeProfile, SkillCatalog, TaskAnchor, ToolAdmission,
+    FileSessionStore, LoadedSession, ProcessRunner, ProjectRules, PromptProfile,
+    RuntimeCapabilities, RuntimeError, RuntimeModelRole, RuntimeProfile, SkillCatalog, TaskAnchor,
+    ToolAdmission,
     artifact::ArtifactContent,
     memory::{MemoryActivationSource, StoredMemoryActivationSource},
     model_config::RuntimeModelConfigs,
@@ -636,6 +637,13 @@ impl RuntimeBuilder {
         self
     }
 
+    /// Installs a session that was already loaded by the runtime boundary.
+    #[must_use]
+    pub fn with_loaded_session(mut self, loaded: LoadedSession) -> Self {
+        self.loaded_session = Some(loaded.into_state());
+        self
+    }
+
     /// Loads persisted session state from an injected filesystem store, then builds a runtime.
     pub async fn resume_from_store(
         mut self,
@@ -721,8 +729,14 @@ impl RuntimeBuilder {
         });
 
         let loaded_from_store = self.loaded_session.is_some();
+        let external_tool_catalog = tool_registry.external_tool_catalog()?;
         let mut session = match self.loaded_session {
-            Some(session) => session,
+            Some(session) => {
+                if session.external_tool_catalog() != &external_tool_catalog {
+                    return Err(RuntimeError::ExternalToolCatalogMismatch);
+                }
+                session
+            }
             None => {
                 if let Some(checkpoint) = self
                     .compacted_checkpoint
@@ -740,7 +754,10 @@ impl RuntimeBuilder {
                         }
                     }
                 }
-                let mut session = SessionState::new(self.session_id.clone());
+                let mut session = SessionState::with_external_tool_catalog(
+                    self.session_id.clone(),
+                    external_tool_catalog,
+                );
                 for (artifact, content) in self.compacted_checkpoint_evidence {
                     if crate::session::is_runtime_reserved_artifact_id(artifact.id()) {
                         return Err(RuntimeError::ReservedArtifactId {

--- a/crates/merry-runtime/src/runtime/session_access.rs
+++ b/crates/merry-runtime/src/runtime/session_access.rs
@@ -16,6 +16,16 @@ use std::sync::Arc;
 const TOOL_ABANDONED_BY_SETTLEMENT_CODE: &str = "tool_abandoned_by_run_settlement";
 
 impl Runtime {
+    /// Returns the session's frozen external definitions, independently of availability.
+    pub async fn external_tool_catalog(&self) -> merry_core::SessionToolCatalog {
+        self.inner
+            .session
+            .lock()
+            .await
+            .external_tool_catalog()
+            .clone()
+    }
+
     /// Records exact artifact state into the owning session and returns observable events.
     ///
     /// When this is the first observable action in the session, `SessionStarted`

--- a/crates/merry-runtime/src/runtime/tests/tool_catalog.rs
+++ b/crates/merry-runtime/src/runtime/tests/tool_catalog.rs
@@ -1,0 +1,203 @@
+use super::*;
+use crate::{FileSessionStore, LoadedSession, SessionStoreError};
+use merry_core::{
+    ExternalToolBinding, ToolAdapterId, ToolBindingName, ToolSourceFingerprint, ToolSourceId,
+};
+
+fn external_tool(name: &str, description: &str) -> RegisteredTool {
+    let spec = ToolSpec::new(
+        ToolName::new(name).unwrap(),
+        description,
+        registered_tool_spec().input_schema().clone(),
+    )
+    .unwrap();
+    RegisteredTool::read_only(spec, Arc::new(SuccessfulToolExecutor::new())).with_external_binding(
+        ExternalToolBinding::new(
+            ToolAdapterId::new("fixture").unwrap(),
+            ToolSourceId::new("server").unwrap(),
+            ToolBindingName::new(name).unwrap(),
+            ToolSourceFingerprint::new("endpoint").unwrap(),
+        ),
+    )
+}
+
+#[tokio::test]
+async fn external_catalog_round_trip_keeps_actual_provider_tools_and_prefix() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = session_id("external-catalog");
+    let provider = RecordingModelProvider::new();
+    let runtime = Runtime::builder(id.clone())
+        .model_provider(Arc::new(provider.clone()), model_name())
+        .register_tool(external_tool("zeta", "Stable zeta"))
+        .register_tool(external_tool("alpha", "Stable alpha"))
+        .build()
+        .unwrap();
+    collect_step(&runtime, "before resume", StepContext::default()).await;
+    runtime.save_session_to(store.clone()).await.unwrap();
+    assert_eq!(
+        LoadedSession::load(&store, &id)
+            .await
+            .unwrap()
+            .external_tool_catalog()
+            .clone(),
+        runtime.external_tool_catalog().await
+    );
+    let resumed = Runtime::builder(id)
+        .model_provider(Arc::new(provider.clone()), model_name())
+        .register_tool(external_tool("zeta", "Stable zeta"))
+        .register_tool(external_tool("alpha", "Stable alpha"))
+        .resume_from_store(store)
+        .await
+        .unwrap();
+    collect_step(&resumed, "after resume", StepContext::default()).await;
+    let requests = provider.recorded_requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].tools(), requests[1].tools());
+    assert_eq!(
+        requests[0].stable_prefix_hash(),
+        requests[1].stable_prefix_hash()
+    );
+}
+
+#[tokio::test]
+async fn resume_rejects_catalog_removal_addition_reordering_and_definition_changes() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = session_id("catalog-drift");
+    let original = || vec![external_tool("one", "One"), external_tool("two", "Two")];
+    let runtime = original()
+        .into_iter()
+        .fold(Runtime::builder(id.clone()), RuntimeBuilder::register_tool)
+        .build()
+        .unwrap();
+    runtime.save_session_to(store.clone()).await.unwrap();
+    let variants = [
+        vec![external_tool("one", "One")],
+        vec![
+            external_tool("one", "One"),
+            external_tool("two", "Two"),
+            external_tool("three", "Three"),
+        ],
+        vec![external_tool("two", "Two"), external_tool("one", "One")],
+        vec![external_tool("one", "Changed"), external_tool("two", "Two")],
+    ];
+    for tools in variants {
+        let result = tools
+            .into_iter()
+            .fold(Runtime::builder(id.clone()), RuntimeBuilder::register_tool)
+            .resume_from_store(store.clone())
+            .await;
+        assert!(matches!(
+            result,
+            Err(RuntimeError::ExternalToolCatalogMismatch)
+        ));
+    }
+}
+
+#[tokio::test]
+async fn an_empty_catalog_stays_empty_after_resume() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = session_id("empty-catalog");
+    let runtime = Runtime::builder(id.clone()).build().unwrap();
+    runtime.save_session_to(store.clone()).await.unwrap();
+    assert!(
+        LoadedSession::load(&store, &id)
+            .await
+            .unwrap()
+            .external_tool_catalog()
+            .entries()
+            .is_empty()
+    );
+    let result = Runtime::builder(id)
+        .register_tool(external_tool("late", "Late"))
+        .resume_from_store(store)
+        .await;
+    assert!(matches!(
+        result,
+        Err(RuntimeError::ExternalToolCatalogMismatch)
+    ));
+}
+
+#[tokio::test]
+async fn catalog_loader_rejects_missing_or_null_catalogs_instead_of_rediscovering() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = session_id("corrupt-catalog");
+    Runtime::builder(id.clone())
+        .build()
+        .unwrap()
+        .save_session_to(store.clone())
+        .await
+        .unwrap();
+    let path = temp.path().join(id.as_str()).join("state.json");
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+    for catalog in [None, Some(serde_json::Value::Null)] {
+        match catalog {
+            None => {
+                document
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("external_tool_catalog");
+            }
+            Some(catalog) => document["external_tool_catalog"] = catalog,
+        }
+        tokio::fs::write(&path, serde_json::to_vec(&document).unwrap())
+            .await
+            .unwrap();
+        assert!(matches!(
+            LoadedSession::load(&store, &id).await,
+            Err(RuntimeError::SessionStore {
+                source: SessionStoreError::Json { .. }
+            })
+        ));
+        assert!(matches!(
+            Runtime::builder(id.clone())
+                .resume_from_store(store.clone())
+                .await,
+            Err(RuntimeError::SessionStore {
+                source: SessionStoreError::Json { .. }
+            })
+        ));
+    }
+}
+
+#[tokio::test]
+async fn resume_rejects_unsupported_formats_without_migrating_the_document() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = FileSessionStore::new(temp.path());
+    let id = session_id("unsupported-format");
+    Runtime::builder(id.clone())
+        .build()
+        .unwrap()
+        .save_session_to(store.clone())
+        .await
+        .unwrap();
+    let path = temp.path().join(id.as_str()).join("state.json");
+    let mut document: serde_json::Value =
+        serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+    document
+        .as_object_mut()
+        .unwrap()
+        .remove("external_tool_catalog");
+    for version in [3, 5] {
+        document["format_version"] = json!(version);
+        let bytes = serde_json::to_vec(&document).unwrap();
+        tokio::fs::write(&path, &bytes).await.unwrap();
+        assert!(matches!(
+            LoadedSession::load(&store, &id).await,
+            Err(RuntimeError::SessionStore {
+                source: SessionStoreError::UnsupportedFormatVersion { actual }
+            }) if actual == version
+        ));
+        assert!(matches!(
+            Runtime::builder(id.clone()).resume_from_store(store.clone()).await,
+            Err(RuntimeError::SessionStore {
+                source: SessionStoreError::UnsupportedFormatVersion { actual }
+            }) if actual == version
+        ));
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), bytes);
+    }
+}

--- a/crates/merry-runtime/src/session/mod.rs
+++ b/crates/merry-runtime/src/session/mod.rs
@@ -73,10 +73,18 @@ pub(crate) struct SessionState {
     resolved_tool_calls: BTreeSet<ToolCallId>,
     usage: Option<merry_core::SessionUsage>,
     trajectory_snapshot: Option<TrajectorySnapshot>,
+    external_tool_catalog: merry_core::SessionToolCatalog,
 }
 
 impl SessionState {
     pub(crate) fn new(session_id: SessionId) -> Self {
+        Self::with_external_tool_catalog(session_id, merry_core::SessionToolCatalog::default())
+    }
+
+    pub(crate) fn with_external_tool_catalog(
+        session_id: SessionId,
+        external_tool_catalog: merry_core::SessionToolCatalog,
+    ) -> Self {
         Self {
             session_id,
             next_sequence: 0,
@@ -102,11 +110,16 @@ impl SessionState {
             resolved_tool_calls: BTreeSet::new(),
             usage: None,
             trajectory_snapshot: None,
+            external_tool_catalog,
         }
     }
 
     pub(crate) fn trajectory_snapshot(&self) -> Option<TrajectorySnapshot> {
         self.trajectory_snapshot.clone()
+    }
+
+    pub(crate) fn external_tool_catalog(&self) -> &merry_core::SessionToolCatalog {
+        &self.external_tool_catalog
     }
 
     pub(crate) fn set_trajectory_snapshot(&mut self, snapshot: TrajectorySnapshot) {

--- a/crates/merry-runtime/src/session/persistence.rs
+++ b/crates/merry-runtime/src/session/persistence.rs
@@ -36,7 +36,7 @@ use std::{
     sync::Arc,
 };
 
-const CURRENT_SESSION_STATE_FORMAT_VERSION: u32 = 3;
+const CURRENT_SESSION_STATE_FORMAT_VERSION: u32 = 4;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct StoredSessionDocumentHeader {
@@ -66,6 +66,7 @@ struct StoredSessionDocument {
     terminal_plans: Vec<PlanSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     trajectory_snapshot: Option<TrajectorySnapshot>,
+    external_tool_catalog: merry_core::SessionToolCatalog,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -330,6 +331,7 @@ impl SessionState {
             active_plan: view.active_plan.map(PlanState::persisted),
             terminal_plans: view.terminal_plans.to_vec(),
             trajectory_snapshot: view.trajectory_snapshot.cloned(),
+            external_tool_catalog: self.external_tool_catalog.clone(),
         };
         let document_bytes = serde_json::to_vec_pretty(&document)?;
         Ok(PersistableSessionBundle {
@@ -423,6 +425,7 @@ impl SessionState {
                 .collect::<BTreeSet<_>>(),
             usage: document.usage,
             trajectory_snapshot: document.trajectory_snapshot,
+            external_tool_catalog: document.external_tool_catalog,
         };
 
         if let Some(anchor) = document.task_anchor {

--- a/crates/merry-runtime/src/session/tests/persistence.rs
+++ b/crates/merry-runtime/src/session/tests/persistence.rs
@@ -179,7 +179,8 @@ async fn session_state_round_trip_preserves_turns_user_artifact_and_projections(
 
 fn current_document() -> serde_json::Value {
     serde_json::json!({
-        "format_version": 3,
+        "format_version": 4,
+        "external_tool_catalog": { "format_version": 1, "entries": [] },
         "session_id": session_id(),
         "next_sequence": 0,
         "session_started": false,
@@ -973,7 +974,7 @@ async fn session_state_current_format_without_plan_round_trips_current_format() 
             .expect("rewritten state reads"),
     )
     .expect("rewritten state is JSON");
-    assert_eq!(rewritten["format_version"], 3);
+    assert_eq!(rewritten["format_version"], 4);
     assert_eq!(rewritten["active_plan"], serde_json::Value::Null);
     assert_eq!(rewritten["terminal_plans"], serde_json::json!([]));
 }

--- a/crates/merry-runtime/src/tool.rs
+++ b/crates/merry-runtime/src/tool.rs
@@ -1065,6 +1065,7 @@ fn validate_proposal_evidence_matches_action_kind(
 #[derive(Clone)]
 pub struct RegisteredTool {
     spec: ToolSpec,
+    external_binding: Option<merry_core::ExternalToolBinding>,
     executor: Arc<dyn ToolExecutor>,
     action_kind: ToolActionKind,
     proposals_enabled: bool,
@@ -1086,12 +1087,28 @@ impl RegisteredTool {
     ) -> Self {
         Self {
             spec,
+            external_binding: None,
             executor,
             action_kind,
             proposals_enabled: false,
             runner: ToolRunner::Runtime,
             concurrency: ToolConcurrency::Exclusive,
         }
+    }
+
+    /// Attaches a stable adapter binding for session catalog persistence.
+    ///
+    /// Binding metadata is never rendered into the model's tool definition.
+    #[must_use]
+    pub fn with_external_binding(mut self, binding: merry_core::ExternalToolBinding) -> Self {
+        self.external_binding = Some(binding);
+        self
+    }
+
+    /// Returns the adapter identity, if this tool belongs to an external catalog.
+    #[must_use]
+    pub fn external_binding(&self) -> Option<&merry_core::ExternalToolBinding> {
+        self.external_binding.as_ref()
     }
 
     /// Enables read-only proposal evidence for a mutating tool.
@@ -1129,6 +1146,7 @@ impl RegisteredTool {
     pub fn bridge(spec: ToolSpec) -> Self {
         Self {
             spec,
+            external_binding: None,
             executor: Arc::new(BridgeExecutor),
             action_kind: ToolActionKind::ReadOnly,
             proposals_enabled: false,
@@ -1251,6 +1269,23 @@ impl ToolRegistry {
             .filter_map(|name| self.tools.get(name))
             .map(|entry| entry.tool.spec().clone())
             .collect()
+    }
+
+    pub(crate) fn external_tool_catalog(
+        &self,
+    ) -> Result<merry_core::SessionToolCatalog, merry_core::CoreError> {
+        merry_core::SessionToolCatalog::new(
+            self.order
+                .iter()
+                .filter_map(|name| {
+                    let tool = &self.tools.get(name)?.tool;
+                    Some(merry_core::SessionToolCatalogEntry::new(
+                        tool.spec().clone(),
+                        tool.external_binding()?.clone(),
+                    ))
+                })
+                .collect(),
+        )
     }
 
     pub(crate) fn registered_tool(&self, name: &ToolName) -> Option<&RegisteredTool> {

--- a/crates/merry-runtime/src/tool_catalog.rs
+++ b/crates/merry-runtime/src/tool_catalog.rs
@@ -1,0 +1,33 @@
+use crate::{FileSessionStore, RuntimeError, session::SessionState};
+use merry_core::{SessionId, SessionToolCatalog};
+
+/// A validated persisted session loaded once before adapter-specific rebinding.
+///
+/// The runtime owns the complete session state. Surface adapters may inspect the
+/// frozen external catalog before building tools, then transfer this handle into
+/// [`crate::RuntimeBuilder`] without loading the session a second time.
+pub struct LoadedSession {
+    state: SessionState,
+}
+
+impl LoadedSession {
+    /// Loads and validates one session from the supplied store.
+    pub async fn load(
+        store: &FileSessionStore,
+        session_id: &SessionId,
+    ) -> Result<Self, RuntimeError> {
+        Ok(Self {
+            state: SessionState::load_from(store, session_id).await?,
+        })
+    }
+
+    /// Returns the frozen external definitions, independently of availability.
+    #[must_use]
+    pub fn external_tool_catalog(&self) -> &SessionToolCatalog {
+        self.state.external_tool_catalog()
+    }
+
+    pub(crate) fn into_state(self) -> SessionState {
+        self.state
+    }
+}

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -93,6 +93,12 @@ max_model_turns = 2048
 # User-configured MCP servers are trusted external tools. HTTP MCP endpoints
 # are allowed to use the network because registering them in global config is
 # an explicit user grant.
+# Discovery failures warn and do not stop Merry (5 seconds per server, 10 seconds
+# total). Session tool definitions are frozen, including across resume. Offline
+# saved tools can reconnect on use after a short cooldown; calls are not replayed.
+# New tools, changed definitions, or changed endpoints require a new session.
+# Removing a server or narrowing its allowlist disables execution immediately on
+# the next resume, without deleting its saved provider-visible definitions.
 #
 # [mcp.context7]
 # url = "https://mcp.example.test/mcp"


### PR DESCRIPTION
## Summary
- Continue CLI/TUI startup when remote MCP discovery fails, with visible warnings and bounded discovery; keep headless JSONL output machine-readable.
- Persist external tool definitions, bindings, and order in the session. Resume preserves the provider-visible catalog even when servers are offline or configuration changes disable execution.
- Reconnect eligible servers lazily after a cooldown, and rebuild expired HTTP MCP sessions after a session-bearing request returns 404. Never replay the failed call.
- Keep catalog conversion, connection state, runtime session ownership, and CLI diagnostics in their owning layers. Pass loaded sessions into runtime builders without a second store read.
- Add deterministic startup, resume, execution, session-expiration, catalog, and presentation regression coverage.

## Session Contract
- Session format 4 requires an external tool catalog, including an explicitly empty catalog. Historical formats are rejected without migration; Merry is unreleased and no compatibility layer is added.
- New or incompatible tool definitions require a new session. Connectivity changes do not silently change the frozen catalog; this protects the tool prefix, not every cause of provider cache expiration.
- File-size-only refactoring is intentionally out of scope.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`: 1996 passed, 9 ignored, 0 failed
- Python native binding rebuilt with `test-utils`
- Ruff format/check and ty: passed
- Python tests: 51 passed
- Python example/probe compile checks and `uv build`: passed
- `git diff --check`: passed