### PR TITLE
fix(sandbox): restore SSH bootstrap and network request ceilings

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,15 @@ Optional development paths such as `.rustup/toolchains` remain built in, but
 missing sources are skipped without creating directories beneath a read-only
 HOME. This applies to both inner-only and outer+inner execution.
 
+`[permissions] network` is the inner sandbox's network capability ceiling and
+defaults to `true`. It does not preauthorize network access: ordinary actions
+remain network-isolated, and each action must request and obtain its own network
+approval. With `network = false`, network requests are rejected before review
+or execution, including in fully trusted review mode; approval cannot override
+the ceiling. The setting is inherited by new process sessions and does not
+restrict model-provider or configured MCP connections. Explicit `--no-sandbox`
+host execution remains outside this network-isolation boundary.
+
 Trusted `readonly_paths` and `readwrite_paths` are preauthorized in the inner
 sandbox at their declared access level. `review_paths` marks existing subtrees
 within these grants for **per-action** review, without adding a new grant or
@@ -291,15 +300,24 @@ but new or changed host keys are not automatically accepted and host trust files
 are not made writable. No `StrictHostKeyChecking` or SSH configuration override
 is injected.
 
-System SSH configuration already exposed by the filesystem policy remains
-available, independently of `ssh_agent`. Before entering a user namespace, Merry
+Enabling `ssh_agent` imports `/etc/passwd` and `/etc/group` for client account
+lookup, plus `/etc/ssh/ssh_config` and `/etc/ssh/ssh_config.d`, read-only. It does
+not require granting the whole `/etc` directory or import SSH server
+configuration, host private keys, or shadow password databases. These imports
+obey explicit path denials; Include targets outside the existing sandbox view
+still need an explicit `readonly_paths` grant. System SSH configuration already
+exposed by filesystem rules remains available when `ssh_agent` is disabled.
+
+Before entering a user namespace, Merry
 validates regular configuration files against OpenSSH's owner/write-mode rules.
 Safe root-owned files that would otherwise become UID 65534 are supplied as
 unchanged, read-only private snapshots at their original paths. Snapshots travel
 through sealed anonymous-memory FDs and are consumed by bubblewrap; the host
-files are never modified. Both the outer and inner mount plans preserve path
-denials and per-action review. This does not import `/etc/ssh` if it was not
-already exposed or make unsafe/unknown ownership acceptable.
+files are never modified. Snapshot mounts replace the corresponding original
+file binds instead of stacking a second mount that inner actions cannot rebind.
+Both the outer and inner mount plans preserve path denials and per-action review.
+This does not import the whole `/etc/ssh` directory or make unsafe/unknown
+ownership acceptable.
 
 Snapshot discovery starts at `/etc/ssh/ssh_config` and follows static recursive
 `Include` paths, quoted filenames, globs, and symlinks within the allowed view.

--- a/crates/merry-cli/src/config/mod.rs
+++ b/crates/merry-cli/src/config/mod.rs
@@ -228,6 +228,18 @@ impl MerryConfig {
         Ok(rules)
     }
 
+    /// Returns whether inner process actions may request network capability.
+    ///
+    /// Defaults to true. This is a capability ceiling, not preauthorization:
+    /// enabled requests still require approval for each action.
+    pub fn network_requests_allowed(&self) -> bool {
+        self.raw
+            .permissions
+            .as_ref()
+            .and_then(|permissions| permissions.network)
+            .unwrap_or(true)
+    }
+
     /// Returns host IPC integrations explicitly enabled by trusted global
     /// configuration. These form the outer sandbox capability ceiling and are
     /// forwarded to inner process sandboxes when their endpoints are present.
@@ -398,6 +410,7 @@ struct GlobalToml {
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 struct PermissionsToml {
+    network: Option<bool>,
     ssh_agent: Option<bool>,
     dbus: Option<bool>,
     gpg_agent: Option<bool>,

--- a/crates/merry-cli/src/config/tests/permissions.rs
+++ b/crates/merry-cli/src/config/tests/permissions.rs
@@ -5,6 +5,26 @@ use merry_runtime::{PathAccess, PathAccessRuleSource};
 use std::path::{Path, PathBuf};
 
 #[test]
+fn network_capability_ceiling_defaults_to_enabled_and_preserves_false() {
+    let paths = XdgPaths::from_parts(home(), None, None);
+    for (text, allowed) in [
+        ("", true),
+        ("[permissions]\n", true),
+        ("[permissions]\nnetwork = true\n", true),
+        ("[permissions]\nnetwork = false\n", false),
+    ] {
+        let config = MerryConfig::load_optional_from_text(Some(text), &paths)
+            .unwrap()
+            .unwrap();
+        assert_eq!(config.network_requests_allowed(), allowed, "{text}");
+    }
+    for value in ["0", "\"false\"", "[]"] {
+        let text = format!("[permissions]\nnetwork = {value}\n");
+        assert!(MerryConfig::load_optional_from_text(Some(&text), &paths).is_err());
+    }
+}
+
+#[test]
 fn review_paths_restrict_declared_subtrees_without_changing_preauthorization() {
     let paths = XdgPaths::from_parts(home(), None, None);
     let config = MerryConfig::load_optional_from_text(

--- a/crates/merry-cli/src/runtime_config.rs
+++ b/crates/merry-cli/src/runtime_config.rs
@@ -122,6 +122,7 @@ pub(crate) fn action_process_backend_options(
         .collect();
     Ok(ActionProcessBackendOptions::new()
         .with_path_rules(path_rules)
+        .with_network_requests_allowed(config.is_none_or(MerryConfig::network_requests_allowed))
         .with_environment_overrides(environment_overrides))
 }
 
@@ -166,6 +167,9 @@ pub(crate) async fn prepared_action_process_backend_options(
         None => Ok(options),
     }
 }
+
+#[cfg(all(test, target_os = "linux"))]
+mod network_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/merry-cli/src/runtime_config/network_tests.rs
+++ b/crates/merry-cli/src/runtime_config/network_tests.rs
@@ -1,0 +1,152 @@
+use super::action_process_backend_options;
+use crate::{
+    config::{MerryConfig, XdgPaths},
+    runtime_events::{collect_runtime_step_events, first_pending_tool_call},
+    testing::{ScriptedProvider, model_name, tool_call},
+};
+use merry_core::{RuntimeJournalPayload, SessionId, ToolCallResultStatus};
+use merry_process::{LocalProcessBackend, ProcessBackend, ProcessBackendMode};
+use merry_runtime::{
+    PermissionAdmissionContext, PermissionAdmissionDecision, PermissionAdmissionFuture,
+    PermissionAdmissionSource, PermissionRequest, PermissionReviewMode, Runtime, StepContext,
+    StepInput, ToolExecutionContext, request_permissions_tool,
+};
+use serde_json::json;
+use std::{
+    fs,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+#[derive(Default)]
+struct ApprovingReview {
+    calls: AtomicUsize,
+}
+
+impl ApprovingReview {
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl PermissionAdmissionSource for ApprovingReview {
+    fn review<'a>(
+        &'a self,
+        _request: PermissionRequest,
+        _context: PermissionAdmissionContext,
+    ) -> PermissionAdmissionFuture<'a> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async {
+            Ok(PermissionAdmissionDecision::approved(
+                "approve the test action",
+            ))
+        })
+    }
+}
+
+#[tokio::test]
+async fn network_config_is_a_ceiling_not_preauthorization() {
+    for (config_text, allowed, mode) in [
+        (None, true, PermissionReviewMode::HostDecisionOnly),
+        (Some(""), true, PermissionReviewMode::HostDecisionOnly),
+        (
+            Some("[permissions]\nnetwork = true\n"),
+            true,
+            PermissionReviewMode::HostDecisionOnly,
+        ),
+        (
+            Some("[permissions]\nnetwork = false\n"),
+            false,
+            PermissionReviewMode::HostDecisionOnly,
+        ),
+        (
+            Some("[permissions]\nnetwork = false\n"),
+            false,
+            PermissionReviewMode::Required,
+        ),
+        (
+            Some("[permissions]\nnetwork = false\n"),
+            false,
+            PermissionReviewMode::FullyTrusted,
+        ),
+    ] {
+        let fixture = tempfile::tempdir().unwrap();
+        let workspace = fixture.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+        let paths = XdgPaths::from_parts(fixture.path().join("home"), None, None);
+        let config = MerryConfig::load_optional_from_text(config_text, &paths).unwrap();
+        let options = action_process_backend_options(config.as_ref()).unwrap();
+        assert_eq!(options.network_requests_allowed(), allowed);
+        let backend =
+            LocalProcessBackend::new(&workspace, ProcessBackendMode::Isolated, options).unwrap();
+        let provider = ScriptedProvider::new(
+            (0..2)
+                .map(|index| {
+                    vec![Ok(tool_call(
+                        &format!("network-{index}"),
+                        "request_permissions",
+                        json!({
+                            "requested": {"network": true},
+                            "for_action": {
+                                "command": "printf x >> network-executed",
+                                "cwd": null
+                            }
+                        })
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                    )
+                    .unwrap())]
+                })
+                .collect(),
+        );
+        let review = Arc::new(ApprovingReview::default());
+        let runtime = Runtime::builder(SessionId::new("network-ceiling").unwrap())
+            .model_provider(Arc::new(provider), model_name())
+            .register_tool(request_permissions_tool().unwrap())
+            .permissioned_process_runner_factory(backend.new_session().permissioned_factory())
+            .permission_review_mode(mode)
+            .permission_admission_source(review.clone())
+            .build()
+            .unwrap();
+        for completed in 1..=2 {
+            let events = collect_runtime_step_events(
+                &runtime,
+                StepInput::user_text("Run the network probe after permission admission.").unwrap(),
+                StepContext::default(),
+            )
+            .await
+            .unwrap();
+            let pending = first_pending_tool_call(&events).unwrap();
+            let events = runtime
+                .execute_tool_call(pending.id(), ToolExecutionContext::default())
+                .await
+                .unwrap();
+            let result = events
+                .iter()
+                .find_map(|event| match &event.payload {
+                    RuntimeJournalPayload::ToolCallResolved { result } => Some(result),
+                    _ => None,
+                })
+                .unwrap();
+            if allowed {
+                assert_eq!(result.status(), ToolCallResultStatus::Succeeded);
+                assert_eq!(review.call_count(), completed);
+                assert_eq!(
+                    fs::read(workspace.join("network-executed")).unwrap().len(),
+                    completed
+                );
+            } else {
+                assert_eq!(result.status(), ToolCallResultStatus::Failed);
+                assert_eq!(
+                    result.diagnostic().unwrap().code(),
+                    "permission_request_blocked"
+                );
+                assert_eq!(review.call_count(), 0);
+                assert!(!workspace.join("network-executed").exists());
+            }
+        }
+    }
+}

--- a/crates/merry-cli/src/sandbox/integrations.rs
+++ b/crates/merry-cli/src/sandbox/integrations.rs
@@ -109,6 +109,23 @@ pub(super) fn host_integration_access_plan(
     for integration in &host.host_integrations {
         match integration {
             HostIntegration::SshAgent => {
+                for (path, kind) in [
+                    ("/etc/passwd", HostPathKind::RegularFile),
+                    ("/etc/group", HostPathKind::RegularFile),
+                    ("/etc/ssh/ssh_config", HostPathKind::RegularFile),
+                    ("/etc/ssh/ssh_config.d", HostPathKind::Directory),
+                ] {
+                    let path = Path::new(path);
+                    if probe
+                        .metadata(path)
+                        .is_some_and(|metadata| metadata.kind() == kind)
+                    {
+                        plan.mounts.push(GraphicalMount {
+                            source: path.to_path_buf(),
+                            destination: path.to_path_buf(),
+                        });
+                    }
+                }
                 for path in merry_process::ssh_known_hosts(host.xdg_paths.home()) {
                     if probe
                         .metadata(&path)

--- a/crates/merry-cli/src/sandbox/mounts.rs
+++ b/crates/merry-cli/src/sandbox/mounts.rs
@@ -187,6 +187,13 @@ impl MountPlan {
         let mut masked_directories = Vec::new();
         for mount in mounts {
             append_mount_parent_args(args, &mount.destination);
+            #[cfg(target_os = "linux")]
+            if !mount.directory
+                && mount.access != PathAccess::Deny
+                && ssh_config.replaces_file(&mount.logical_destination)
+            {
+                continue;
+            }
             let flag = match (mount.access, mount.optional) {
                 (PathAccess::Deny, _) => {
                     let kind = merry_process::BwrapMaskKind::inspect(&mount.source)

--- a/crates/merry-cli/src/sandbox/tests/ssh.rs
+++ b/crates/merry-cli/src/sandbox/tests/ssh.rs
@@ -27,6 +27,12 @@ fn ssh_agent_config_requires_review_through_both_sandboxes() {
             .block_on(assert_ssh_client());
         return;
     }
+    for expose_etc in [false, true] {
+        assert_ssh_sandboxes(expose_etc);
+    }
+}
+
+fn assert_ssh_sandboxes(expose_etc: bool) {
     let directory = tempfile::Builder::new()
         .prefix("merry-ssh-test-")
         .tempdir_in("/var/tmp")
@@ -54,7 +60,11 @@ fn ssh_agent_config_requires_review_through_both_sandboxes() {
     fs::create_dir_all(host.xdg_paths.config_dir()).unwrap();
     fs::write(
         host.xdg_paths.config_file(),
-        "[permissions]\nssh_agent = true\nreadonly_paths = [\"/etc\"]\n",
+        if expose_etc {
+            "[permissions]\nssh_agent = true\nreadonly_paths = [\"/etc\"]\n"
+        } else {
+            "[permissions]\nssh_agent = true\n"
+        },
     )
     .unwrap();
     let config = MerryConfig::load_optional(&host.xdg_paths)
@@ -79,6 +89,10 @@ fn ssh_agent_config_requires_review_through_both_sandboxes() {
         .rposition(|argument| argument == host.current_exe.as_os_str())
         .unwrap();
     plan.args.truncate(command_index);
+    assert_ssh_bootstrap(&plan, expose_etc);
+    if !expose_etc {
+        assert_ssh_bootstrap_restrictions(&host);
+    }
     plan.args.extend([
         os("--setenv"),
         os(CHILD_ENV),
@@ -111,6 +125,106 @@ fn ssh_agent_config_requires_review_through_both_sandboxes() {
         fs::read_to_string(ssh.join("known_hosts2")).unwrap(),
         HOST_KEY
     );
+}
+
+fn assert_ssh_bootstrap(plan: &crate::sandbox::Plan, expose_etc: bool) {
+    let output = bootstrap_output(
+        plan,
+        r#"
+                cat /etc/ssh/ssh_config > /dev/null
+                test -S "$SSH_AUTH_SOCK"
+                test ! -w /etc/ssh/ssh_config
+                test ! -w /etc/passwd
+                test ! -w /etc/group
+                if test "$1" = false; then
+                    test ! -e /etc/ssh/sshd_config
+                    test ! -e /etc/ssh/sshd_config.d
+                    test ! -e /etc/ssh/ssh_host_ed25519_key
+                    test ! -e /etc/shadow
+                    test ! -e /etc/gshadow
+                fi
+                ssh -G -o StrictHostKeyChecking=yes -o Hostname=127.0.0.1 sandbox.example
+        "#,
+        &[if expose_etc { "true" } else { "false" }],
+    );
+    assert!(
+        output.status.success(),
+        "SSH bootstrap (expose_etc={expose_etc}) failed: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_ssh_bootstrap_restrictions(host: &crate::sandbox::host::Host) {
+    for denied in [
+        None,
+        Some("/etc"),
+        Some("/etc/ssh"),
+        Some("/etc/ssh/ssh_config"),
+    ] {
+        let mut host = host.clone();
+        if let Some(path) = denied {
+            host.trusted_path_rules.push(PathAccessRule::new(
+                path,
+                PathAccess::Deny,
+                PathAccessRuleSource::TrustedGlobalConfig,
+            ));
+        } else {
+            host.host_integrations.clear();
+        }
+        let Bootstrap::Reexec(mut plan) =
+            plan_bootstrap(true, ClipboardAccess::Disabled, &host).unwrap()
+        else {
+            panic!("expected sandbox reexec plan");
+        };
+        let command_index = plan
+            .args
+            .iter()
+            .rposition(|argument| argument == host.current_exe.as_os_str())
+            .unwrap();
+        plan.args.truncate(command_index);
+        let output = bootstrap_output(
+            &plan,
+            r#"
+                test ! -s /etc/ssh/ssh_config
+                if test "$1" = enabled; then
+                    test -S "$SSH_AUTH_SOCK"
+                else
+                    test -z "${SSH_AUTH_SOCK:-}"
+                    test ! -e /etc/ssh/ssh_config.d
+                    test ! -e /etc/passwd
+                    test ! -e /etc/group
+                fi
+            "#,
+            &[if denied.is_some() {
+                "enabled"
+            } else {
+                "disabled"
+            }],
+        );
+        assert!(
+            output.status.success(),
+            "SSH bootstrap restrictions ({denied:?}) failed: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn bootstrap_output(
+    plan: &crate::sandbox::Plan,
+    script: &str,
+    args: &[&str],
+) -> std::process::Output {
+    let mut command = Command::new(&plan.program);
+    command
+        .args(&plan.args)
+        .args(["/bin/sh", "-eu", "-c", script, "ssh-bootstrap"])
+        .args(args)
+        .env_clear()
+        .envs(plan.env.iter().cloned());
+    plan.ssh_config.configure_command(&mut command).unwrap();
+    command.output().unwrap()
 }
 
 async fn assert_ssh_client() {

--- a/crates/merry-process/src/lib.rs
+++ b/crates/merry-process/src/lib.rs
@@ -154,10 +154,12 @@ pub trait ProcessBackend: Send + Sync {
 }
 
 /// Inputs shared by local process backend implementations.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ProcessBackendOptions {
     /// Trusted filesystem rules installed for isolated actions.
     path_rules: Vec<PathAccessRule>,
+    /// Isolated-session capability ceiling, not a grant to an ordinary runner.
+    network_requests_allowed: bool,
     /// Host integrations already approved by the embedding application.
     host_integrations: Vec<HostIntegration>,
     gpg_agent_sockets: Option<GpgAgentSockets>,
@@ -165,8 +167,20 @@ pub struct ProcessBackendOptions {
     environment_overrides: Vec<(OsString, OsString)>,
 }
 
+impl Default for ProcessBackendOptions {
+    fn default() -> Self {
+        Self {
+            path_rules: Vec::new(),
+            network_requests_allowed: true,
+            host_integrations: Vec::new(),
+            gpg_agent_sockets: None,
+            environment_overrides: Vec::new(),
+        }
+    }
+}
+
 impl ProcessBackendOptions {
-    /// Creates empty host-process backend options.
+    /// Creates default options without preauthorized process capabilities.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -176,6 +190,17 @@ impl ProcessBackendOptions {
     #[must_use]
     pub fn with_path_rules(mut self, path_rules: impl IntoIterator<Item = PathAccessRule>) -> Self {
         self.path_rules = path_rules.into_iter().collect();
+        self
+    }
+
+    /// Sets whether isolated process sessions may request network capability.
+    ///
+    /// Defaults to true, which still requires approval for each action. False
+    /// rejects network requests before review. Explicit host execution is not
+    /// isolated and is not restricted by this ceiling.
+    #[must_use]
+    pub fn with_network_requests_allowed(mut self, allowed: bool) -> Self {
+        self.network_requests_allowed = allowed;
         self
     }
 
@@ -211,6 +236,12 @@ impl ProcessBackendOptions {
     #[must_use]
     pub fn path_rules(&self) -> &[PathAccessRule] {
         &self.path_rules
+    }
+
+    /// Returns whether isolated sessions may request, not preauthorize, network access.
+    #[must_use]
+    pub fn network_requests_allowed(&self) -> bool {
+        self.network_requests_allowed
     }
 
     /// Returns host integrations already approved by the embedding application.
@@ -331,6 +362,7 @@ impl LocalProcessBackend {
             workspace_root,
             environment,
             options.path_rules,
+            options.network_requests_allowed,
         ))
     }
 
@@ -350,6 +382,7 @@ impl LocalProcessBackend {
         workspace_root: PathBuf,
         environment: BwrapProcessEnvironment,
         path_rules: Vec<PathAccessRule>,
+        network_requests_allowed: bool,
     ) -> Self {
         let child_workspace_root = workspace_root.clone();
         let child_environment = environment;
@@ -360,6 +393,7 @@ impl LocalProcessBackend {
                     &child_workspace_root,
                     &child_environment,
                     &child_path_rules,
+                    network_requests_allowed,
                 )
             }),
         }
@@ -370,6 +404,7 @@ impl LocalProcessBackend {
         workspace_root: &Path,
         environment: &BwrapProcessEnvironment,
         path_rules: &[PathAccessRule],
+        network_requests_allowed: bool,
     ) -> ProcessSession {
         let session_permissions = BwrapSessionPermissions::new();
         let runner = BwrapProcessRunner::new_at_workspace_root(workspace_root)
@@ -380,6 +415,7 @@ impl LocalProcessBackend {
             BwrapPermissionedProcessRunnerFactory::new_at_workspace_root(workspace_root)
                 .with_environment(environment.clone())
                 .with_path_rules(path_rules.iter().cloned())
+                .with_network_requests_allowed(network_requests_allowed)
                 .with_session_permissions(session_permissions);
         ProcessSession::from_parts(
             AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),

--- a/crates/merry-process/src/process_runner/permissions.rs
+++ b/crates/merry-process/src/process_runner/permissions.rs
@@ -133,6 +133,7 @@ pub struct BwrapPermissionedProcessRunnerFactory {
     pub(super) cwd_root: PathBuf,
     pub(super) environment: BwrapProcessEnvironment,
     pub(super) path_rules: Vec<PathAccessRule>,
+    network_requests_allowed: bool,
     pub(super) session_permissions: Option<ProcessSessionPermissionView>,
     pub(super) bwrap_program: PathBuf,
 }
@@ -145,6 +146,7 @@ impl BwrapPermissionedProcessRunnerFactory {
             cwd_root: root.into(),
             environment: BwrapProcessEnvironment::from_current_process(),
             path_rules: Vec::new(),
+            network_requests_allowed: true,
             session_permissions: None,
             bwrap_program: PathBuf::from(BWRAP_PROGRAM),
         }
@@ -161,6 +163,16 @@ impl BwrapPermissionedProcessRunnerFactory {
     #[must_use]
     pub fn with_path_rules(mut self, rules: impl IntoIterator<Item = PathAccessRule>) -> Self {
         self.path_rules = rules.into_iter().collect();
+        self
+    }
+
+    /// Sets whether network capability requests can proceed to review.
+    ///
+    /// Defaults to true without preauthorizing access. False rejects requests
+    /// during validation and materialization, including direct runner creation.
+    #[must_use]
+    pub fn with_network_requests_allowed(mut self, allowed: bool) -> Self {
+        self.network_requests_allowed = allowed;
         self
     }
 
@@ -246,6 +258,7 @@ impl BwrapPermissionedProcessRunnerFactory {
         &self,
         request: &PermissionRequest,
     ) -> Result<(BwrapProcessRunner, Vec<ProcessPathGrant>), ProcessRunnerError> {
+        self.validate_network_request(request)?;
         let mut environment = self.environment.validate_for_workspace(&self.cwd_root)?;
         let integrations = self.requested_host_integrations_for_request(request);
         environment.validate_requested_host_integrations(&integrations)?;
@@ -297,6 +310,19 @@ impl BwrapPermissionedProcessRunnerFactory {
         runner.bwrap_program = self.bwrap_program.clone();
         Ok((runner, grants))
     }
+
+    /// Enforces the capability ceiling before review, grants, or runner construction.
+    fn validate_network_request(
+        &self,
+        request: &PermissionRequest,
+    ) -> Result<(), ProcessRunnerError> {
+        if request.requests_network() && !self.network_requests_allowed {
+            return Err(ProcessRunnerError::infrastructure(
+                "network requests are disabled by the configured process capability ceiling",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl PermissionedProcessRunnerFactory for BwrapPermissionedProcessRunnerFactory {
@@ -308,6 +334,7 @@ impl PermissionedProcessRunnerFactory for BwrapPermissionedProcessRunnerFactory 
         &self,
         request: &PermissionRequest,
     ) -> Result<bool, ProcessRunnerError> {
+        self.validate_network_request(request)?;
         let environment = self.environment.validate_for_workspace(&self.cwd_root)?;
         let snapshot = self
             .session_permissions

--- a/crates/merry-process/src/ssh_config.rs
+++ b/crates/merry-process/src/ssh_config.rs
@@ -171,6 +171,18 @@ impl BwrapSshConfigFiles {
         })
     }
 
+    /// Returns whether a snapshot replaces the original file mount at `path`.
+    ///
+    /// Callers should omit that original file bind while retaining its parent
+    /// directories. Stacking both mounts exposes an obsolete mount alias whose
+    /// replacement is an unlinked bubblewrap data file and cannot be rebound.
+    #[must_use]
+    pub fn replaces_file(&self, path: &Path) -> bool {
+        self.snapshots
+            .iter()
+            .any(|snapshot| snapshot.destination == path)
+    }
+
     /// Appends read-only data mounts after ordinary mounts. The caller must also
     /// call `configure_command` on the same bubblewrap invocation before spawning it.
     pub fn append_args(&self, args: &mut Vec<OsString>) {

--- a/crates/merry-process/tests/network.rs
+++ b/crates/merry-process/tests/network.rs
@@ -1,0 +1,139 @@
+#![cfg(target_os = "linux")]
+
+use merry_core::{PendingToolCall, ToolCallArguments, ToolCallId, ToolName};
+use merry_process::{
+    BwrapPermissionedProcessRunnerFactory, LocalProcessBackend, ProcessBackend, ProcessBackendMode,
+    ProcessBackendOptions,
+};
+use merry_runtime::{
+    PermissionRequest, PermissionedAction, PermissionedProcessRunnerFactory, ProcessRunner,
+    ProcessRunnerContext, parse_permission_request,
+};
+use serde_json::{Value, json};
+use std::{fs, sync::Arc};
+use tokio_util::sync::CancellationToken;
+
+fn request(requested: Value, command: &str) -> PermissionRequest {
+    parse_permission_request(&PendingToolCall::new(
+        ToolCallId::new("network-probe").unwrap(),
+        ToolName::new("request_permissions").unwrap(),
+        ToolCallArguments::try_from(json!({
+            "requested": requested,
+            "for_action": {"command": command, "cwd": null}
+        }))
+        .unwrap(),
+    ))
+    .unwrap()
+}
+
+#[tokio::test]
+async fn disabled_network_ceiling_rejects_every_grant_entrypoint_and_child_session() {
+    let fixture = tempfile::tempdir().unwrap();
+    let workspace = fixture.path().join("workspace");
+    let shared = fixture.path().join("shared");
+    fs::create_dir(&workspace).unwrap();
+    fs::create_dir(&shared).unwrap();
+    let backend = LocalProcessBackend::new(
+        &workspace,
+        ProcessBackendMode::Isolated,
+        ProcessBackendOptions::new().with_network_requests_allowed(false),
+    )
+    .unwrap();
+    let standalone: Arc<dyn PermissionedProcessRunnerFactory> = Arc::new(
+        BwrapPermissionedProcessRunnerFactory::new_at_workspace_root(&workspace)
+            .with_network_requests_allowed(false),
+    );
+    let network_only = request(
+        json!({"network": true}),
+        "printf executed > network-executed",
+    );
+    let combined = request(
+        json!({"network": true, "paths": [{"path": shared, "access": "rw"}]}),
+        "printf executed > network-executed",
+    );
+    let path_only = request(json!({"paths": [{"path": shared, "access": "rw"}]}), "true");
+    for factory in [
+        standalone,
+        backend.new_session().permissioned_factory(),
+        backend.new_session().permissioned_factory(),
+    ] {
+        for request in [&network_only, &combined] {
+            let error = factory.validate_request(request).unwrap_err();
+            assert!(error.to_string().contains("network requests are disabled"));
+            assert!(factory.request_capabilities_are_satisfied(request).is_err());
+            assert!(factory.prepare_approved_request(request).is_err());
+            let PermissionedAction::Process(intent) = request.action();
+            let error = factory
+                .runner_for(request)
+                .run(
+                    intent.clone(),
+                    ProcessRunnerContext::new(CancellationToken::new()),
+                )
+                .await
+                .unwrap_err();
+            assert!(error.to_string().contains("network requests are disabled"));
+        }
+        factory.validate_request(&path_only).unwrap();
+        assert!(
+            !factory
+                .request_capabilities_are_satisfied(&path_only)
+                .unwrap()
+        );
+        assert!(!workspace.join("network-executed").exists());
+    }
+}
+
+#[tokio::test]
+async fn network_ceiling_never_enables_baseline_network_or_retains_an_action_grant() {
+    let fixture = tempfile::tempdir().unwrap();
+    let parent_namespace = fs::read_link("/proc/self/ns/net").unwrap();
+    let parent_namespace = parent_namespace.to_str().unwrap();
+    let request = request(json!({"network": true}), "readlink /proc/self/ns/net");
+    for options in [
+        ProcessBackendOptions::new(),
+        ProcessBackendOptions::new().with_network_requests_allowed(true),
+        ProcessBackendOptions::new().with_network_requests_allowed(false),
+    ] {
+        let allowed = options.network_requests_allowed();
+        let backend =
+            LocalProcessBackend::new(fixture.path(), ProcessBackendMode::Isolated, options)
+                .unwrap();
+        for _ in 0..2 {
+            let session = backend.new_session();
+            let baseline = session.runner();
+            assert_ne!(namespace(&*baseline, &request).await, parent_namespace);
+            let factory = session.permissioned_factory();
+            if allowed {
+                factory.validate_request(&request).unwrap();
+                assert!(
+                    !factory
+                        .request_capabilities_are_satisfied(&request)
+                        .unwrap()
+                );
+                let approved = factory.runner_for(&request);
+                assert_eq!(namespace(&*approved, &request).await, parent_namespace);
+                assert!(
+                    !factory
+                        .request_capabilities_are_satisfied(&request)
+                        .unwrap()
+                );
+            } else {
+                assert!(factory.validate_request(&request).is_err());
+            }
+            assert_ne!(namespace(&*baseline, &request).await, parent_namespace);
+        }
+    }
+}
+
+async fn namespace(runner: &dyn ProcessRunner, request: &PermissionRequest) -> String {
+    let PermissionedAction::Process(intent) = request.action();
+    let output = runner
+        .run(
+            intent.clone(),
+            ProcessRunnerContext::new(CancellationToken::new()),
+        )
+        .await
+        .unwrap();
+    assert!(output.ok(), "{output:?}");
+    output.stdout_text().trim().to_owned()
+}

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -27,6 +27,13 @@ profile = "default"
 # to a declared subtree without raising its access ceiling. deny_paths always
 # wins. Project-local config must not silently authorize host-wide access.
 #
+# Inner action network capability ceiling; defaults to true when omitted.
+# true allows network requests, not network access: each action still requires
+# its own approval. false rejects network requests before review or execution.
+# This does not restrict model-provider or configured MCP network connections,
+# and does not add network isolation to explicit --no-sandbox host execution.
+network = true
+
 # Optional host integrations. These are explicit outer-sandbox ceilings and
 # forwarding switches, not inner preauthorizations. Inner actions must request
 # the matching host integration and pass runtime review before using its socket
@@ -41,9 +48,15 @@ profile = "default"
 # accept new host keys, or bypass deny_paths / review_paths. A blanket ~/.ssh
 # deny still blocks these trust files; choose narrower deny paths if they should
 # remain readable.
-# Already-visible system SSH configuration is kept, not disabled. Safe root-owned
-# ssh_config files and static Includes use private read-only snapshots to retain
-# OpenSSH ownership checks across user namespaces. Host files are never changed.
+# ssh_agent also imports /etc/passwd and /etc/group for client account lookup,
+# plus /etc/ssh/ssh_config and /etc/ssh/ssh_config.d, all read-only. No blanket
+# /etc grant is needed. These imports obey deny_paths and do not import SSH
+# server configuration, host private keys, or shadow password databases.
+# Include targets outside the existing sandbox view still need readonly_paths.
+# Explicitly authorized system SSH configuration remains visible when ssh_agent
+# is disabled. Safe root-owned config files and static Includes use private
+# read-only snapshots to retain OpenSSH ownership checks across user namespaces.
+# Host files are never changed.
 # gpg_agent enables the native GPG socket discovered with gpgconf --list-dirs,
 # independently of ssh_agent (including GPG's SSH endpoint). After GPG approval,
 # inner actions also import pubring.kbx / pubring.gpg read-only; no extra

--- a/sdks/python/merry/_tools.py
+++ b/sdks/python/merry/_tools.py
@@ -44,12 +44,18 @@ if TYPE_CHECKING:
 InputT = TypeVar("InputT", bound=BaseModel)
 OutputT = TypeVar("OutputT", bound=BaseModel)
 RunOutputT = TypeVar("RunOutputT", bound=BaseModel)
+HandlerInputT_contra = TypeVar(
+    "HandlerInputT_contra", bound=BaseModel, contravariant=True
+)
+HandlerOutputT_co = TypeVar("HandlerOutputT_co", bound=BaseModel, covariant=True)
 
 
-class ToolHandler(Protocol[InputT, OutputT]):
+class ToolHandler(Protocol[HandlerInputT_contra, HandlerOutputT_co]):
     """Callable contract for an async Pydantic tool handler."""
 
-    def __call__(self, arguments: InputT, /) -> Awaitable[OutputT]: ...
+    def __call__(
+        self, arguments: HandlerInputT_contra, /
+    ) -> Awaitable[HandlerOutputT_co]: ...
 
 
 class ToolRegistration(Protocol):

--- a/sdks/python/tests/test_tools.py
+++ b/sdks/python/tests/test_tools.py
@@ -21,6 +21,33 @@ class LookupOutput(BaseModel):
     status: str = Field(description="Current order status.")
 
 
+def test_tool_handler_accepts_wider_inputs_and_narrower_outputs() -> None:
+    class RegionalLookupInput(LookupInput):
+        region: str = Field(description="Order fulfillment region.")
+
+    class DetailedLookupOutput(LookupOutput):
+        order_id: str = Field(description="Stable order identifier.")
+
+    async def lookup(arguments: LookupInput) -> DetailedLookupOutput:
+        return DetailedLookupOutput(status="shipped", order_id=arguments.order_id)
+
+    original: merry.ToolHandler[LookupInput, DetailedLookupOutput] = lookup
+    compatible: merry.ToolHandler[RegionalLookupInput, LookupOutput] = original
+    tool: merry.Tool[RegionalLookupInput, LookupOutput] = merry.Tool.from_function(
+        compatible,
+        name="lookup_order",
+        description="Look up an order using a compatible handler.",
+        input_model=RegionalLookupInput,
+        output_model=LookupOutput,
+    )
+
+    output = asyncio.run(tool(RegionalLookupInput(order_id="A123", region="west")))
+
+    assert isinstance(output, DetailedLookupOutput)
+    assert output.status == "shipped"
+    assert output.order_id == "A123"
+
+
 def test_tool_decorator_executes_through_rust_batch_handoff() -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary
- Restore `[permissions] network` as a default-enabled capability ceiling, not preauthorization. Ordinary actions remain network-isolated and network grants stay action-scoped.
- Reject `network = false` requests before review or runner construction, including fully trusted review mode and direct factory entrypoints. New process sessions inherit the ceiling.
- Make `ssh_agent = true` import only read-only client account/configuration files, without requiring a blanket `/etc` grant or exposing SSH server configuration, host private keys, or shadow databases.
- Replace original SSH file binds with their snapshots instead of stacking mounts that fail when rebound by the inner sandbox.
- Fix the Python CI type-check failure by giving `ToolHandler` dedicated contravariant input and covariant output type variables, while preserving the invariant `Tool` and builder contracts.
- Update the README and tracked config example, with runtime admission, network namespace, SSH bootstrap, explicit-denial, and typed handler compatibility regressions.

## Scope
The network ceiling applies to isolated process actions. It does not restrict model-provider or configured MCP connections, and explicit `--no-sandbox` host execution remains outside this boundary. Provider-visible tools and schemas, review policy, and CI checks are unchanged.

## Verification
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all`
- [x] `cargo test -p merry-process -p merry-cli network_ -- --nocapture`
- [x] SDK `uv sync --locked`
- [x] SDK `uv run --with ruff --with ty ruff format --check .`
- [x] SDK `uv run --with ruff --with ty ruff check .`
- [x] SDK `uv run --with ruff --with ty ty check` — zero diagnostics
- [x] SDK tests after `uv run --with maturin maturin develop --uv --features test-utils`: `uv run --with pytest python -m pytest tests -q` — 52 passed
- [x] SDK `uv run python -m compileall -q examples probes`
- [x] SDK `uv build` — source distribution and wheel built
- [x] `git diff --check` and staged-diff review
- [x] GPG signatures verified for both commits

## CI Follow-up
Commit `7acd062` fixes the two `invalid-protocol` diagnostics reported by the initial Python SDK CI run. The handler protocol now explicitly accepts wider input handlers and narrower output handlers. A public API regression checks typed protocol assignment and tool execution; no diagnostic suppression, tool downgrade, or CI weakening is used.