### PR TITLE
feat(tui): improve command display and transcript copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",

--- a/crates/merry-cli/Cargo.toml
+++ b/crates/merry-cli/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 
 [dependencies]
 clap.workspace = true
-crossterm.workspace = true
+crossterm = { workspace = true, features = ["osc52"] }
 futures-util.workspace = true
 merry-core = { path = "../merry-core", version = "0.1.0" }
 merry-llm = { path = "../merry-llm", version = "0.1.0" }

--- a/crates/merry-cli/src/config/mod.rs
+++ b/crates/merry-cli/src/config/mod.rs
@@ -505,6 +505,7 @@ struct RuntimeModelToml {
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 struct TuiToml {
+    show_successful_command_output: Option<bool>,
     theme: Option<TuiThemeToml>,
     keymap: Option<TuiKeymapToml>,
 }
@@ -541,6 +542,8 @@ pub(crate) struct TuiKeymapToml {
     pub(crate) quit: Option<String>,
     pub(crate) scroll_up: Option<String>,
     pub(crate) scroll_down: Option<String>,
+    pub(crate) follow_latest: Option<String>,
+    pub(crate) open_command_details: Option<String>,
     pub(crate) review_previous_user_input: Option<String>,
     pub(crate) history_previous: Option<String>,
     pub(crate) history_next: Option<String>,
@@ -550,6 +553,7 @@ pub(crate) struct TuiKeymapToml {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct TuiConfig {
+    pub(crate) show_successful_command_output: bool,
     pub(crate) theme: TuiThemeToml,
     pub(crate) keymap: TuiKeymapToml,
 }
@@ -560,6 +564,7 @@ impl MerryConfig {
             return Ok(TuiConfig::default());
         };
         let config = TuiConfig {
+            show_successful_command_output: tui.show_successful_command_output.unwrap_or(false),
             theme: tui.theme.clone().unwrap_or_default(),
             keymap: tui.keymap.clone().unwrap_or_default(),
         };

--- a/crates/merry-cli/src/config/tests/loading.rs
+++ b/crates/merry-cli/src/config/tests/loading.rs
@@ -360,6 +360,7 @@ fn example_config_toml_matches_current_schema_and_resolves_user_defaults() {
     assert_eq!(tui.keymap.cancel_input_or_quit.as_deref(), Some("ctrl+c"));
     assert_eq!(tui.keymap.insert_newline.as_deref(), Some("ctrl+j"));
     assert_eq!(tui.keymap.scroll_up.as_deref(), Some("pageup"));
+    assert_eq!(tui.keymap.open_command_details.as_deref(), Some("ctrl+t"));
     assert_eq!(
         tui.keymap.open_session_in_browser.as_deref(),
         Some("ctrl+g")

--- a/crates/merry-cli/src/config/tests/loading.rs
+++ b/crates/merry-cli/src/config/tests/loading.rs
@@ -216,6 +216,7 @@ discard_suspended = "ctrl+d"
     .expect("config should be present");
 
     let tui = config.tui_config().expect("tui config should validate");
+    assert!(!tui.show_successful_command_output);
     assert_eq!(tui.theme.status.as_deref(), Some("cyan"));
     assert_eq!(tui.theme.assistant.as_deref(), Some("white"));
     assert_eq!(tui.theme.tool_keyword.as_deref(), Some("light_cyan"));
@@ -234,6 +235,43 @@ discard_suspended = "ctrl+d"
         Some("ctrl+u")
     );
     assert_eq!(tui.keymap.history_previous.as_deref(), Some("up"));
+}
+
+#[test]
+fn rejects_selection_copy_keymap_config() {
+    let paths = XdgPaths::from_parts(home(), None, None);
+    let error = MerryConfig::load_optional_from_text(
+        Some("[tui.keymap]\ncopy_selection = 'ctrl+shift+c'"),
+        &paths,
+    )
+    .expect_err("selection copy has no configurable shortcut");
+    assert!(error.to_string().contains("unknown field `copy_selection`"));
+}
+
+#[test]
+fn successful_command_output_is_an_opt_in_boolean() {
+    let paths = XdgPaths::from_parts(home(), None, None);
+    for (text, expected) in [
+        ("[global]\nprofile = 'default'", false),
+        ("[tui]", false),
+        ("[tui]\nshow_successful_command_output = false", false),
+        ("[tui]\nshow_successful_command_output = true", true),
+    ] {
+        let config = MerryConfig::load_optional_from_text(Some(text), &paths)
+            .expect("config should parse")
+            .expect("config should be present");
+        assert_eq!(
+            config.tui_config().unwrap().show_successful_command_output,
+            expected
+        );
+    }
+    assert!(
+        MerryConfig::load_optional_from_text(
+            Some("[tui]\nshow_successful_command_output = 'true'"),
+            &paths,
+        )
+        .is_err()
+    );
 }
 
 #[test]
@@ -313,6 +351,7 @@ fn example_config_toml_matches_current_schema_and_resolves_user_defaults() {
     let tui = config
         .tui_config()
         .expect("example TUI config should validate");
+    assert!(!tui.show_successful_command_output);
     assert_eq!(tui.theme.status.as_deref(), Some("light_magenta"));
     assert_eq!(tui.theme.assistant.as_deref(), Some("white"));
     assert_eq!(tui.theme.tool_keyword.as_deref(), Some("light_cyan"));

--- a/crates/merry-cli/src/tool_display.rs
+++ b/crates/merry-cli/src/tool_display.rs
@@ -26,8 +26,10 @@ fn format_process_call_detail(arguments: &Map<String, Value>) -> Option<String> 
     let cwd = arguments.get("cwd").and_then(Value::as_str).unwrap_or(".");
     Some(format!(
         "{} ({})",
-        compact_shell_command(command),
-        compact_inline(cwd, 80)
+        display_shell_command(command),
+        cwd.chars()
+            .filter(|character| !character.is_control())
+            .collect::<String>()
     ))
 }
 
@@ -106,10 +108,9 @@ fn compact_shell_word(value: &str) -> String {
     }
 }
 
-fn compact_shell_command(value: &str) -> String {
-    let mut output = value
+fn display_shell_command(value: &str) -> String {
+    let output = value
         .chars()
-        .take(120)
         .map(|character| {
             if character.is_control() {
                 ' '
@@ -118,9 +119,6 @@ fn compact_shell_command(value: &str) -> String {
             }
         })
         .collect::<String>();
-    if value.chars().count() > 120 {
-        output.push_str("...");
-    }
     let output = output.trim();
     if output.is_empty() {
         "\"\"".to_owned()
@@ -242,5 +240,32 @@ mod tests {
         assert_eq!(detail, "rg -n 'select!' crates/merry-runtime (.)");
         assert!(!detail.contains("command="));
         assert!(!detail.contains("cwd="));
+    }
+
+    #[test]
+    fn process_detail_keeps_long_commands_and_working_directories_complete() {
+        let command = format!("printf '%s' '{}'", "完整-command-".repeat(30));
+        let cwd = format!("src/{}/workspace", "nested/".repeat(20));
+        let arguments = json!({"command": command, "cwd": cwd});
+
+        let detail =
+            format_tool_call_detail("run_process", arguments.as_object().unwrap()).unwrap();
+
+        assert_eq!(detail, format!("{command} ({cwd})"));
+    }
+
+    #[test]
+    fn process_detail_sanitizes_terminal_controls_without_losing_the_command_tail() {
+        let command = format!("printf '{}'\n\t&& echo done\r", "x".repeat(150));
+        let arguments = json!({"command": command, "cwd": "src\u{1b}"});
+
+        let detail =
+            format_tool_call_detail("run_process", arguments.as_object().unwrap()).unwrap();
+
+        assert_eq!(
+            detail,
+            format!("printf '{}'  && echo done (src)", "x".repeat(150))
+        );
+        assert!(!detail.chars().any(char::is_control));
     }
 }

--- a/crates/merry-cli/src/tui/command.rs
+++ b/crates/merry-cli/src/tui/command.rs
@@ -9,6 +9,8 @@ pub(crate) enum PaletteCommand {
     ShowStatus,
     OpenSessionInBrowser,
     ReviewPreviousUserInput,
+    OpenCommandDetails,
+    FollowLatest,
     Interrupt,
     ResumeSuspended,
     DiscardSuspended,
@@ -66,7 +68,7 @@ impl CommandSpec {
     }
 }
 
-const COMMANDS: [CommandSpec; 20] = [
+const COMMANDS: [CommandSpec; 22] = [
     CommandSpec::new(PaletteCommand::OpenSettings, "Merry", "Settings", None),
     CommandSpec::new(
         PaletteCommand::OpenProviders,
@@ -93,6 +95,18 @@ const COMMANDS: [CommandSpec; 20] = [
         "Navigation",
         "Previous user input",
         Some(KeyAction::ReviewPreviousUserInput),
+    ),
+    CommandSpec::new(
+        PaletteCommand::OpenCommandDetails,
+        "Navigation",
+        "Inspect command output",
+        Some(KeyAction::OpenCommandDetails),
+    ),
+    CommandSpec::new(
+        PaletteCommand::FollowLatest,
+        "Navigation",
+        "Follow latest output",
+        Some(KeyAction::FollowLatest),
     ),
     CommandSpec::new(
         PaletteCommand::Interrupt,

--- a/crates/merry-cli/src/tui/command_controller.rs
+++ b/crates/merry-cli/src/tui/command_controller.rs
@@ -90,6 +90,13 @@ pub(crate) fn run_palette_command(
             state.close_overlay();
             handle_key_action(KeyAction::ReviewPreviousUserInput, state)
         }
+        PaletteCommand::OpenCommandDetails => {
+            handle_key_action(KeyAction::OpenCommandDetails, state)
+        }
+        PaletteCommand::FollowLatest => {
+            state.close_overlay();
+            handle_key_action(KeyAction::FollowLatest, state)
+        }
         PaletteCommand::Interrupt => {
             prepare_timeline_feedback(state);
             if state.can_interrupt_run() {

--- a/crates/merry-cli/src/tui/command_details/mod.rs
+++ b/crates/merry-cli/src/tui/command_details/mod.rs
@@ -1,0 +1,207 @@
+use crate::tui::{
+    controller::ControllerEffect,
+    overlay::{Overlay, OverlayKeyResult},
+    state::{CommandView, TimelineItem, TuiState},
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use merry_core::ArtifactId;
+
+pub(crate) use output::CapturedOutput;
+pub(crate) use render::{prepare_viewport, render_details};
+
+mod output;
+mod render;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandNavigation {
+    Latest,
+    Previous,
+    Next,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DetailsOutput {
+    Loading,
+    Ready(CapturedOutput),
+    Failed(String),
+}
+
+/// An on-demand view of one completed command, backed by its runtime artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandDetails {
+    timeline_index: usize,
+    ordinal: usize,
+    total: usize,
+    view: CommandView,
+    output: DetailsOutput,
+    scroll: usize,
+    feedback: Option<String>,
+    layout: Option<render::DetailsLayout>,
+}
+
+impl CommandDetails {
+    fn new(timeline_index: usize, ordinal: usize, total: usize, view: CommandView) -> Self {
+        Self {
+            timeline_index,
+            ordinal,
+            total,
+            view,
+            output: DetailsOutput::Loading,
+            scroll: 0,
+            feedback: None,
+            layout: None,
+        }
+    }
+
+    pub(crate) fn artifact_id(&self) -> Option<&ArtifactId> {
+        match &self.view {
+            CommandView::Finished { artifact, .. } => Some(artifact.id()),
+            CommandView::Running { .. } => None,
+        }
+    }
+
+    pub(crate) fn set_feedback(&mut self, feedback: String) {
+        self.feedback = Some(feedback);
+    }
+
+    pub(crate) fn handle_key(&mut self, key: KeyEvent) -> OverlayKeyResult {
+        if key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            return OverlayKeyResult::Consumed;
+        }
+        match key.code {
+            KeyCode::Esc => OverlayKeyResult::Close,
+            KeyCode::Left | KeyCode::Char('[') => OverlayKeyResult::PreviousCommand,
+            KeyCode::Right | KeyCode::Char(']') => OverlayKeyResult::NextCommand,
+            KeyCode::Char('c' | 'C') => {
+                if let CommandView::Finished { command, .. } = &self.view {
+                    OverlayKeyResult::CopyText(command.clone())
+                } else {
+                    OverlayKeyResult::Consumed
+                }
+            }
+            KeyCode::Char('y' | 'Y') => match &self.output {
+                DetailsOutput::Ready(output) => OverlayKeyResult::CopyText(output.copy_text()),
+                _ => {
+                    self.set_feedback("Output is not available yet".into());
+                    OverlayKeyResult::Consumed
+                }
+            },
+            KeyCode::Up => {
+                self.scroll = self.scroll.saturating_sub(1);
+                OverlayKeyResult::Consumed
+            }
+            KeyCode::Down => {
+                self.scroll = self.scroll.saturating_add(1);
+                OverlayKeyResult::Consumed
+            }
+            KeyCode::PageUp => {
+                self.scroll = self.scroll.saturating_sub(10);
+                OverlayKeyResult::Consumed
+            }
+            KeyCode::PageDown => {
+                self.scroll = self.scroll.saturating_add(10);
+                OverlayKeyResult::Consumed
+            }
+            KeyCode::Home => {
+                self.scroll = 0;
+                OverlayKeyResult::Consumed
+            }
+            KeyCode::End => {
+                self.scroll = usize::MAX;
+                OverlayKeyResult::Consumed
+            }
+            _ => OverlayKeyResult::Consumed,
+        }
+    }
+}
+
+/// Selects a completed command without changing the draft, runtime, or timeline viewport.
+pub(crate) fn inspect_command(
+    state: &mut TuiState,
+    direction: CommandNavigation,
+) -> ControllerEffect {
+    let indices = state
+        .timeline()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            matches!(
+                item,
+                TimelineItem::Command {
+                    view: CommandView::Finished { .. }
+                }
+            )
+            .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    if indices.is_empty() {
+        state.show_info_dialog(
+            "Command output",
+            "No completed commands yet. Running commands will be available after completion."
+                .into(),
+        );
+        return ControllerEffect::None;
+    }
+    let current = match state.overlay() {
+        Some(Overlay::CommandDetails(details)) => indices
+            .iter()
+            .position(|index| *index == details.timeline_index),
+        _ => None,
+    };
+    let position = match (current, direction) {
+        (Some(position), CommandNavigation::Next) => {
+            position.saturating_add(1).min(indices.len() - 1)
+        }
+        (Some(position), CommandNavigation::Previous) => position.saturating_sub(1),
+        _ => indices.len() - 1,
+    };
+    if current == Some(position) {
+        return ControllerEffect::None;
+    }
+    let index = indices[position];
+    let TimelineItem::Command { view } = &state.timeline()[index] else {
+        return ControllerEffect::None;
+    };
+    let details = CommandDetails::new(index, position + 1, indices.len(), view.clone());
+    let Some(artifact_id) = details.artifact_id().cloned() else {
+        return ControllerEffect::None;
+    };
+    state.open_command_details(details);
+    ControllerEffect::LoadCommandOutput(artifact_id)
+}
+
+/// Ignores stale loads after closing the viewer or selecting a different command.
+pub(crate) fn apply_output(
+    state: &mut TuiState,
+    artifact_id: &ArtifactId,
+    result: Result<CapturedOutput, String>,
+) {
+    if let Some(Overlay::CommandDetails(details)) = state.overlay_mut()
+        && details.artifact_id() == Some(artifact_id)
+    {
+        details.layout = None;
+        details.feedback = None;
+        details.output = match result {
+            Ok(output) => DetailsOutput::Ready(output),
+            Err(error) => DetailsOutput::Failed(error),
+        };
+    }
+}
+
+/// Reads only the selected artifact, with a bounded wait and no execution side effects.
+pub(crate) async fn load_output(
+    runtime: &merry_runtime::Runtime,
+    artifact_id: &ArtifactId,
+) -> Result<CapturedOutput, String> {
+    let content = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        runtime.read_artifact_content(artifact_id),
+    )
+    .await
+    .map_err(|_| "Reading the command output timed out".to_owned())?
+    .map_err(|error| error.to_string())?;
+    CapturedOutput::from_artifact(content)
+}

--- a/crates/merry-cli/src/tui/command_details/output.rs
+++ b/crates/merry-cli/src/tui/command_details/output.rs
@@ -1,0 +1,1 @@
+pub(crate) use crate::tui::process_output::{CapturedOutput, CapturedStream};

--- a/crates/merry-cli/src/tui/command_details/render.rs
+++ b/crates/merry-cli/src/tui/command_details/render.rs
@@ -1,0 +1,276 @@
+use super::{CapturedOutput, CommandDetails, DetailsOutput, output::CapturedStream};
+use crate::tui::{
+    keymap::KeyAction,
+    overlay::Overlay,
+    overlay_render::render_surface,
+    state::{CommandFailure, CommandView, TuiState},
+    text_wrap::{StyledTextPart, semantic_style, wrap_styled_parts_preserving_leading_whitespace},
+    theme::SemanticColor,
+};
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Modifier,
+    text::{Line, Span},
+    widgets::{Paragraph, Wrap},
+};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DetailsLayout {
+    width: u16,
+    lines: Vec<Line<'static>>,
+}
+
+fn regions(
+    area: Rect,
+    state: &TuiState,
+    details: &CommandDetails,
+) -> (Rect, Rect, Rect, Paragraph<'static>) {
+    let width = area.width.saturating_sub(2).min(120);
+    let height = area.height.saturating_sub(2);
+    let region = Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    );
+    let inner = region.inner(ratatui::layout::Margin::new(1, 1));
+    let hints = footer_hints(state, details, inner.width);
+    let footer_height = u16::try_from(hints.line_count(inner.width))
+        .unwrap_or(u16::MAX)
+        .min(inner.height.saturating_sub(1));
+    let body = Rect::new(
+        inner.x,
+        inner.y,
+        inner.width,
+        inner.height.saturating_sub(footer_height),
+    );
+    let footer = Rect::new(inner.x, body.bottom(), inner.width, footer_height);
+    (region, body, footer, hints)
+}
+
+pub(crate) fn prepare_viewport(state: &mut TuiState, area: Rect) {
+    let Some(Overlay::CommandDetails(details)) = state.overlay() else {
+        return;
+    };
+    let (_, body, _, _) = regions(area, state, details);
+    let layout = details
+        .layout
+        .as_ref()
+        .is_none_or(|layout| layout.width != body.width)
+        .then(|| DetailsLayout {
+            width: body.width,
+            lines: content_lines(state, details, body.width),
+        });
+    if let Some(Overlay::CommandDetails(details)) = state.overlay_mut() {
+        if let Some(layout) = layout {
+            details.layout = Some(layout);
+        }
+        if let Some(layout) = &details.layout {
+            details.scroll = details
+                .scroll
+                .min(layout.lines.len().saturating_sub(usize::from(body.height)));
+        }
+    }
+}
+
+pub(crate) fn render_details(frame: &mut Frame<'_>, state: &TuiState, details: &CommandDetails) {
+    let (region, body, footer, hints) = regions(frame.area(), state, details);
+    if body.is_empty() {
+        return;
+    }
+    render_surface(
+        frame,
+        state,
+        region,
+        &format!(" Command {}/{} ", details.ordinal, details.total),
+    );
+    let lines = details
+        .layout
+        .as_ref()
+        .filter(|layout| layout.width == body.width)
+        .map_or_else(
+            || Cow::Owned(content_lines(state, details, body.width)),
+            |layout| Cow::Borrowed(layout.lines.as_slice()),
+        );
+    let max_scroll = lines.len().saturating_sub(usize::from(body.height));
+    let visible = lines
+        .iter()
+        .skip(details.scroll.min(max_scroll))
+        .take(usize::from(body.height))
+        .cloned()
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(visible), body);
+    frame.render_widget(hints, footer);
+}
+
+fn footer_hints(state: &TuiState, details: &CommandDetails, width: u16) -> Paragraph<'static> {
+    let close = state
+        .keymap()
+        .binding_label_for(KeyAction::OpenCommandDetails)
+        .map_or_else(
+            || "Esc close".to_owned(),
+            |key| format!("{key} / Esc close"),
+        );
+    let (navigation, copy) = if width < 50 {
+        ("←/→ cmd ↑/↓ scroll", "C/Y copy")
+    } else {
+        (
+            "←/→ command · ↑/↓/PgUp/PgDn scroll",
+            "C copy command · Y copy output",
+        )
+    };
+    let hints = vec![
+        Line::styled(navigation, semantic_style(state, SemanticColor::Muted)),
+        Line::styled(
+            format!("{close} · {copy}"),
+            semantic_style(state, SemanticColor::Muted),
+        ),
+        Line::styled(
+            details.feedback.clone().unwrap_or_default(),
+            semantic_style(state, SemanticColor::Warning),
+        ),
+    ];
+    Paragraph::new(hints).wrap(Wrap { trim: false })
+}
+
+fn content_lines(state: &TuiState, details: &CommandDetails, width: u16) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    if let CommandView::Finished {
+        detail,
+        command,
+        cwd,
+        exit_code,
+        failure,
+        elapsed,
+        ..
+    } = &details.view
+    {
+        append_text(
+            &mut lines,
+            state,
+            if command.is_empty() { detail } else { command },
+            width,
+            SemanticColor::Assistant,
+        );
+        append_text(
+            &mut lines,
+            state,
+            &format!("Directory: {cwd}"),
+            width,
+            SemanticColor::Muted,
+        );
+        let mut status = match failure {
+            Some(CommandFailure::Cancelled) => "Cancelled".to_owned(),
+            Some(CommandFailure::Failed) => "Failed".to_owned(),
+            None => exit_code
+                .map(|code| format!("Exit: {code}"))
+                .unwrap_or_else(|| "Exit: unknown".into()),
+        };
+        if let Some(elapsed) = elapsed {
+            status.push_str(&format!(
+                " · Elapsed: {:.1}s (including waiting)",
+                elapsed.as_secs_f64()
+            ));
+        }
+        let color = if exit_code.is_some_and(|code| code != 0)
+            || *failure == Some(CommandFailure::Failed)
+        {
+            SemanticColor::Error
+        } else {
+            SemanticColor::Muted
+        };
+        append_text(&mut lines, state, &status, width, color);
+        lines.push(Line::default());
+    }
+    match &details.output {
+        DetailsOutput::Loading => append_text(
+            &mut lines,
+            state,
+            "Loading captured output…",
+            width,
+            SemanticColor::Muted,
+        ),
+        DetailsOutput::Failed(error) => append_text(
+            &mut lines,
+            state,
+            &format!("Could not load output: {error}"),
+            width,
+            SemanticColor::Error,
+        ),
+        DetailsOutput::Ready(CapturedOutput::Text(text)) => {
+            append_text(&mut lines, state, text, width, SemanticColor::Assistant)
+        }
+        DetailsOutput::Ready(CapturedOutput::Process { stdout, stderr }) => {
+            append_stream(&mut lines, state, "stdout", stdout, width);
+            lines.push(Line::default());
+            append_stream(&mut lines, state, "stderr", stderr, width);
+        }
+    }
+    lines
+}
+
+fn append_stream(
+    lines: &mut Vec<Line<'static>>,
+    state: &TuiState,
+    label: &str,
+    stream: &CapturedStream,
+    width: u16,
+) {
+    lines.push(Line::from(Span::styled(
+        label.to_owned(),
+        semantic_style(state, SemanticColor::Muted).add_modifier(Modifier::BOLD),
+    )));
+    if stream.text.is_empty() {
+        append_text(lines, state, "(empty)", width, SemanticColor::Muted);
+    } else {
+        append_text(lines, state, &stream.text, width, SemanticColor::Assistant);
+    }
+    if stream.truncated {
+        append_text(
+            lines,
+            state,
+            "… capture truncated; only captured output is available",
+            width,
+            SemanticColor::Warning,
+        );
+    }
+    if stream.utf8 == Some(false) {
+        append_text(
+            lines,
+            state,
+            "Non-UTF-8 output is displayed as text; the artifact retains the original bytes.",
+            width,
+            SemanticColor::Warning,
+        );
+    }
+}
+
+fn append_text(
+    lines: &mut Vec<Line<'static>>,
+    state: &TuiState,
+    text: &str,
+    width: u16,
+    color: SemanticColor,
+) {
+    for line in text.split('\n') {
+        let clean = line
+            .chars()
+            .filter(|character| !character.is_control() || *character == '\t')
+            .collect::<String>()
+            .replace('\t', "    ");
+        if clean.is_empty() {
+            lines.push(Line::default());
+        } else {
+            lines.extend(wrap_styled_parts_preserving_leading_whitespace(
+                vec![StyledTextPart {
+                    text: clean,
+                    style: semantic_style(state, color),
+                    atomic: false,
+                }],
+                width,
+            ));
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/controller.rs
+++ b/crates/merry-cli/src/tui/controller.rs
@@ -23,7 +23,7 @@ use crate::{
 pub(super) use effects::persist_submitted_input_history;
 pub(super) use input::project_local_effect;
 pub(crate) use input::{
-    apply_clipboard_image_completion, handle_key_action, handle_key_event,
+    apply_clipboard_image_completion, handle_key_action, handle_key_event, handle_mouse_input,
     handle_mouse_scroll_down, handle_mouse_scroll_up, handle_paste_event,
 };
 use merry_runtime::InteractiveRunMessage;
@@ -48,6 +48,32 @@ struct ClipboardImageCompletion {
     result: Result<DraftImage, String>,
 }
 
+pub(super) struct CommandOutputCompletion {
+    artifact_id: merry_core::ArtifactId,
+    generation: u64,
+    result: Result<super::command_details::CapturedOutput, String>,
+}
+
+impl CommandOutputCompletion {
+    pub(super) fn new(
+        artifact_id: merry_core::ArtifactId,
+        generation: u64,
+        result: Result<super::command_details::CapturedOutput, String>,
+    ) -> Self {
+        Self {
+            artifact_id,
+            generation,
+            result,
+        }
+    }
+
+    pub(super) fn apply(self, state: &mut TuiState) {
+        if self.generation == state.command_details_generation() {
+            super::command_details::apply_output(state, &self.artifact_id, self.result);
+        }
+    }
+}
+
 pub(super) struct ProviderController<'a> {
     pub(super) management: &'a mut ProviderManagementService,
     pub(super) discovery_tx: &'a mpsc::Sender<ModelDiscoveryCompletion>,
@@ -61,6 +87,9 @@ pub(crate) enum ControllerEffect {
     SubmitNext(TuiSubmission),
     SubmitBacklog(TuiSubmission),
     PasteImage,
+    LoadCommandOutput(merry_core::ArtifactId),
+    CopyText(String),
+    CopyTextTooLarge,
     Interrupt,
     ResumeSuspended,
     DiscardSuspended,
@@ -145,6 +174,7 @@ pub(crate) async fn run_controller(
     let mut background_tasks = JoinSet::new();
     let (model_discovery_tx, mut model_discovery_rx) = mpsc::channel(4);
     let (clipboard_image_tx, mut clipboard_image_rx) = mpsc::channel(4);
+    let (command_output_tx, mut command_output_rx) = mpsc::channel(4);
     let mut model_discovery_generation = 0_u64;
     let mut model_discovery_token: Option<CancellationToken> = None;
     let mut subagent_activity_open = true;
@@ -163,80 +193,83 @@ pub(crate) async fn run_controller(
             .update_subagent_activity(session.subagent_activity.borrow().clone());
         let mut refresh_interval = new_refresh_interval();
         refresh_interval.tick().await;
-        render_once(&mut terminal, &state)?;
+        render_once(&mut terminal, &mut state)?;
 
         loop {
             tokio::select! {
                 Some(result) = background_tasks.join_next(), if !background_tasks.is_empty() => {
                     result.map_err(unexpected)?;
                 }
-                _ = refresh_interval.tick(), if state.is_active_run() => {
+                _ = refresh_interval.tick(), if needs_refresh(&state) => {
                     if let Some(next) = session.prune_cancelled_permission_reviews() {
                         match next {
                             Some((approval_id, body)) => state.open_permission_review(approval_id, body),
                             None => state.close_overlay(),
                         }
                     }
-                    render_once(&mut terminal, &state)?;
+                    refresh_interactions(&mut state, terminal.size().map_err(unexpected)?);
+                    render_once(&mut terminal, &mut state)?;
                 }
                 event = terminal.next_event() => {
                     let Some(event) = event.map_err(unexpected)? else {
                         break;
                     };
 
-                    match event {
+                    let effect = match event {
                         TerminalEvent::Key(key) => {
-                            let effect = handle_key_event(key, &mut state);
-                            project_local_effect(&effect, &mut state);
-                            render_once(&mut terminal, &state)?;
-                            let providers = ProviderController {
-                                management: &mut provider_management,
-                                discovery_tx: &model_discovery_tx,
-                                discovery_generation: &mut model_discovery_generation,
-                                discovery_token: &mut model_discovery_token,
-                            };
-                            let input_history = InputHistoryController {
-                                store: &input_history_store,
-                                warning_shown: &mut input_history_warning_shown,
-                            };
-                            let services = ControllerServices {
-                                preferences_store: &preferences_store,
-                                input_history,
-                                providers,
-                                clipboard_image_tx: &clipboard_image_tx,
-                                web_service: &mut web_service,
-                                background_tasks: &mut background_tasks,
-                            };
-                            let should_quit = dispatch_effect(
-                                effect,
-                                &mut session,
-                                &mut state,
-                                services,
-                            )
-                            .await?;
-                            if should_quit {
-                                break;
-                            }
-                            render_once(&mut terminal, &state)?;
+                            Some(handle_key_event(key, &mut state))
+                        }
+                        TerminalEvent::Mouse(mouse) => {
+                            let size = terminal.size().map_err(unexpected)?;
+                            Some(handle_mouse_input(mouse, size, &mut state))
                         }
                         TerminalEvent::MouseScrollUp(position) => {
                             let size = terminal.size().map_err(unexpected)?;
                             handle_mouse_scroll_up(position, size, &mut state);
-                            render_once(&mut terminal, &state)?;
+                            None
                         }
                         TerminalEvent::MouseScrollDown(position) => {
                             let size = terminal.size().map_err(unexpected)?;
                             handle_mouse_scroll_down(position, size, &mut state);
-                            render_once(&mut terminal, &state)?;
+                            None
                         }
                         TerminalEvent::Paste(text) => {
                             handle_paste_event(&text, &mut state);
-                            render_once(&mut terminal, &state)?;
+                            None
                         }
                         TerminalEvent::Resize => {
-                            render_once(&mut terminal, &state)?;
+                            state.clear_text_selection();
+                            None
+                        }
+                    };
+                    if let Some(effect) = effect {
+                        project_local_effect(&effect, &mut state);
+                        render_once(&mut terminal, &mut state)?;
+                        let providers = ProviderController {
+                            management: &mut provider_management,
+                            discovery_tx: &model_discovery_tx,
+                            discovery_generation: &mut model_discovery_generation,
+                            discovery_token: &mut model_discovery_token,
+                        };
+                        let input_history = InputHistoryController {
+                            store: &input_history_store,
+                            warning_shown: &mut input_history_warning_shown,
+                        };
+                        let services = ControllerServices {
+                            preferences_store: &preferences_store,
+                            input_history,
+                            providers,
+                            clipboard_image_tx: &clipboard_image_tx,
+                            command_output_tx: &command_output_tx,
+                            terminal: &mut terminal,
+                            web_service: &mut web_service,
+                            background_tasks: &mut background_tasks,
+                        };
+                        if dispatch_effect(effect, &mut session, &mut state, services).await? {
+                            break;
                         }
                     }
+                    render_once(&mut terminal, &mut state)?;
                 }
                 message = session.stream.next_message() => {
                     let Some(message) = message.map_err(unexpected)? else {
@@ -245,7 +278,7 @@ pub(crate) async fn run_controller(
                     match message {
                         InteractiveRunMessage::Event(event) => {
                             projector.apply(event, &mut state);
-                            render_once(&mut terminal, &state)?;
+                            render_once(&mut terminal, &mut state)?;
                         }
                         InteractiveRunMessage::ToolInvocations { batch } => {
                             return Err(unexpected(format!(
@@ -266,7 +299,7 @@ pub(crate) async fn run_controller(
                             state.plan_mut().update_subagent_activity(
                                 session.subagent_activity.borrow().clone(),
                             );
-                            render_once(&mut terminal, &state)?;
+                            render_once(&mut terminal, &mut state)?;
                         }
                         Err(_) => {
                             subagent_activity_open = false;
@@ -281,7 +314,7 @@ pub(crate) async fn run_controller(
                     if let Some((approval_id, body)) = session.enqueue_permission_review(request) {
                         state.open_permission_review(approval_id, body);
                     }
-                    render_once(&mut terminal, &state)?;
+                    render_once(&mut terminal, &mut state)?;
                 }
                 completion = model_discovery_rx.recv() => {
                     let Some(completion) = completion else {
@@ -289,7 +322,7 @@ pub(crate) async fn run_controller(
                     };
                     if completion.generation == model_discovery_generation {
                         state.update_model_picker(&completion.alias, completion.result);
-                        render_once(&mut terminal, &state)?;
+                        render_once(&mut terminal, &mut state)?;
                     }
                 }
                 completion = clipboard_image_rx.recv() => {
@@ -297,7 +330,11 @@ pub(crate) async fn run_controller(
                         continue;
                     };
                     apply_clipboard_image_completion(completion.result, &mut state);
-                    render_once(&mut terminal, &state)?;
+                    render_once(&mut terminal, &mut state)?;
+                }
+                Some(completion) = command_output_rx.recv() => {
+                    completion.apply(&mut state);
+                    render_once(&mut terminal, &mut state)?;
                 }
             }
         }
@@ -311,6 +348,7 @@ pub(crate) async fn run_controller(
     }
     model_discovery_rx.close();
     clipboard_image_rx.close();
+    command_output_rx.close();
     let session_result = session.stream.wait_until_closed().await.map_err(unexpected);
     let tasks_result = drain_background_tasks(&mut background_tasks).await;
     let web_result = web_service.shutdown().await.map_err(unexpected);
@@ -340,11 +378,25 @@ async fn drain_background_tasks(tasks: &mut JoinSet<()>) -> Result<(), CliError>
     }
 }
 
-fn render_once(terminal: &mut TerminalSession, state: &TuiState) -> Result<(), CliError> {
+fn render_once(terminal: &mut TerminalSession, state: &mut TuiState) -> Result<(), CliError> {
+    render::prepare_viewport(state, terminal.size().map_err(unexpected)?);
     terminal
         .draw(|frame| render::render(frame, state))
         .map_err(unexpected)?;
     Ok(())
+}
+
+fn needs_refresh(state: &TuiState) -> bool {
+    state.is_active_run()
+        || state.clipboard_feedback().is_some()
+        || state.text_selection_is_autoscrolling()
+}
+
+fn refresh_interactions(state: &mut TuiState, size: Size) {
+    state.expire_clipboard_feedback();
+    let rects = cockpit_rects(size, state);
+    state.validate_text_selection_area(render::timeline_content_region(rects.timeline));
+    state.autoscroll_text_selection();
 }
 
 fn new_refresh_interval() -> time::Interval {

--- a/crates/merry-cli/src/tui/controller/effects.rs
+++ b/crates/merry-cli/src/tui/controller/effects.rs
@@ -3,7 +3,9 @@
 use crate::{
     cli_error::{CliError, unexpected},
     tui::{
-        controller::{ClipboardImageCompletion, ControllerEffect, ProviderController},
+        controller::{
+            ClipboardImageCompletion, CommandOutputCompletion, ControllerEffect, ProviderController,
+        },
         input_history_store::InputHistoryStore,
         preferences::TuiPreferencesStore,
         runtime::TuiRuntimeSession,
@@ -24,6 +26,8 @@ pub(super) struct ControllerServices<'a> {
     pub(super) input_history: InputHistoryController<'a>,
     pub(super) providers: ProviderController<'a>,
     pub(super) clipboard_image_tx: &'a mpsc::Sender<ClipboardImageCompletion>,
+    pub(super) command_output_tx: &'a mpsc::Sender<CommandOutputCompletion>,
+    pub(super) terminal: &'a mut crate::tui::terminal::TerminalSession,
     pub(super) web_service: &'a mut RuntimeWebService,
     pub(super) background_tasks: &'a mut JoinSet<()>,
 }
@@ -39,6 +43,8 @@ pub(super) async fn dispatch_effect(
         input_history,
         providers,
         clipboard_image_tx,
+        command_output_tx,
+        terminal,
         web_service,
         background_tasks,
     } = services;
@@ -60,6 +66,41 @@ pub(super) async fn dispatch_effect(
     }
     match effect {
         ControllerEffect::None => Ok(false),
+        ControllerEffect::LoadCommandOutput(artifact_id) => {
+            let runtime = session.runtime().clone();
+            let sender = command_output_tx.clone();
+            let generation = state.command_details_generation();
+            background_tasks.spawn(async move {
+                let result = crate::tui::command_details::load_output(&runtime, &artifact_id).await;
+                let _ = sender
+                    .send(CommandOutputCompletion::new(
+                        artifact_id,
+                        generation,
+                        result,
+                    ))
+                    .await;
+            });
+            Ok(false)
+        }
+        ControllerEffect::CopyText(text) => {
+            let (feedback, failed) = match terminal.copy_text(&text) {
+                Ok(()) => (
+                    "Copy requested via OSC 52; terminal support required".to_owned(),
+                    false,
+                ),
+                Err(error) => (format!("Copy failed: {error}"), true),
+            };
+            show_copy_feedback(state, feedback, failed);
+            Ok(false)
+        }
+        ControllerEffect::CopyTextTooLarge => {
+            show_copy_feedback(
+                state,
+                "Copy failed: selected text exceeds the 1 MiB clipboard limit".to_owned(),
+                true,
+            );
+            Ok(false)
+        }
         ControllerEffect::SubmitNext(submission) => {
             let (message, history_text) = submission
                 .into_user_message_and_history()
@@ -212,6 +253,14 @@ pub(super) async fn dispatch_effect(
             Ok(true)
         }
         _ => unreachable!("provider effect handled by the provider dispatcher"),
+    }
+}
+
+fn show_copy_feedback(state: &mut TuiState, feedback: String, failed: bool) {
+    if let Some(crate::tui::overlay::Overlay::CommandDetails(details)) = state.overlay_mut() {
+        details.set_feedback(feedback);
+    } else {
+        state.show_clipboard_feedback(feedback, failed);
     }
 }
 

--- a/crates/merry-cli/src/tui/controller/input.rs
+++ b/crates/merry-cli/src/tui/controller/input.rs
@@ -1,13 +1,16 @@
 //! Synchronous input-to-effect translation and local UI state updates; no external I/O.
 
 use crate::tui::{
+    command_details::CommandNavigation,
     controller::{ControllerEffect, cockpit_rects, exit_review_if_active},
+    copy_controls::CopyTextError,
     input::{DraftImage, TuiSubmission},
     keymap::KeyAction,
-    overlay::OverlayKeyResult,
+    overlay::{Overlay, OverlayKeyResult},
     preferences::TuiPreferences,
     provider_overlay::ModelPickerTarget,
     state::TuiState,
+    text_interaction::MouseInput,
 };
 use crossterm::event::{KeyCode, KeyEvent};
 use merry_core::QueuedInputLane;
@@ -38,6 +41,14 @@ pub(crate) fn handle_key_action(action: KeyAction, state: &mut TuiState) -> Cont
             state.open_command_palette();
             ControllerEffect::None
         }
+        KeyAction::OpenCommandDetails => {
+            if matches!(state.overlay(), Some(Overlay::CommandDetails(_))) {
+                state.close_overlay();
+                ControllerEffect::None
+            } else {
+                crate::tui::command_details::inspect_command(state, CommandNavigation::Latest)
+            }
+        }
         KeyAction::TogglePlan => {
             state.plan_mut().toggle();
             ControllerEffect::None
@@ -64,6 +75,10 @@ pub(crate) fn handle_key_action(action: KeyAction, state: &mut TuiState) -> Cont
         }
         KeyAction::ScrollDown => {
             state.scroll_timeline_down_by(TIMELINE_SCROLL_STEP);
+            ControllerEffect::None
+        }
+        KeyAction::FollowLatest => {
+            state.follow_latest();
             ControllerEffect::None
         }
         KeyAction::ReviewPreviousUserInput => {
@@ -101,10 +116,25 @@ pub(super) fn submit_input(
 }
 
 pub(crate) fn handle_key_event(key: KeyEvent, state: &mut TuiState) -> ControllerEffect {
+    if state.overlay().is_none() && state.clear_text_selection() && key.code == KeyCode::Esc {
+        return ControllerEffect::None;
+    }
+    if matches!(state.overlay(), Some(Overlay::CommandDetails(_)))
+        && state.keymap().action_for(key.into()) == Some(KeyAction::OpenCommandDetails)
+    {
+        return handle_key_action(KeyAction::OpenCommandDetails, state);
+    }
     if let Some(overlay) = state.overlay_mut() {
         let result = overlay.handle_key(key);
         return match result {
             OverlayKeyResult::Consumed => ControllerEffect::None,
+            OverlayKeyResult::PreviousCommand => {
+                crate::tui::command_details::inspect_command(state, CommandNavigation::Previous)
+            }
+            OverlayKeyResult::NextCommand => {
+                crate::tui::command_details::inspect_command(state, CommandNavigation::Next)
+            }
+            OverlayKeyResult::CopyText(text) => ControllerEffect::CopyText(text),
             OverlayKeyResult::Close => {
                 state.close_overlay();
                 ControllerEffect::None
@@ -236,6 +266,8 @@ pub(crate) fn handle_key_event(key: KeyEvent, state: &mut TuiState) -> Controlle
             && matches!(
                 action,
                 KeyAction::OpenCommandPanel
+                    | KeyAction::OpenCommandDetails
+                    | KeyAction::FollowLatest
                     | KeyAction::TogglePlan
                     | KeyAction::Interrupt
                     | KeyAction::Quit
@@ -276,8 +308,49 @@ pub(super) fn input_is_known_slash(state: &TuiState) -> bool {
 }
 
 pub(crate) fn handle_paste_event(text: &str, state: &mut TuiState) {
+    state.clear_text_selection();
     if !state.insert_overlay_paste(text) {
         state.insert_input_paste(text);
+    }
+}
+
+pub(crate) fn handle_mouse_input(
+    mouse: MouseInput,
+    terminal_size: Size,
+    state: &mut TuiState,
+) -> ControllerEffect {
+    if state.overlay().is_some() {
+        state.clear_text_selection();
+        return ControllerEffect::None;
+    }
+    let rects = cockpit_rects(terminal_size, state);
+    state.validate_text_selection_area(crate::tui::render::timeline_content_region(rects.timeline));
+    match mouse {
+        MouseInput::Down(position) => {
+            state.clear_text_selection();
+            match crate::tui::render::timeline_mouse_down(state, rects.timeline, position) {
+                crate::tui::render::TimelineMouseDown::Copy(text) => {
+                    return ControllerEffect::CopyText(text);
+                }
+                crate::tui::render::TimelineMouseDown::CopyTooLarge => {
+                    return ControllerEffect::CopyTextTooLarge;
+                }
+                crate::tui::render::TimelineMouseDown::Select(selection) => {
+                    state.begin_text_selection(selection);
+                }
+                crate::tui::render::TimelineMouseDown::None => {}
+            }
+            ControllerEffect::None
+        }
+        MouseInput::Drag(position) => {
+            state.drag_text_selection(position);
+            ControllerEffect::None
+        }
+        MouseInput::Up(position) => match state.finish_text_selection(position) {
+            Ok(Some(text)) => ControllerEffect::CopyText(text),
+            Ok(None) => ControllerEffect::None,
+            Err(CopyTextError::TooLarge) => ControllerEffect::CopyTextTooLarge,
+        },
     }
 }
 
@@ -286,6 +359,14 @@ pub(crate) fn handle_mouse_scroll_up(
     terminal_size: Size,
     state: &mut TuiState,
 ) {
+    state.clear_text_selection();
+    if let Some(crate::tui::overlay::Overlay::CommandDetails(details)) = state.overlay_mut() {
+        details.handle_key(KeyEvent::new(
+            KeyCode::PageUp,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        return;
+    }
     if state.overlay().is_some() {
         return;
     }
@@ -305,6 +386,14 @@ pub(crate) fn handle_mouse_scroll_down(
     terminal_size: Size,
     state: &mut TuiState,
 ) {
+    state.clear_text_selection();
+    if let Some(crate::tui::overlay::Overlay::CommandDetails(details)) = state.overlay_mut() {
+        details.handle_key(KeyEvent::new(
+            KeyCode::PageDown,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        return;
+    }
     if state.overlay().is_some() {
         return;
     }

--- a/crates/merry-cli/src/tui/controller/tests.rs
+++ b/crates/merry-cli/src/tui/controller/tests.rs
@@ -1,6 +1,8 @@
 use super::{TUI_REFRESH_INTERVAL, drain_background_tasks, new_refresh_interval};
 use tokio::{sync::oneshot, task::JoinSet, time};
 
+mod selection_scroll;
+
 #[tokio::test(start_paused = true)]
 async fn refresh_interval_is_not_reset_by_unrelated_work() {
     let mut refresh_interval = new_refresh_interval();

--- a/crates/merry-cli/src/tui/controller/tests/selection_scroll.rs
+++ b/crates/merry-cli/src/tui/controller/tests/selection_scroll.rs
@@ -1,0 +1,399 @@
+use super::super::{
+    ControllerEffect, TUI_REFRESH_INTERVAL, cockpit_rects, handle_key_event, handle_mouse_input,
+    handle_mouse_scroll_up, needs_refresh, new_refresh_interval, refresh_interactions,
+};
+use crate::tui::{
+    keymap::Keymap,
+    render::{prepare_viewport, render, timeline_content_region},
+    state::{TimelineItem, TuiState},
+    text_interaction::MouseInput,
+    theme::TuiTheme,
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Position, Rect, Size},
+    style::Modifier,
+};
+use tokio::time;
+
+fn label(index: usize) -> String {
+    format!("row-{index:05}")
+}
+
+fn transcript(rows: usize) -> String {
+    (0..rows).map(label).collect::<Vec<_>>().join("\n")
+}
+
+fn state(markdown: &str, start_at_top: bool) -> TuiState {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "test".into(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    state.push_timeline_item(TimelineItem::Assistant {
+        text: markdown.into(),
+    });
+    if start_at_top {
+        state.scroll_timeline_up_by(usize::MAX);
+    }
+    state
+}
+
+fn draw(state: &mut TuiState, size: Size) -> Buffer {
+    prepare_viewport(state, size);
+    let backend = ratatui::backend::TestBackend::new(size.width, size.height);
+    let mut terminal = ratatui::Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| render(frame, state))
+        .unwrap()
+        .buffer
+        .clone()
+}
+
+fn area(state: &TuiState, size: Size) -> Rect {
+    timeline_content_region(cockpit_rects(size, state).timeline)
+}
+
+fn row_text(buffer: &Buffer, area: Rect, row: u16) -> String {
+    (area.x..area.right())
+        .map(|column| buffer[(column, row)].symbol())
+        .collect()
+}
+
+fn visible_text(buffer: &Buffer, area: Rect) -> String {
+    (area.y..area.bottom())
+        .map(|row| row_text(buffer, area, row))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn point(buffer: &Buffer, text: &str) -> Position {
+    for row in buffer.area.y..buffer.area.bottom() {
+        for column in buffer.area.x..buffer.area.right() {
+            if text.chars().enumerate().all(|(offset, character)| {
+                let column = column.saturating_add(u16::try_from(offset).unwrap());
+                column < buffer.area.right()
+                    && buffer[(column, row)].symbol() == character.to_string()
+            }) {
+                return Position::new(column, row);
+            }
+        }
+    }
+    panic!("missing {text} in {}", visible_text(buffer, buffer.area));
+}
+
+fn row_index(buffer: &Buffer, area: Rect, row: u16) -> usize {
+    row_text(buffer, area, row)
+        .trim()
+        .strip_prefix("row-")
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+fn begin_drag(state: &mut TuiState, size: Size, start: Position, end: Position) {
+    assert_eq!(
+        handle_mouse_input(MouseInput::Down(start), size, state),
+        ControllerEffect::None
+    );
+    assert_eq!(
+        handle_mouse_input(MouseInput::Drag(end), size, state),
+        ControllerEffect::None
+    );
+}
+
+fn expected_rows(start: usize, end: usize) -> String {
+    (start..=end).map(label).collect::<Vec<_>>().join("\n")
+}
+
+#[tokio::test(start_paused = true)]
+async fn stationary_edges_scroll_idle_transcripts_and_copy_every_offscreen_row() {
+    for upwards in [true, false] {
+        let size = Size::new(32, 18);
+        let mut state = state(&transcript(120), !upwards);
+        let buffer = draw(&mut state, size);
+        let area = area(&state, size);
+        let anchor_index = if upwards { 117 } else { 2 };
+        let mut anchor = point(&buffer, &label(anchor_index));
+        let edge = if upwards {
+            anchor.x += 8;
+            Position::new(area.x, area.y)
+        } else {
+            Position::new(area.x + 8, area.bottom() - 1)
+        };
+        begin_drag(&mut state, size, anchor, edge);
+        assert!(!state.is_active_run());
+        assert!(state.clipboard_feedback().is_none());
+        assert!(needs_refresh(&state));
+        let mut interval = new_refresh_interval();
+        interval.tick().await;
+        let mut previous = visible_text(&buffer, area);
+        for _ in 0..8 {
+            time::advance(TUI_REFRESH_INTERVAL).await;
+            interval.tick().await;
+            refresh_interactions(&mut state, size);
+            let current = visible_text(&draw(&mut state, size), area);
+            assert_ne!(current, previous);
+            previous = current;
+        }
+        assert!(!previous.contains(&label(anchor_index)));
+        let buffer = draw(&mut state, size);
+        let edge_index = row_index(&buffer, area, edge.y);
+        let expected = if upwards {
+            assert!(anchor_index - edge_index > usize::from(area.height));
+            expected_rows(edge_index, anchor_index)
+        } else {
+            assert!(edge_index - anchor_index > usize::from(area.height));
+            expected_rows(anchor_index, edge_index)
+        };
+        assert_eq!(
+            handle_mouse_input(MouseInput::Up(edge), size, &mut state),
+            ControllerEffect::CopyText(expected)
+        );
+        assert!(!needs_refresh(&state));
+        assert_eq!(visible_text(&draw(&mut state, size), area), previous);
+        refresh_interactions(&mut state, size);
+        assert_eq!(visible_text(&draw(&mut state, size), area), previous);
+        assert_eq!(
+            handle_mouse_input(MouseInput::Up(edge), size, &mut state),
+            ControllerEffect::None
+        );
+    }
+}
+
+#[test]
+fn returning_inside_stops_autoscroll_and_the_opposite_edge_reverses_it() {
+    let size = Size::new(32, 18);
+    let mut state = state(&transcript(120), false);
+    let buffer = draw(&mut state, size);
+    let area = area(&state, size);
+    let anchor = point(&buffer, &label(117));
+    let top = Position::new(area.x, area.y);
+    begin_drag(&mut state, size, anchor, top);
+    refresh_interactions(&mut state, size);
+    let after_up = row_index(&draw(&mut state, size), area, area.y);
+    let inside = Position::new(area.x, area.y + 4);
+    assert_eq!(
+        handle_mouse_input(MouseInput::Drag(inside), size, &mut state),
+        ControllerEffect::None
+    );
+    assert!(!needs_refresh(&state));
+    for _ in 0..4 {
+        refresh_interactions(&mut state, size);
+    }
+    assert_eq!(row_index(&draw(&mut state, size), area, area.y), after_up);
+    let bottom = Position::new(area.x, area.bottom() - 1);
+    assert_eq!(
+        handle_mouse_input(MouseInput::Drag(bottom), size, &mut state),
+        ControllerEffect::None
+    );
+    assert!(needs_refresh(&state));
+    refresh_interactions(&mut state, size);
+    assert!(row_index(&draw(&mut state, size), area, area.y) > after_up);
+}
+
+#[test]
+fn edge_clicks_do_not_scroll_and_dragging_stops_at_both_history_limits() {
+    for upwards in [true, false] {
+        let size = Size::new(32, 18);
+        let mut state = state(&transcript(120), !upwards);
+        let buffer = draw(&mut state, size);
+        let area = area(&state, size);
+        let edge = Position::new(
+            area.x + 20,
+            if upwards { area.y } else { area.bottom() - 1 },
+        );
+        assert_eq!(
+            handle_mouse_input(MouseInput::Down(edge), size, &mut state),
+            ControllerEffect::None
+        );
+        assert!(!needs_refresh(&state));
+        refresh_interactions(&mut state, size);
+        assert_eq!(
+            visible_text(&draw(&mut state, size), area),
+            visible_text(&buffer, area)
+        );
+        assert_eq!(
+            handle_mouse_input(MouseInput::Up(edge), size, &mut state),
+            ControllerEffect::None
+        );
+        let anchor = point(&buffer, &label(if upwards { 117 } else { 2 }));
+        begin_drag(&mut state, size, anchor, edge);
+        for _ in 0..60 {
+            refresh_interactions(&mut state, size);
+        }
+        assert!(!needs_refresh(&state));
+        let at_limit = visible_text(&draw(&mut state, size), area);
+        assert!(at_limit.contains(&label(if upwards { 0 } else { 119 })));
+        for _ in 0..4 {
+            refresh_interactions(&mut state, size);
+        }
+        assert_eq!(visible_text(&draw(&mut state, size), area), at_limit);
+        let opposite = Position::new(edge.x, if upwards { area.bottom() - 1 } else { area.y });
+        assert_eq!(
+            handle_mouse_input(MouseInput::Drag(opposite), size, &mut state),
+            ControllerEffect::None
+        );
+        assert!(needs_refresh(&state));
+        refresh_interactions(&mut state, size);
+        assert_ne!(visible_text(&draw(&mut state, size), area), at_limit);
+    }
+}
+
+#[test]
+fn cancellation_removes_edge_scrolling_and_prevents_a_late_release_from_copying() {
+    enum Cancel {
+        Escape,
+        Resize,
+        Overlay,
+        Click,
+        Wheel,
+    }
+    for cancel in [
+        Cancel::Escape,
+        Cancel::Resize,
+        Cancel::Overlay,
+        Cancel::Click,
+        Cancel::Wheel,
+    ] {
+        let size = Size::new(32, 18);
+        let mut state = state(&transcript(120), false);
+        let buffer = draw(&mut state, size);
+        let area = area(&state, size);
+        let edge = Position::new(area.x, area.y);
+        begin_drag(&mut state, size, point(&buffer, &label(117)), edge);
+        refresh_interactions(&mut state, size);
+        assert!(state.text_selection_is_autoscrolling());
+        match cancel {
+            Cancel::Escape => assert_eq!(
+                handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &mut state),
+                ControllerEffect::None
+            ),
+            Cancel::Resize => refresh_interactions(&mut state, Size::new(24, 18)),
+            Cancel::Overlay => {
+                state.show_info_dialog("Modal", "cancel selection".into());
+                refresh_interactions(&mut state, size);
+            }
+            Cancel::Click => assert_eq!(
+                handle_mouse_input(MouseInput::Down(Position::new(0, 0)), size, &mut state),
+                ControllerEffect::None
+            ),
+            Cancel::Wheel => handle_mouse_scroll_up(edge, size, &mut state),
+        }
+        assert!(!state.text_selection_is_autoscrolling());
+        assert_eq!(
+            handle_mouse_input(MouseInput::Up(edge), size, &mut state),
+            ControllerEffect::None
+        );
+        assert!(!needs_refresh(&state));
+    }
+}
+
+#[test]
+fn streaming_during_autoscroll_keeps_the_copied_snapshot_and_the_final_reading_position() {
+    let size = Size::new(32, 18);
+    let original = transcript(120);
+    let mut state = state(&original, true);
+    let buffer = draw(&mut state, size);
+    let area = area(&state, size);
+    let edge = Position::new(area.x + 8, area.bottom() - 1);
+    begin_drag(&mut state, size, point(&buffer, &label(2)), edge);
+    refresh_interactions(&mut state, size);
+    state.replace_timeline_item(
+        0,
+        TimelineItem::Assistant {
+            text: original.replace("row-", "new-"),
+        },
+    );
+    for _ in 0..8 {
+        refresh_interactions(&mut state, size);
+    }
+    let buffer = draw(&mut state, size);
+    let first = row_index(&buffer, area, area.y);
+    let last = row_index(&buffer, area, edge.y);
+    assert!(!visible_text(&buffer, area).contains("new-"));
+    assert_eq!(
+        handle_mouse_input(MouseInput::Up(edge), size, &mut state),
+        ControllerEffect::CopyText(expected_rows(2, last))
+    );
+    let after_copy = visible_text(&draw(&mut state, size), area);
+    assert!(after_copy.starts_with(&format!("new-{first:05}")));
+    assert!(!after_copy.contains("row-"));
+    assert!(state.is_timeline_detached());
+}
+
+#[test]
+fn autoscroll_and_copy_cross_u16_offsets_and_multiple_copy_chunks() {
+    let size = Size::new(32, 18);
+    let mut state = state(&transcript(66_100), false);
+    let buffer = draw(&mut state, size);
+    let area = area(&state, size);
+    let anchor = point(&buffer, &label(66_097));
+    let edge = Position::new(area.x, area.y);
+    begin_drag(
+        &mut state,
+        size,
+        Position::new(anchor.x + 8, anchor.y),
+        edge,
+    );
+    for _ in 0..200 {
+        refresh_interactions(&mut state, size);
+    }
+    let buffer = draw(&mut state, size);
+    let first = row_index(&buffer, area, area.y);
+    assert!(first < usize::from(u16::MAX));
+    assert_eq!(
+        handle_mouse_input(MouseInput::Up(edge), size, &mut state),
+        ControllerEffect::CopyText(expected_rows(first, 66_097))
+    );
+}
+
+#[test]
+fn wrapped_unicode_snapshot_matches_the_visible_transcript_and_copies_whole_glyphs() {
+    let size = Size::new(24, 18);
+    let mut state = state(
+        &format!(
+            "{}\nprefix 界🙂e\u{301} suffix",
+            "wrapped 界 word ".repeat(500)
+        ),
+        false,
+    );
+    let buffer = draw(&mut state, size);
+    let area = area(&state, size);
+    let prefix = point(&buffer, "prefix");
+    let first = Position::new(prefix.x + 7, prefix.y);
+    assert_eq!(buffer[(first.x, first.y)].symbol(), "界");
+    assert_eq!(
+        handle_mouse_input(
+            MouseInput::Down(Position::new(first.x + 1, first.y)),
+            size,
+            &mut state
+        ),
+        ControllerEffect::None
+    );
+    assert_eq!(
+        visible_text(&draw(&mut state, size), area),
+        visible_text(&buffer, area)
+    );
+    assert_eq!(
+        handle_mouse_input(MouseInput::Drag(first), size, &mut state),
+        ControllerEffect::None
+    );
+    let selected = draw(&mut state, size);
+    assert!(
+        selected[(first.x, first.y)]
+            .modifier
+            .contains(Modifier::REVERSED)
+    );
+    assert!(
+        selected[(first.x + 1, first.y)]
+            .modifier
+            .contains(Modifier::REVERSED)
+    );
+    assert_eq!(
+        handle_mouse_input(MouseInput::Up(first), size, &mut state),
+        ControllerEffect::CopyText("界".into())
+    );
+}

--- a/crates/merry-cli/src/tui/copy_controls.rs
+++ b/crates/merry-cli/src/tui/copy_controls.rs
@@ -1,0 +1,112 @@
+use crate::tui::{state::TuiState, text_wrap::semantic_style, theme::SemanticColor};
+use ratatui::{
+    style::Modifier,
+    text::{Line, Span},
+};
+
+pub(crate) const MAX_CLIPBOARD_BYTES: usize = 1_048_576;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CopyTextError {
+    TooLarge,
+}
+
+pub(crate) struct CopyTextBuilder {
+    text: String,
+}
+
+impl CopyTextBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            text: String::new(),
+        }
+    }
+
+    pub(crate) fn push_str(&mut self, chunk: &str) -> Result<(), CopyTextError> {
+        let next_len = self
+            .text
+            .len()
+            .checked_add(chunk.len())
+            .ok_or(CopyTextError::TooLarge)?;
+        if next_len > MAX_CLIPBOARD_BYTES {
+            return Err(CopyTextError::TooLarge);
+        }
+        self.text.push_str(chunk);
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> String {
+        self.text
+    }
+}
+
+pub(crate) fn validate_copy_text(text: String) -> Result<String, CopyTextError> {
+    if text.len() > MAX_CLIPBOARD_BYTES {
+        Err(CopyTextError::TooLarge)
+    } else {
+        Ok(text)
+    }
+}
+
+/// Code owns its parsed text; replies refer to the existing timeline instead of duplicating it.
+pub(crate) enum CopyContent {
+    Text(String),
+    AssistantMessage(usize),
+}
+
+/// Associates an actual copy control with its undecorated source and logical row.
+pub(crate) struct CopyTarget {
+    pub(crate) line_index: usize,
+    pub(crate) column: u16,
+    pub(crate) width: u16,
+    pub(crate) content: CopyContent,
+}
+
+impl CopyTarget {
+    pub(crate) fn new(line_index: usize, width: u16, content: CopyContent) -> Self {
+        Self {
+            line_index,
+            column: 0,
+            width,
+            content,
+        }
+    }
+}
+
+/// Renders a complete copy control, or omits it when even the compact label cannot fit.
+pub(crate) fn copy_header(
+    state: &TuiState,
+    label: &'static str,
+    width: u16,
+) -> Option<(Line<'static>, u16)> {
+    let label = if usize::from(width) >= label.len() {
+        label
+    } else if width >= 6 {
+        "[Copy]"
+    } else {
+        return None;
+    };
+    let line = Line::from(Span::styled(
+        label,
+        semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD),
+    ));
+    Some((line, u16::try_from(label.len()).unwrap_or(u16::MAX)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CopyTextBuilder, MAX_CLIPBOARD_BYTES};
+
+    #[test]
+    fn copy_builder_rejects_the_first_chunk_over_the_limit() {
+        let mut builder = CopyTextBuilder::new();
+        builder
+            .push_str(&"x".repeat(MAX_CLIPBOARD_BYTES - 1))
+            .expect("payload below the limit should be accepted");
+        builder
+            .push_str("x")
+            .expect("payload at the limit should be accepted");
+        assert_eq!(builder.push_str("x"), Err(super::CopyTextError::TooLarge));
+        assert_eq!(builder.finish().len(), MAX_CLIPBOARD_BYTES);
+    }
+}

--- a/crates/merry-cli/src/tui/keymap.rs
+++ b/crates/merry-cli/src/tui/keymap.rs
@@ -83,7 +83,7 @@ impl Default for Keymap {
                     KeyAction::OpenCommandPanel,
                 ),
                 (
-                    KeyBinding::new(KeyCode::Char('o'), KeyModifiers::ALT),
+                    KeyBinding::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
                     KeyAction::OpenCommandDetails,
                 ),
                 (
@@ -268,6 +268,7 @@ fn parse_binding(value: &str) -> Result<KeyBinding, crate::config::ConfigError> 
         "ctrl+p" => Ok(KeyBinding::new(KeyCode::Char('p'), KeyModifiers::CONTROL)),
         "ctrl+q" => Ok(KeyBinding::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
         "ctrl+r" => Ok(KeyBinding::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+        "ctrl+t" => Ok(KeyBinding::new(KeyCode::Char('t'), KeyModifiers::CONTROL)),
         "ctrl+u" => Ok(KeyBinding::new(KeyCode::Char('u'), KeyModifiers::CONTROL)),
         "ctrl+v" => Ok(KeyBinding::new(KeyCode::Char('v'), KeyModifiers::CONTROL)),
         other => Err(crate::config::ConfigError::Invalid(format!(
@@ -280,6 +281,54 @@ fn parse_binding(value: &str) -> Result<KeyBinding, crate::config::ConfigError> 
 mod tests {
     use super::*;
     use crate::config::TuiKeymapToml;
+
+    #[test]
+    fn command_details_defaults_to_ctrl_t_without_retaining_alt_o() {
+        let keymap = Keymap::default();
+
+        assert_eq!(
+            keymap.action_for(KeyBinding::new(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+            Some(KeyAction::OpenCommandDetails)
+        );
+        assert_eq!(
+            keymap.action_for(KeyBinding::new(KeyCode::Char('o'), KeyModifiers::ALT)),
+            None
+        );
+        assert_eq!(
+            keymap.action_for(KeyBinding::new(KeyCode::Char('o'), KeyModifiers::CONTROL)),
+            Some(KeyAction::TogglePlan)
+        );
+        assert_eq!(
+            keymap
+                .binding_label_for(KeyAction::OpenCommandDetails)
+                .as_deref(),
+            Some("Ctrl+T")
+        );
+    }
+
+    #[test]
+    fn explicitly_configured_alt_o_replaces_the_new_default() {
+        let keymap = Keymap::from_config(&TuiKeymapToml {
+            open_command_details: Some("alt+o".to_owned()),
+            ..TuiKeymapToml::default()
+        })
+        .expect("existing explicit shortcut config should remain valid");
+
+        assert_eq!(
+            keymap.action_for(KeyBinding::new(KeyCode::Char('o'), KeyModifiers::ALT)),
+            Some(KeyAction::OpenCommandDetails)
+        );
+        assert_eq!(
+            keymap.action_for(KeyBinding::new(KeyCode::Char('t'), KeyModifiers::CONTROL)),
+            None
+        );
+        assert_eq!(
+            keymap
+                .binding_label_for(KeyAction::OpenCommandDetails)
+                .as_deref(),
+            Some("Alt+O")
+        );
+    }
 
     #[test]
     fn configured_binding_takes_precedence_over_existing_default_binding() {

--- a/crates/merry-cli/src/tui/keymap.rs
+++ b/crates/merry-cli/src/tui/keymap.rs
@@ -11,11 +11,13 @@ pub(crate) enum KeyAction {
     OpenSessionInBrowser,
     Interrupt,
     OpenCommandPanel,
+    OpenCommandDetails,
     TogglePlan,
     CloseOverlay,
     Quit,
     ScrollUp,
     ScrollDown,
+    FollowLatest,
     ReviewPreviousUserInput,
     HistoryPrevious,
     HistoryNext,
@@ -81,6 +83,10 @@ impl Default for Keymap {
                     KeyAction::OpenCommandPanel,
                 ),
                 (
+                    KeyBinding::new(KeyCode::Char('o'), KeyModifiers::ALT),
+                    KeyAction::OpenCommandDetails,
+                ),
+                (
                     KeyBinding::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
                     KeyAction::TogglePlan,
                 ),
@@ -99,6 +105,10 @@ impl Default for Keymap {
                 (
                     KeyBinding::new(KeyCode::PageDown, KeyModifiers::NONE),
                     KeyAction::ScrollDown,
+                ),
+                (
+                    KeyBinding::new(KeyCode::End, KeyModifiers::CONTROL),
+                    KeyAction::FollowLatest,
                 ),
                 (
                     KeyBinding::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
@@ -159,6 +169,12 @@ impl Keymap {
         }
         if let Some(binding) = config.scroll_down.as_deref() {
             keymap.set_binding(parse_binding(binding)?, KeyAction::ScrollDown);
+        }
+        if let Some(binding) = config.follow_latest.as_deref() {
+            keymap.set_binding(parse_binding(binding)?, KeyAction::FollowLatest);
+        }
+        if let Some(binding) = config.open_command_details.as_deref() {
+            keymap.set_binding(parse_binding(binding)?, KeyAction::OpenCommandDetails);
         }
         if let Some(binding) = config.review_previous_user_input.as_deref() {
             keymap.set_binding(parse_binding(binding)?, KeyAction::ReviewPreviousUserInput);
@@ -233,6 +249,8 @@ fn parse_binding(value: &str) -> Result<KeyBinding, crate::config::ConfigError> 
     match normalized.as_str() {
         "enter" => Ok(KeyBinding::new(KeyCode::Enter, KeyModifiers::NONE)),
         "esc" => Ok(KeyBinding::new(KeyCode::Esc, KeyModifiers::NONE)),
+        "ctrl+end" => Ok(KeyBinding::new(KeyCode::End, KeyModifiers::CONTROL)),
+        "alt+o" => Ok(KeyBinding::new(KeyCode::Char('o'), KeyModifiers::ALT)),
         "up" => Ok(KeyBinding::new(KeyCode::Up, KeyModifiers::NONE)),
         "down" => Ok(KeyBinding::new(KeyCode::Down, KeyModifiers::NONE)),
         "pageup" | "page_up" | "pgup" => Ok(KeyBinding::new(KeyCode::PageUp, KeyModifiers::NONE)),

--- a/crates/merry-cli/src/tui/markdown.rs
+++ b/crates/merry-cli/src/tui/markdown.rs
@@ -1,10 +1,13 @@
 use super::{
+    copy_controls::{CopyContent, CopyTarget, copy_header},
     highlight::highlight_code_to_lines,
     state::TuiState,
     text_wrap::{
-        StyledTextPart, wrap_styled_parts, wrap_styled_parts_preserving_leading_whitespace,
+        StyledTextPart, inline_code_style, semantic_style, wrap_styled_parts,
+        wrap_styled_parts_preserving_leading_whitespace,
     },
     theme::SemanticColor,
+    transcript::{SelectionPolicy, TranscriptRow},
 };
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 use ratatui::{
@@ -13,11 +16,23 @@ use ratatui::{
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+/// Display lines and source-backed controls produced by the same Markdown parse.
+pub(crate) struct RenderedMarkdown {
+    pub(crate) rows: Vec<TranscriptRow>,
+    pub(crate) copy_targets: Vec<CopyTarget>,
+}
+
+impl RenderedMarkdown {
+    fn new(rows: Vec<TranscriptRow>, copy_targets: Vec<CopyTarget>) -> Self {
+        Self { rows, copy_targets }
+    }
+}
+
 pub(crate) fn markdown_lines(
     state: &TuiState,
     markdown: &str,
     region_width: u16,
-) -> Vec<Line<'static>> {
+) -> RenderedMarkdown {
     let parser = Parser::new_ext(
         markdown,
         Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TABLES | Options::ENABLE_TASKLISTS,
@@ -32,7 +47,8 @@ pub(crate) fn markdown_lines(
 struct MarkdownRenderer<'state> {
     state: &'state TuiState,
     region_width: u16,
-    lines: Vec<Line<'static>>,
+    rows: Vec<TranscriptRow>,
+    copy_targets: Vec<CopyTarget>,
     parts: Vec<StyledTextPart>,
     style_stack: Vec<Style>,
     link_stack: Vec<LinkState>,
@@ -79,7 +95,8 @@ impl<'state> MarkdownRenderer<'state> {
         Self {
             state,
             region_width,
-            lines: Vec::new(),
+            rows: Vec::new(),
+            copy_targets: Vec::new(),
             parts: Vec::new(),
             style_stack: vec![semantic_style(state, SemanticColor::Assistant)],
             link_stack: Vec::new(),
@@ -111,10 +128,13 @@ impl<'state> MarkdownRenderer<'state> {
             Event::SoftBreak | Event::HardBreak => self.flush_parts(),
             Event::Rule => {
                 self.flush_parts();
-                self.lines.push(Line::from(Span::styled(
-                    "-".repeat(usize::from(self.region_width).max(1)),
-                    semantic_style(self.state, SemanticColor::Muted),
-                )));
+                self.push_row(TranscriptRow::new(
+                    Line::from(Span::styled(
+                        "-".repeat(usize::from(self.region_width).max(1)),
+                        semantic_style(self.state, SemanticColor::Muted),
+                    )),
+                    SelectionPolicy::Keep,
+                ));
             }
             Event::Html(html) | Event::InlineHtml(html) => self.push_text(html.as_ref()),
             Event::FootnoteReference(reference) => self.push_text(reference.as_ref()),
@@ -394,8 +414,10 @@ impl<'state> MarkdownRenderer<'state> {
         }
         let parts = std::mem::take(&mut self.parts);
         if self.quote_depth == 0 {
-            self.lines
-                .extend(wrap_styled_parts(parts, self.region_width));
+            self.push_lines(
+                wrap_styled_parts(parts, self.region_width),
+                SelectionPolicy::Keep,
+            );
             return;
         }
 
@@ -407,41 +429,73 @@ impl<'state> MarkdownRenderer<'state> {
             .max(1);
         let prefix_style =
             semantic_style(self.state, SemanticColor::Focus).add_modifier(Modifier::BOLD);
-        self.lines.extend(
+        self.push_lines(
             wrap_styled_parts(parts, content_width)
                 .into_iter()
                 .map(|mut line| {
                     line.spans
                         .insert(0, Span::styled(prefix.clone(), prefix_style));
                     line
-                }),
+                })
+                .collect(),
+            SelectionPolicy::Keep,
         );
     }
 
     fn flush_code_block(&mut self, block: CodeBlockState) {
-        let text = block
-            .text
-            .strip_suffix('\n')
-            .unwrap_or(block.text.as_str())
-            .to_owned();
+        let copy_target = if !block.text.is_empty()
+            && let Some((header, width)) = copy_header(self.state, "[Copy code]", self.region_width)
+        {
+            let line_index = self.rows.len();
+            self.push_row(TranscriptRow::new(header, SelectionPolicy::Skip));
+            Some((line_index, width))
+        } else {
+            None
+        };
+        let text = block.text.strip_suffix('\n').unwrap_or(block.text.as_str());
         if let Some(lang) = block.lang {
-            let highlighted = highlight_code_to_lines(&text, &lang, self.state.code_theme());
-            self.lines.extend(
+            let highlighted = highlight_code_to_lines(text, &lang, self.state.code_theme());
+            self.push_lines(
                 highlighted
                     .into_iter()
-                    .flat_map(|line| code_block_visual_lines(self.state, line, self.region_width)),
+                    .flat_map(|line| code_block_visual_lines(self.state, line, self.region_width))
+                    .collect(),
+                SelectionPolicy::StripPrefix(2),
             );
-            return;
+        } else {
+            for line in text.split('\n') {
+                self.push_lines(
+                    code_block_lines(self.state, line, self.region_width),
+                    SelectionPolicy::StripPrefix(2),
+                );
+            }
         }
-        for line in text.split('\n') {
-            self.lines
-                .extend(code_block_lines(self.state, line, self.region_width));
+        if let Some((line_index, width)) = copy_target {
+            self.copy_targets.push(CopyTarget::new(
+                line_index,
+                width,
+                CopyContent::Text(block.text),
+            ));
         }
     }
 
     fn flush_table(&mut self, table: TableState) {
-        self.lines
-            .extend(table_lines(self.state, table.rows, self.region_width));
+        self.push_lines(
+            table_lines(self.state, table.rows, self.region_width),
+            SelectionPolicy::Keep,
+        );
+    }
+
+    fn push_row(&mut self, row: TranscriptRow) {
+        self.rows.push(row);
+    }
+
+    fn push_lines(&mut self, lines: Vec<Line<'static>>, selection: SelectionPolicy) {
+        self.rows.extend(
+            lines
+                .into_iter()
+                .map(|line| TranscriptRow::new(line, selection)),
+        );
     }
 
     fn push_style(&mut self, style: Style) {
@@ -497,12 +551,15 @@ impl<'state> MarkdownRenderer<'state> {
         }
     }
 
-    fn finish(mut self) -> Vec<Line<'static>> {
+    fn finish(mut self) -> RenderedMarkdown {
         self.flush_parts();
-        if self.lines.is_empty() {
-            self.lines.push(Line::from(String::new()));
+        if self.rows.is_empty() {
+            self.push_row(TranscriptRow::new(
+                Line::from(String::new()),
+                SelectionPolicy::Keep,
+            ));
         }
-        self.lines
+        RenderedMarkdown::new(self.rows, self.copy_targets)
     }
 }
 
@@ -785,20 +842,8 @@ fn link_style(state: &TuiState, _url: &str) -> Style {
     semantic_style(state, SemanticColor::Command).add_modifier(Modifier::UNDERLINED)
 }
 
-fn inline_code_style(state: &TuiState, base: Style) -> Style {
-    base.fg.unwrap_or_default();
-    semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD)
-}
-
 fn strikethrough_style(state: &TuiState) -> Style {
     semantic_style(state, SemanticColor::Muted).add_modifier(Modifier::CROSSED_OUT)
-}
-
-fn semantic_style(state: &TuiState, color: SemanticColor) -> Style {
-    state
-        .theme()
-        .color(color)
-        .map_or_else(Style::default, |color| Style::default().fg(color))
 }
 
 fn quote_prefix(depth: usize) -> String {

--- a/crates/merry-cli/src/tui/mod.rs
+++ b/crates/merry-cli/src/tui/mod.rs
@@ -28,9 +28,11 @@ use tokio_util::sync::CancellationToken;
 mod clipboard_image;
 mod command;
 mod command_controller;
+mod command_details;
 mod completion;
 mod controller;
 mod controller_provider;
+mod copy_controls;
 mod highlight;
 mod input;
 mod input_history_store;
@@ -44,6 +46,7 @@ mod plan_controller;
 mod plan_projector;
 mod plan_render;
 mod preferences;
+mod process_output;
 mod projector;
 mod provider_overlay;
 mod provider_render;
@@ -56,9 +59,11 @@ mod session_picker;
 mod state;
 mod status;
 mod terminal;
+mod text_interaction;
 mod text_wrap;
 pub(crate) mod theme;
 mod tool_error;
+mod transcript;
 
 #[cfg(test)]
 mod history_tests;
@@ -161,7 +166,8 @@ pub(crate) async fn run(
         session.model_label.clone(),
         keymap,
         theme,
-    );
+    )
+    .with_successful_command_output(tui_config.show_successful_command_output);
     let input_history_store =
         InputHistoryStore::for_workspace(paths.state_dir(), &session.workspace_root);
     state.set_input_history(input_history_store.load().await);
@@ -587,6 +593,7 @@ async fn run_provider_setup(
                         state.insert_overlay_paste(&text);
                     }
                     terminal::TerminalEvent::Resize
+                    | terminal::TerminalEvent::Mouse(_)
                     | terminal::TerminalEvent::MouseScrollUp(_)
                     | terminal::TerminalEvent::MouseScrollDown(_) => {}
                 }

--- a/crates/merry-cli/src/tui/overlay.rs
+++ b/crates/merry-cli/src/tui/overlay.rs
@@ -67,6 +67,7 @@ pub(crate) enum Overlay {
     PermissionReview(PermissionReviewOverlay),
     Dialog(MessageDialogOverlay),
     Shortcuts(ShortcutsBack),
+    CommandDetails(super::command_details::CommandDetails),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,6 +205,9 @@ pub(crate) struct CommandPalette {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum OverlayKeyResult {
     Consumed,
+    PreviousCommand,
+    NextCommand,
+    CopyText(String),
     Close,
     Back,
     Run(PaletteCommand),
@@ -475,6 +479,7 @@ impl Overlay {
 
         match self {
             Self::CommandPalette(palette) => palette.handle_key(key),
+            Self::CommandDetails(details) => details.handle_key(key),
             Self::Settings(settings) => settings.handle_key(key),
             Self::ProviderManager(manager) => match manager.handle_key(key) {
                 ProviderOverlayAction::Back => OverlayKeyResult::Back,
@@ -544,6 +549,7 @@ impl Overlay {
             Self::Settings(settings) => settings.insert_paste(text),
             Self::ProviderForm(form) => form.insert_paste(text),
             Self::ProviderManager(_)
+            | Self::CommandDetails(_)
             | Self::ModelPicker(_)
             | Self::PlanApproval(_)
             | Self::PermissionReview(_)

--- a/crates/merry-cli/src/tui/overlay_render.rs
+++ b/crates/merry-cli/src/tui/overlay_render.rs
@@ -30,6 +30,9 @@ pub(crate) fn render_overlay(frame: &mut Frame<'_>, state: &TuiState) {
     };
 
     match overlay {
+        Overlay::CommandDetails(details) => {
+            super::command_details::render_details(frame, state, details)
+        }
         Overlay::CommandPalette(palette) => {
             let visible = palette.visible_commands();
             let command_rows = command_palette_rows(&visible);
@@ -404,6 +407,8 @@ fn render_shortcuts(frame: &mut Frame<'_>, state: &TuiState) {
         shortcut_line_for_action(state, "Submit backlog", KeyAction::SubmitBacklog),
         shortcut_line_for_action(state, "Command palette", KeyAction::OpenCommandPanel),
         shortcut_line_for_action(state, "Toggle plan", KeyAction::TogglePlan),
+        shortcut_line_for_action(state, "Command output", KeyAction::OpenCommandDetails),
+        shortcut_line_for_action(state, "Follow latest", KeyAction::FollowLatest),
         shortcut_line_for_action(
             state,
             "Open trajectory in browser",

--- a/crates/merry-cli/src/tui/process_output.rs
+++ b/crates/merry-cli/src/tui/process_output.rs
@@ -1,0 +1,105 @@
+use crate::tui::state::ProcessOutputPreview;
+use merry_runtime::ArtifactContent;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// A normalized captured process stream.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub(crate) struct CapturedStream {
+    #[serde(default)]
+    pub(crate) text: String,
+    #[serde(default)]
+    pub(crate) truncated: bool,
+    #[serde(default)]
+    pub(crate) utf8: Option<bool>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "kind")]
+enum ProcessOutputWire {
+    #[serde(rename = "process_action")]
+    Process {
+        #[serde(default)]
+        stdout: CapturedStream,
+        #[serde(default)]
+        stderr: CapturedStream,
+    },
+}
+
+/// Normalized captured text. Unknown artifact formats remain inspectable as raw text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CapturedOutput {
+    Process {
+        stdout: CapturedStream,
+        stderr: CapturedStream,
+    },
+    Text(String),
+}
+
+impl CapturedOutput {
+    pub(crate) fn from_artifact(content: ArtifactContent) -> Result<Self, String> {
+        let text = match content {
+            ArtifactContent::Text { content } | ArtifactContent::Json { content } => content,
+            _ => {
+                return Err(
+                    "This artifact contains binary data, not a text command output.".into(),
+                );
+            }
+        };
+        Ok(match serde_json::from_str::<ProcessOutputWire>(&text) {
+            Ok(ProcessOutputWire::Process { stdout, stderr }) => Self::Process { stdout, stderr },
+            Err(_) => Self::Text(text),
+        })
+    }
+
+    /// Copies captured text, preserving whitespace and separating stdout from stderr.
+    pub(crate) fn copy_text(&self) -> String {
+        match self {
+            Self::Process { stdout, stderr } => {
+                let mut text = stdout.text.clone();
+                if !text.is_empty() && !text.ends_with('\n') && !stderr.text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(&stderr.text);
+                text
+            }
+            Self::Text(text) => text.clone(),
+        }
+    }
+}
+
+pub(crate) fn process_output_preview(output: &str) -> Option<ProcessOutputPreview> {
+    let value = serde_json::from_str::<Value>(output).ok()?;
+    if value.get("kind").and_then(Value::as_str) != Some("process_action") {
+        return None;
+    }
+    let stdout = value
+        .pointer("/stdout/text")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let stderr = value
+        .pointer("/stderr/text")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let truncated = value.pointer("/stdout/truncated").and_then(Value::as_bool) == Some(true)
+        || value.pointer("/stderr/truncated").and_then(Value::as_bool) == Some(true);
+    Some(ProcessOutputPreview::new(stdout, stderr, truncated))
+}
+
+pub(crate) fn process_exit_code(output: &str) -> Option<i64> {
+    let value = serde_json::from_str::<Value>(output).ok()?;
+    process_exit_code_from_value(&value)
+}
+
+pub(crate) fn process_exit_code_from_value(value: &Value) -> Option<i64> {
+    if value.get("kind").and_then(Value::as_str) != Some("process_action") {
+        return None;
+    }
+    value.get("status").and_then(Value::as_i64).or_else(|| {
+        value
+            .pointer("/status/kind")
+            .and_then(Value::as_str)
+            .filter(|kind| *kind == "exited")
+            .and_then(|_| value.pointer("/status/code").and_then(Value::as_i64))
+    })
+}

--- a/crates/merry-cli/src/tui/projector.rs
+++ b/crates/merry-cli/src/tui/projector.rs
@@ -1,12 +1,13 @@
 use crate::tui::{
     overlay::Overlay,
     plan_projector::plan_timeline_item,
+    process_output::process_exit_code,
     projector::tool_output::{
-        compact_tool_output, completed_tool_title, expanded_tool_title, failed_tool_body,
-        parse_apply_patch_view, process_exit_code, process_output_bodies,
-        started_tool_title_and_detail, success_tool_bodies, tool_output_text,
+        compact_tool_output, completed_process_view, completed_tool_title, expanded_tool_title,
+        failed_tool_body, parse_apply_patch_view, started_tool_title_and_detail,
+        success_tool_bodies, tool_output_text,
     },
-    state::{QueuePreview, TimelineItem, TuiState},
+    state::{CommandView, QueuePreview, TimelineItem, TuiState},
 };
 use merry_core::{
     PlanAttemptOutcome, PlanDirectiveStatus, PlanPhase, RuntimeEvent, TOOL_CANCELLED_BY_USER_CODE,
@@ -16,6 +17,7 @@ use merry_runtime::SessionTranscriptItem;
 use merry_tools::APPLY_PATCH_TOOL;
 use serde_json::Value;
 use std::collections::HashMap;
+use tokio::time::Instant;
 
 mod tool_output;
 
@@ -34,6 +36,9 @@ struct StartedToolView {
     title: String,
     detail: String,
     patch_argument: Option<String>,
+    command: String,
+    cwd: String,
+    started_at: Option<Instant>,
 }
 
 #[allow(dead_code)]
@@ -52,6 +57,7 @@ impl TuiProjector {
                 state.push_timeline_item(TimelineItem::Assistant { text });
             }
             SessionTranscriptItem::ToolCall { call } => {
+                let call_id = call.id().clone();
                 self.apply(
                     RuntimeEvent::ToolCallStarted {
                         call,
@@ -59,6 +65,9 @@ impl TuiProjector {
                     },
                     state,
                 );
+                if let Some(tool) = self.started_tools.get_mut(&call_id) {
+                    tool.started_at = None;
+                }
             }
             SessionTranscriptItem::ToolResult { result, output, .. } => {
                 self.apply(
@@ -146,9 +155,15 @@ impl TuiProjector {
                 let process_exit_code = tool
                     .as_ref()
                     .filter(|tool| tool.name.as_str() == "run_process")
-                    .and_then(|_| process_exit_code(&text))
-                    .filter(|exit_code| failed && *exit_code != 0);
-                if cancelled_by_user {
+                    .and_then(|_| process_exit_code(&text));
+                if let Some(tool) = tool.as_ref()
+                    && tool.name.as_str() == "run_process"
+                {
+                    state.replace_timeline_item(
+                        tool.timeline_index,
+                        completed_process_view(tool, &text, process_exit_code, &result),
+                    );
+                } else if cancelled_by_user {
                     let item = TimelineItem::Muted {
                         title: tool.as_ref().map_or_else(
                             || "Tool -> cancelled".to_owned(),
@@ -161,18 +176,6 @@ impl TuiProjector {
                     } else {
                         state.push_timeline_item(item);
                     }
-                } else if let Some(exit_code) = process_exit_code
-                    && let Some(tool) = tool.as_ref()
-                {
-                    let body =
-                        process_output_bodies(&text).unwrap_or_else(|| compact_tool_output(&text));
-                    state.replace_timeline_item(
-                        tool.timeline_index,
-                        TimelineItem::Expanded {
-                            title: completed_tool_title(tool, &format!("exit {exit_code}")),
-                            body,
-                        },
-                    );
                 } else if failed {
                     let body = failed_tool_body(result.diagnostic(), &text);
                     let item = TimelineItem::Diagnostic {
@@ -333,6 +336,7 @@ impl TuiProjector {
                 });
             }
             RuntimeEvent::RunFailed { diagnostic, .. } => {
+                self.finish_pending_commands(state, "failed");
                 self.streaming_assistant_index = None;
                 let item = TimelineItem::Diagnostic {
                     title: if self.compaction_timeline_index.is_some() {
@@ -349,6 +353,7 @@ impl TuiProjector {
                 }
             }
             RuntimeEvent::RunCancelled { diagnostic, .. } => {
+                self.finish_pending_commands(state, "cancelled");
                 self.streaming_assistant_index = None;
                 let had_compaction = if let Some(index) = self.compaction_timeline_index.take() {
                     state.replace_timeline_item(
@@ -371,6 +376,7 @@ impl TuiProjector {
                 }
             }
             RuntimeEvent::Closed => {
+                self.finish_pending_commands(state, "interrupted");
                 self.streaming_assistant_index = None;
                 state.push_timeline_item(TimelineItem::Muted {
                     title: "closed".to_owned(),
@@ -381,6 +387,23 @@ impl TuiProjector {
         }
     }
 
+    /// Stops command animations when the run ends before individual results arrive.
+    fn finish_pending_commands(&mut self, state: &mut TuiState, status: &str) {
+        self.started_tools.retain(|_, tool| {
+            if tool.name.as_str() != "run_process" {
+                return true;
+            }
+            state.replace_timeline_item(
+                tool.timeline_index,
+                TimelineItem::Muted {
+                    title: completed_tool_title(tool, status),
+                    detail: String::new(),
+                },
+            );
+            false
+        });
+    }
+
     fn start_tool(&mut self, call: merry_core::PendingToolCall, state: &mut TuiState) {
         self.streaming_assistant_index = None;
         let call_id = call.id().clone();
@@ -388,10 +411,21 @@ impl TuiProjector {
         let (title, detail) =
             started_tool_title_and_detail(tool_name.as_str(), call.arguments().as_object());
         let timeline_index = state.timeline().len();
-        state.push_timeline_item(TimelineItem::Muted {
-            title: title.clone(),
-            detail: detail.clone(),
-        });
+        let started_at = Instant::now();
+        let item = if tool_name.as_str() == "run_process" {
+            TimelineItem::Command {
+                view: CommandView::Running {
+                    detail: detail.clone(),
+                    started_at,
+                },
+            }
+        } else {
+            TimelineItem::Muted {
+                title: title.clone(),
+                detail: detail.clone(),
+            }
+        };
+        state.push_timeline_item(item);
         self.started_tools.insert(
             call_id,
             StartedToolView {
@@ -399,6 +433,21 @@ impl TuiProjector {
                 timeline_index,
                 title,
                 detail,
+                started_at: Some(started_at),
+                command: call
+                    .arguments()
+                    .as_object()
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned(),
+                cwd: call
+                    .arguments()
+                    .as_object()
+                    .get("cwd")
+                    .and_then(Value::as_str)
+                    .unwrap_or(".")
+                    .to_owned(),
                 patch_argument: call
                     .arguments()
                     .as_object()

--- a/crates/merry-cli/src/tui/projector/tool_output.rs
+++ b/crates/merry-cli/src/tui/projector/tool_output.rs
@@ -3,8 +3,13 @@
 use crate::{
     tool_display::format_tool_call_detail,
     tui::{
+        process_output::process_output_preview,
         projector::StartedToolView,
-        state::{PatchChangeView, PatchLineKind, PatchLineView, TimelineItem},
+        state::{
+            CommandFailure, CommandView, PatchChangeView, PatchLineKind, PatchLineView,
+            ProcessOutputPreview, TimelineItem,
+        },
+        text_wrap::truncate_chars,
         tool_error::compact_failed_tool_body,
     },
 };
@@ -13,8 +18,6 @@ use merry_tools::APPLY_PATCH_TOOL;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
-
-pub(super) const PROCESS_PREVIEW_MAX_LINES: usize = 5;
 
 // This bounds the timeline preview only; the workspace tool and Focus retain the full file.
 pub(super) const READ_FILE_PREVIEW_MAX_LINES: usize = 120;
@@ -106,7 +109,6 @@ pub(super) fn parse_mcp_tool_name(name: &str) -> Option<(&str, &str)> {
 
 pub(super) fn success_tool_bodies(name: &str, output: &str) -> Option<String> {
     match name {
-        "run_process" => process_output_bodies(output),
         "request_permissions" => permission_output_bodies(output),
         "read_text" => read_text_output_bodies(output),
         _ => None,
@@ -163,65 +165,45 @@ pub(super) struct WorkspaceReadTextOutput {
     pub(super) truncated: bool,
 }
 
-pub(super) fn process_output_bodies(output: &str) -> Option<String> {
-    let value = serde_json::from_str::<Value>(output).ok()?;
-    let stdout = value
-        .pointer("/stdout/text")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let stderr = value
-        .pointer("/stderr/text")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let status = process_exit_code_from_value(&value);
-
-    let mut lines = Vec::new();
-    append_stream_preview(&mut lines, stdout);
-    append_stream_preview(&mut lines, stderr);
-    if lines.is_empty()
-        && let Some(status) = status
-        && status != 0
+pub(super) fn completed_process_view(
+    tool: &StartedToolView,
+    output: &str,
+    exit_code: Option<i64>,
+    result: &merry_core::ToolCallResult,
+) -> TimelineItem {
+    let failure = if result
+        .diagnostic()
+        .is_some_and(|diagnostic| diagnostic.code() == merry_core::TOOL_CANCELLED_BY_USER_CODE)
     {
-        lines.push(format!("  exit {status}"));
+        Some(CommandFailure::Cancelled)
+    } else if result.status() == merry_core::ToolCallResultStatus::Failed
+        && !exit_code.is_some_and(|code| code != 0)
+    {
+        Some(CommandFailure::Failed)
+    } else {
+        None
+    };
+    let mut preview = process_output_preview(output)
+        .unwrap_or_else(|| ProcessOutputPreview::new(&compact_tool_output(output), "", false));
+    if failure == Some(CommandFailure::Failed) {
+        preview = ProcessOutputPreview::new(
+            &failed_tool_body(result.diagnostic(), output),
+            "",
+            preview.truncated,
+        );
     }
-
-    (!lines.is_empty()).then(|| lines.join("\n"))
-}
-
-pub(super) fn process_exit_code(output: &str) -> Option<i64> {
-    let value = serde_json::from_str::<Value>(output).ok()?;
-    process_exit_code_from_value(&value)
-}
-
-pub(super) fn process_exit_code_from_value(value: &Value) -> Option<i64> {
-    if value.get("kind").and_then(Value::as_str) != Some("process_action") {
-        return None;
+    TimelineItem::Command {
+        view: CommandView::Finished {
+            detail: tool.detail.clone(),
+            exit_code,
+            failure,
+            preview,
+            command: tool.command.clone(),
+            cwd: tool.cwd.clone(),
+            artifact: result.artifact().clone(),
+            elapsed: tool.started_at.map(|started_at| started_at.elapsed()),
+        },
     }
-    value.get("status").and_then(Value::as_i64).or_else(|| {
-        value
-            .pointer("/status/kind")
-            .and_then(Value::as_str)
-            .filter(|kind| *kind == "exited")
-            .and_then(|_| value.pointer("/status/code").and_then(Value::as_i64))
-    })
-}
-
-pub(super) fn append_stream_preview(lines: &mut Vec<String>, text: &str) {
-    let stream_lines = text
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .take(PROCESS_PREVIEW_MAX_LINES.saturating_sub(lines.len()));
-    lines.extend(stream_lines.map(|line| format!("  {line}")));
-}
-
-pub(super) fn truncate_chars(text: &str, max_chars: usize) -> String {
-    if max_chars <= 3 {
-        return ".".repeat(max_chars);
-    }
-    if text.chars().count() <= max_chars {
-        return text.to_owned();
-    }
-    text.chars().take(max_chars - 3).collect::<String>() + "..."
 }
 
 pub(super) fn compact_tool_output(output: &str) -> String {

--- a/crates/merry-cli/src/tui/render.rs
+++ b/crates/merry-cli/src/tui/render.rs
@@ -21,16 +21,40 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Paragraph},
 };
+pub(crate) use timeline::{TimelineMouseDown, timeline_content_region, timeline_mouse_down};
 
 mod command_style;
 
 mod composer;
 
 mod timeline;
+mod timeline_layout;
 
 pub(crate) const STATUS_HEIGHT: u16 = 1;
 
 const HEADER_HEIGHT: u16 = 1;
+
+/// Captures the visible timeline anchor before drawing or processing subsequent updates.
+pub(crate) fn prepare_viewport(state: &mut TuiState, size: ratatui::layout::Size) {
+    let area = Rect::new(0, 0, size.width, size.height);
+    super::command_details::prepare_viewport(state, area);
+    let heights = pane_heights_for_area(state, area);
+    let rects = cockpit_layout(
+        area,
+        BottomPaneHeights {
+            queue: heights.queue,
+            completion: heights.completion,
+            input: heights.input,
+            status: STATUS_HEIGHT,
+        },
+        state.plan().is_open(),
+        state.plan().is_focused(),
+    );
+    state.validate_text_selection_area(timeline::timeline_content_region(rects.timeline));
+    if state.text_selection().is_none() {
+        timeline::prepare_timeline_viewport(state, rects.timeline);
+    }
+}
 
 pub(crate) fn render(frame: &mut Frame<'_>, state: &TuiState) {
     let pane_heights = pane_heights(state, frame.area().height);
@@ -166,6 +190,18 @@ fn header_background_style(state: &TuiState) -> Style {
 }
 
 fn render_status(frame: &mut Frame<'_>, state: &TuiState, region: Rect) {
+    if let Some(feedback) = state.clipboard_feedback() {
+        let color = if feedback.failed {
+            SemanticColor::Error
+        } else {
+            SemanticColor::Focus
+        };
+        frame.render_widget(
+            Paragraph::new(feedback.message.as_str()).style(semantic_style(state, color)),
+            region,
+        );
+        return;
+    }
     let interaction_style = if state.is_active_run() {
         semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD)
     } else {

--- a/crates/merry-cli/src/tui/render/timeline.rs
+++ b/crates/merry-cli/src/tui/render/timeline.rs
@@ -1,214 +1,122 @@
 //! Timeline content, wrapping, and bounded viewport projection.
 
 use crate::tui::{
-    markdown::markdown_lines,
+    copy_controls::{CopyContent, CopyTarget, CopyTextError, copy_header, validate_copy_text},
+    keymap::KeyAction,
+    markdown::{RenderedMarkdown, markdown_lines},
     render::command_style::command_spans,
-    state::{PatchChangeView, TimelineItem, TuiState},
+    state::{CommandFailure, CommandView, PatchChangeView, TimelineItem, TuiState},
+    text_interaction::TextSelection,
     text_wrap::{
         StyledTextPart, inline_code_spans, semantic_style, truncate_chars, wrap_styled_parts,
+        wrap_styled_parts_preserving_leading_whitespace,
     },
     theme::SemanticColor,
+    transcript::{SelectionPolicy, TranscriptRow},
 };
 use merry_core::QueuedInputLane;
 use ratatui::{
     Frame,
-    layout::Rect,
-    style::{Modifier, Style},
+    layout::{Position, Rect},
+    style::Modifier,
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Paragraph, Wrap},
+    widgets::{Block, BorderType, Borders, Padding, Paragraph, Wrap},
+};
+
+pub(super) use super::timeline_layout::prepare_timeline_viewport;
+pub(crate) use super::timeline_layout::timeline_content_region;
+use super::timeline_layout::{
+    TimelineLayout, timeline_layout, timeline_scroll_start, timeline_viewport,
 };
 
 // Keep prefix eviction below the viewport start when Paragraph scroll exceeds u16.
-pub(super) const MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES: usize = 32_768;
-
 pub(super) const TOOL_RESULT_PREVIEW_MAX_LINES: usize = 5;
 
 pub(super) fn render_timeline_pane(frame: &mut Frame<'_>, state: &TuiState, region: Rect) {
-    let timeline = timeline_lines_compact(state, region);
-    let viewport = timeline_viewport(state, timeline, region);
+    let mut block = Block::default()
+        .borders(Borders::BOTTOM)
+        .border_type(BorderType::Plain)
+        .border_style(semantic_style(state, SemanticColor::Muted))
+        .title_style(semantic_style(state, SemanticColor::Muted))
+        .padding(Padding::left(1));
+    let mut review_hint_width = 0;
+    if state.is_timeline_detached() {
+        let key = state.keymap().binding_label_for(KeyAction::FollowLatest);
+        let label = if state.timeline_has_updates() {
+            "New content"
+        } else {
+            "Reviewing"
+        };
+        let hint = key
+            .map(|key| format!(" · {key} latest"))
+            .unwrap_or_default();
+        let title = Line::from(format!(" {label}{hint} "));
+        review_hint_width = title.width();
+        block = block.title_bottom(title);
+    }
+    if state.overlay().is_none()
+        && let Some(key) = state
+            .keymap()
+            .binding_label_for(KeyAction::OpenCommandDetails)
+        && state.timeline().iter().rev().any(|item| {
+            matches!(
+                item,
+                TimelineItem::Command {
+                    view: CommandView::Finished { .. }
+                }
+            )
+        })
+    {
+        let hint = Line::from(format!(" {key} output ")).right_aligned();
+        if review_hint_width.saturating_add(hint.width()) <= usize::from(region.width) {
+            block = block.title_bottom(hint);
+        }
+    }
+    let content_region = block.inner(region);
+    frame.render_widget(block, region);
+    if content_region.is_empty() {
+        return;
+    }
+    if let Some(selection) = state.text_selection()
+        && selection.area() == content_region
+    {
+        selection.render(frame.buffer_mut());
+        return;
+    }
+    let timeline = timeline_layout(state, content_region);
+    let viewport = timeline_viewport(state, timeline, content_region);
     frame.render_widget(
         Paragraph::new(viewport.lines)
             .wrap(Wrap { trim: false })
-            .scroll((viewport.scroll, 0))
-            .block(
-                Block::default()
-                    .borders(Borders::BOTTOM)
-                    .border_type(BorderType::Plain)
-                    .border_style(semantic_style(state, SemanticColor::Muted))
-                    .title_style(semantic_style(state, SemanticColor::Muted)),
-            ),
-        region,
+            .scroll((viewport.scroll, 0)),
+        content_region,
     );
-}
-
-pub(super) struct TimelineLines {
-    pub(super) lines: Vec<Line<'static>>,
-    pub(super) review_logical_start: Option<usize>,
-}
-
-pub(super) struct TimelineViewport {
-    pub(super) lines: Vec<Line<'static>>,
-    pub(super) scroll: u16,
-}
-
-pub(super) fn timeline_lines_compact(state: &TuiState, region: Rect) -> TimelineLines {
-    let mut lines = Vec::new();
-    let mut review_logical_start = None;
-    for (index, item) in state.timeline().iter().enumerate() {
-        if state.timeline_review_user_index() == Some(index) {
-            review_logical_start = Some(lines.len());
-        }
-        let item_lines = match item {
-            TimelineItem::User { text, lane } => user_lines(state, text, *lane),
-            TimelineItem::Assistant { text } => assistant_lines(state, text, region.width),
-            TimelineItem::Muted { title, detail } => muted_lines(state, title, detail),
-            TimelineItem::LocalCommand { title, body } => {
-                local_command_lines(state, title, body, region.width)
-            }
-            TimelineItem::Expanded { title, body } => {
-                expanded_timeline_lines(state, title, body, region.width)
-            }
-            TimelineItem::Diagnostic { title, body } => {
-                diagnostic_lines(state, title, body, region.width)
-            }
-            TimelineItem::Patch { changes } => compact_patch_lines(state, changes),
-        };
-        let item_lines = item_lines
-            .into_iter()
-            .flat_map(split_oversized_timeline_line)
-            .collect();
-        lines.extend(spaced_timeline_item(
-            item_lines,
-            index + 1 < state.timeline().len(),
-        ));
-    }
-    TimelineLines {
-        lines,
-        review_logical_start,
-    }
-}
-
-pub(super) fn timeline_viewport(
-    state: &TuiState,
-    timeline: TimelineLines,
-    region: Rect,
-) -> TimelineViewport {
-    let mut scroll = timeline_scroll_start(state, &timeline, region);
-    let mut lines = timeline.lines;
-    let max_scroll = usize::from(u16::MAX);
-    if scroll > max_scroll {
-        // Paragraph scroll is u16; remove complete prefix lines in one linear pass.
-        let rows_to_drop = scroll - max_scroll;
-        let mut dropped_lines = 0;
-        let mut dropped_rows = 0;
-        for line in &lines {
-            if dropped_rows >= rows_to_drop {
-                break;
-            }
-            dropped_rows += wrapped_line_count(std::slice::from_ref(line), region.width).max(1);
-            dropped_lines += 1;
-        }
-        if dropped_lines > 0 {
-            lines.drain(..dropped_lines);
-            scroll = scroll.saturating_sub(dropped_rows);
-        }
-    }
-
-    TimelineViewport {
-        lines,
-        scroll: u16::try_from(scroll).unwrap_or(u16::MAX),
-    }
-}
-
-pub(super) fn timeline_scroll_start(
-    state: &TuiState,
-    timeline: &TimelineLines,
-    region: Rect,
-) -> usize {
-    if let Some(logical_start) = timeline.review_logical_start {
-        wrapped_line_count(&timeline.lines[..logical_start], region.width)
-    } else {
-        let total = wrapped_line_count(&timeline.lines, region.width);
-        let visible = usize::from(region.height.saturating_sub(1));
-        total
-            .saturating_sub(visible)
-            .saturating_sub(state.timeline_scroll_offset())
-    }
-}
-
-pub(super) fn wrapped_line_count(lines: &[Line<'static>], width: u16) -> usize {
-    Paragraph::new(lines.to_vec())
-        .wrap(Wrap { trim: false })
-        .line_count(width)
-}
-
-pub(super) fn split_oversized_timeline_line(line: Line<'static>) -> Vec<Line<'static>> {
-    let byte_len = line.spans.iter().fold(0_usize, |total, span| {
-        total.saturating_add(span.content.len())
-    });
-    if byte_len <= MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES {
-        return vec![line];
-    }
-
-    let Line {
-        style,
-        alignment,
-        spans,
-    } = line;
-    let mut lines = Vec::new();
-    let mut current_spans = Vec::new();
-    let mut current_graphemes = 0;
-
-    for span in spans {
-        let mut chunk = String::new();
-        for grapheme in span.styled_graphemes(Style::default()) {
-            if current_graphemes == MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES {
-                if !chunk.is_empty() {
-                    current_spans.push(Span::styled(std::mem::take(&mut chunk), span.style));
-                }
-                lines.push(Line {
-                    style,
-                    alignment,
-                    spans: std::mem::take(&mut current_spans),
-                });
-                current_graphemes = 0;
-            }
-            chunk.push_str(grapheme.symbol);
-            current_graphemes += 1;
-        }
-        if !chunk.is_empty() {
-            current_spans.push(Span::styled(chunk, span.style));
-        }
-    }
-
-    if !current_spans.is_empty() || lines.is_empty() {
-        lines.push(Line {
-            style,
-            alignment,
-            spans: current_spans,
-        });
-    }
-    lines
-}
-
-pub(super) fn spaced_timeline_item(
-    mut lines: Vec<Line<'static>>,
-    has_next_item: bool,
-) -> Vec<Line<'static>> {
-    if has_next_item && !lines.is_empty() {
-        lines.push(Line::from(""));
-    }
-    lines
 }
 
 pub(super) fn assistant_lines(
     state: &TuiState,
     text: &str,
+    item_index: usize,
     region_width: u16,
-) -> Vec<Line<'static>> {
-    let mut lines = markdown_lines(state, text, region_width);
-    lines.push(assistant_separator_line(state, region_width));
-    lines
+) -> RenderedMarkdown {
+    let mut rendered = markdown_lines(state, text, region_width);
+    if let Some((header, width)) = copy_header(state, "[Copy reply]", region_width) {
+        rendered
+            .rows
+            .insert(0, TranscriptRow::new(header, SelectionPolicy::Skip));
+        for target in &mut rendered.copy_targets {
+            target.line_index += 1;
+        }
+        rendered.copy_targets.insert(
+            0,
+            CopyTarget::new(0, width, CopyContent::AssistantMessage(item_index)),
+        );
+    }
+    rendered.rows.push(TranscriptRow::new(
+        assistant_separator_line(state, region_width),
+        SelectionPolicy::Skip,
+    ));
+    rendered
 }
 
 pub(super) fn assistant_separator_line(state: &TuiState, region_width: u16) -> Line<'static> {
@@ -289,22 +197,112 @@ pub(super) fn local_command_lines(
     title: &str,
     body: &str,
     region_width: u16,
-) -> Vec<Line<'static>> {
-    let mut lines = vec![Line::from(Span::styled(
-        title.to_owned(),
-        semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD),
-    ))];
-    let body_width = region_width.saturating_sub(2).max(1);
-    lines.extend(
-        markdown_lines(state, body, body_width)
-            .into_iter()
-            .map(|line| {
-                let mut spans = vec![Span::raw("  ")];
-                spans.extend(line.spans);
-                Line::from(spans)
-            }),
+) -> RenderedMarkdown {
+    let mut rows = vec![TranscriptRow::new(
+        Line::from(Span::styled(
+            title.to_owned(),
+            semantic_style(state, SemanticColor::Focus).add_modifier(Modifier::BOLD),
+        )),
+        SelectionPolicy::Skip,
+    )];
+    let body_width = region_width.saturating_sub(1).max(1);
+    let mut rendered = markdown_lines(state, body, body_width);
+    rows.extend(rendered.rows.into_iter().map(|row| {
+        let mut spans = vec![Span::raw(" ")];
+        spans.extend(row.display.spans);
+        TranscriptRow::new(Line::from(spans), row.selection.with_prefix(1))
+    }));
+    rendered.rows = rows;
+    for target in &mut rendered.copy_targets {
+        target.line_index += 1;
+        target.column += 1;
+    }
+    rendered
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TimelineMouseDown {
+    None,
+    Copy(String),
+    CopyTooLarge,
+    Select(TextSelection),
+}
+
+/// Resolves a timeline press from one layout snapshot.
+pub(crate) fn timeline_mouse_down(
+    state: &TuiState,
+    region: Rect,
+    position: Position,
+) -> TimelineMouseDown {
+    let content = timeline_content_region(region);
+    if !region.contains(position) || content.is_empty() {
+        return TimelineMouseDown::None;
+    }
+    let timeline = timeline_layout(state, content);
+    if content.contains(position) {
+        match copy_target_text(state, &timeline, content, position) {
+            Ok(Some(text)) => return TimelineMouseDown::Copy(text),
+            Ok(None) => {}
+            Err(CopyTextError::TooLarge) => return TimelineMouseDown::CopyTooLarge,
+        }
+    }
+    let position = Position::new(
+        position
+            .x
+            .clamp(content.x, content.right().saturating_sub(1)),
+        position
+            .y
+            .clamp(content.y, content.bottom().saturating_sub(1)),
     );
-    lines
+    let scroll = timeline_scroll_start(state, &timeline, content);
+    match TextSelection::new(
+        timeline.rows,
+        timeline.item_starts,
+        timeline.row_starts,
+        content,
+        scroll,
+        position,
+    ) {
+        Some(selection) => TimelineMouseDown::Select(selection),
+        None => TimelineMouseDown::None,
+    }
+}
+
+fn copy_target_text(
+    state: &TuiState,
+    timeline: &TimelineLayout,
+    content: Rect,
+    position: Position,
+) -> Result<Option<String>, CopyTextError> {
+    let clicked_row = timeline_scroll_start(state, timeline, content)
+        .saturating_add(usize::from(position.y - content.y));
+    let column = position.x - content.x;
+    for target in &timeline.copy_targets {
+        let Some(&target_row) = timeline.row_starts.get(target.line_index) else {
+            continue;
+        };
+        if target_row > clicked_row {
+            break;
+        }
+        if target_row == clicked_row
+            && (target.column..target.column.saturating_add(target.width)).contains(&column)
+        {
+            return match &target.content {
+                CopyContent::Text(text) => validate_copy_text(text.clone()).map(Some),
+                CopyContent::AssistantMessage(index) => match state.timeline().get(*index) {
+                    Some(TimelineItem::Assistant { text }) => {
+                        if text.len() > crate::tui::copy_controls::MAX_CLIPBOARD_BYTES {
+                            Err(CopyTextError::TooLarge)
+                        } else {
+                            Ok(Some(text.clone()))
+                        }
+                    }
+                    _ => Ok(None),
+                },
+            };
+        }
+    }
+    Ok(None)
 }
 
 pub(super) fn expanded_timeline_lines(
@@ -338,6 +336,132 @@ pub(super) fn expanded_timeline_lines(
         )));
     }
     lines
+}
+
+pub(super) fn command_lines(
+    state: &TuiState,
+    view: &CommandView,
+    region_width: u16,
+) -> Vec<Line<'static>> {
+    match view {
+        CommandView::Running { detail, started_at } => {
+            let elapsed = started_at.elapsed();
+            let spinner = match (elapsed.as_millis() / 100) % 8 {
+                0 => "⠋",
+                1 => "⠙",
+                2 => "⠹",
+                3 => "⠸",
+                4 => "⠼",
+                5 => "⠴",
+                6 => "⠦",
+                _ => "⠧",
+            };
+            let mut title = command_title_line(state, &format!("Running {spinner}"), detail);
+            append_command_elapsed(state, &mut title, Some(elapsed));
+            wrap_command_title(title, region_width)
+        }
+        CommandView::Finished {
+            detail,
+            exit_code,
+            failure,
+            preview,
+            elapsed,
+            ..
+        } => {
+            let mut title = command_title_line(state, "Ran", detail);
+            let failed =
+                exit_code.is_some_and(|code| code != 0) || *failure == Some(CommandFailure::Failed);
+            if let Some(failure) = failure {
+                let (label, color) = match failure {
+                    CommandFailure::Cancelled => ("cancelled", SemanticColor::Warning),
+                    CommandFailure::Failed => ("failed", SemanticColor::Error),
+                };
+                title.spans.push(Span::styled(
+                    format!(" -> {label}"),
+                    semantic_style(state, color).add_modifier(Modifier::BOLD),
+                ));
+            } else if let Some(code) = exit_code.filter(|_| failed) {
+                title.spans.push(Span::styled(
+                    format!(" -> {code}"),
+                    semantic_style(state, SemanticColor::Error).add_modifier(Modifier::BOLD),
+                ));
+            }
+            append_command_elapsed(state, &mut title, *elapsed);
+            let mut lines = wrap_command_title(title, region_width);
+            if failed || (failure.is_none() && state.show_successful_command_output()) {
+                let body_width = usize::from(region_width).saturating_sub(2).max(4);
+                for line in &preview.lines {
+                    let clean = line
+                        .chars()
+                        .filter(|character| !character.is_control())
+                        .collect::<String>();
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", truncate_chars(clean.trim(), body_width)),
+                        semantic_style(state, SemanticColor::Muted),
+                    )));
+                }
+                if preview.truncated {
+                    lines.push(Line::from(Span::styled(
+                        "  ...",
+                        semantic_style(state, SemanticColor::Muted),
+                    )));
+                }
+            }
+            lines
+        }
+    }
+}
+
+fn append_command_elapsed(
+    state: &TuiState,
+    line: &mut Line<'static>,
+    elapsed: Option<std::time::Duration>,
+) {
+    if let Some(elapsed) = elapsed.filter(|elapsed| elapsed.as_secs() >= 1) {
+        line.spans.push(Span::styled(
+            format!("  {:.1}s", elapsed.as_secs_f64()),
+            semantic_style(state, SemanticColor::Muted),
+        ));
+    }
+}
+
+fn wrap_command_title(title: Line<'static>, width: u16) -> Vec<Line<'static>> {
+    let prefix_width = title.spans.iter().take(2).map(Span::width).sum::<usize>();
+    let indent = if usize::from(width) > prefix_width {
+        prefix_width
+    } else {
+        0
+    };
+    let mut spans = title.spans;
+    let prefix = if indent > 0 {
+        spans.drain(..2).collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let parts = spans
+        .into_iter()
+        .map(|span| StyledTextPart {
+            text: span.content.into_owned(),
+            style: span.style,
+            atomic: false,
+        })
+        .collect();
+    let body_width = width
+        .saturating_sub(u16::try_from(indent).unwrap_or_default())
+        .max(1);
+    wrap_styled_parts_preserving_leading_whitespace(parts, body_width)
+        .into_iter()
+        .enumerate()
+        .map(|(index, mut line)| {
+            let mut leading = if index == 0 {
+                prefix.clone()
+            } else {
+                vec![Span::raw(" ".repeat(indent))]
+            };
+            leading.append(&mut line.spans);
+            Line::from(leading)
+        })
+        .collect()
 }
 
 pub(super) fn diagnostic_lines(
@@ -382,7 +506,7 @@ pub(super) fn tool_title_line_from_parts(
     }
 
     if title == "Ran" {
-        return Some(ran_title_line(state, detail));
+        return Some(command_title_line(state, "Ran", detail));
     }
     tool_title_keyword(title).map(|keyword| tool_keyword_title_line(state, keyword, detail))
 }
@@ -392,7 +516,7 @@ pub(super) fn tool_title_line(state: &TuiState, title: &str) -> Option<Line<'sta
         .strip_prefix("Ran ")
         .or_else(|| title.strip_prefix("Ran: "))
     {
-        return Some(ran_title_line(state, command));
+        return Some(command_title_line(state, "Ran", command));
     }
 
     for keyword in TOOL_TITLE_KEYWORDS {
@@ -444,11 +568,11 @@ pub(super) fn tool_keyword_title_line(
     Line::from(spans)
 }
 
-pub(super) fn ran_title_line(state: &TuiState, detail: &str) -> Line<'static> {
+fn command_title_line(state: &TuiState, keyword: &str, detail: &str) -> Line<'static> {
     let (command, suffix) = split_command_suffix(detail);
     let mut spans = vec![
         Span::styled(
-            "Ran".to_owned(),
+            keyword.to_owned(),
             semantic_style(state, SemanticColor::ToolKeyword).add_modifier(Modifier::BOLD),
         ),
         Span::styled(" ".to_owned(), semantic_style(state, SemanticColor::Muted)),

--- a/crates/merry-cli/src/tui/render/timeline_layout.rs
+++ b/crates/merry-cli/src/tui/render/timeline_layout.rs
@@ -1,0 +1,296 @@
+//! Builds the transcript layout shared by drawing, hit testing, and selection.
+
+use super::timeline::{
+    assistant_lines, command_lines, compact_patch_lines, diagnostic_lines, expanded_timeline_lines,
+    local_command_lines, muted_lines, user_lines,
+};
+use crate::tui::{
+    copy_controls::CopyTarget,
+    state::{TimelineAnchor, TimelineItem, TuiState},
+    transcript::{SelectionPolicy, TranscriptRow},
+};
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Borders, Padding, Paragraph, Wrap},
+};
+
+// Keep prefix eviction below the viewport start when Paragraph scroll exceeds u16.
+pub(super) const MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES: usize = 32_768;
+
+pub(super) struct TimelineLayout {
+    pub(super) rows: Vec<TranscriptRow>,
+    pub(super) review_logical_start: Option<usize>,
+    pub(super) item_starts: Vec<usize>,
+    pub(super) row_starts: Vec<usize>,
+    pub(super) copy_targets: Vec<CopyTarget>,
+}
+
+impl TimelineLayout {
+    pub(super) fn total_rows(&self) -> usize {
+        self.row_starts.last().copied().unwrap_or(0)
+    }
+}
+
+pub(super) struct TimelineViewport {
+    pub(super) lines: Vec<Line<'static>>,
+    pub(super) scroll: u16,
+}
+
+pub(super) fn timeline_layout(state: &TuiState, region: Rect) -> TimelineLayout {
+    let mut rows = Vec::new();
+    let mut review_logical_start = None;
+    let mut item_starts = Vec::new();
+    let mut copy_targets = Vec::new();
+    for (index, item) in state.timeline().iter().enumerate() {
+        item_starts.push(rows.len());
+        if state.timeline_review_user_index() == Some(index) {
+            review_logical_start = Some(rows.len());
+        }
+        let mut item_targets = Vec::new();
+        let item_rows = match item {
+            TimelineItem::User { text, lane } => user_lines(state, text, *lane)
+                .into_iter()
+                .map(|line| TranscriptRow::new(line, SelectionPolicy::StripPrefix(2)))
+                .collect::<Vec<_>>(),
+            TimelineItem::Assistant { text } => {
+                let rendered = assistant_lines(state, text, index, region.width);
+                item_targets = rendered.copy_targets;
+                rendered.rows
+            }
+            TimelineItem::Muted { title, detail } => muted_lines(state, title, detail)
+                .into_iter()
+                .map(|line| TranscriptRow::new(line, SelectionPolicy::Keep))
+                .collect(),
+            TimelineItem::Command { view } => command_lines(state, view, region.width)
+                .into_iter()
+                .map(|line| TranscriptRow::new(line, SelectionPolicy::Keep))
+                .collect(),
+            TimelineItem::LocalCommand { title, body } => {
+                let rendered = local_command_lines(state, title, body, region.width);
+                item_targets = rendered.copy_targets;
+                rendered.rows
+            }
+            TimelineItem::Expanded { title, body } => {
+                expanded_timeline_lines(state, title, body, region.width)
+                    .into_iter()
+                    .map(|line| TranscriptRow::new(line, SelectionPolicy::Keep))
+                    .collect()
+            }
+            TimelineItem::Diagnostic { title, body } => {
+                diagnostic_lines(state, title, body, region.width)
+                    .into_iter()
+                    .map(|line| TranscriptRow::new(line, SelectionPolicy::Keep))
+                    .collect()
+            }
+            TimelineItem::Patch { changes } => compact_patch_lines(state, changes)
+                .into_iter()
+                .map(|line| TranscriptRow::new(line, SelectionPolicy::Keep))
+                .collect(),
+        };
+        let compact_commands = item_rows.len() == 1
+            && matches!(item, TimelineItem::Command { .. })
+            && matches!(
+                state.timeline().get(index + 1),
+                Some(TimelineItem::Command { .. })
+            );
+        let item_rows = spaced_timeline_item(
+            item_rows,
+            index + 1 < state.timeline().len() && !compact_commands,
+        );
+        let mut item_targets = item_targets.into_iter().peekable();
+        for (line_index, row) in item_rows.into_iter().enumerate() {
+            if item_targets
+                .peek()
+                .is_some_and(|target| target.line_index == line_index)
+                && let Some(mut target) = item_targets.next()
+            {
+                target.line_index = rows.len();
+                copy_targets.push(target);
+            }
+            rows.extend(
+                split_oversized_timeline_line(row.display)
+                    .into_iter()
+                    .map(|display| TranscriptRow::new(display, row.selection)),
+            );
+        }
+    }
+    let mut row_starts: Vec<usize> = Vec::with_capacity(rows.len().saturating_add(1));
+    row_starts.push(0);
+    for row in &rows {
+        let count = wrapped_line_count(std::slice::from_ref(&row.display), region.width).max(1);
+        let next = row_starts
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(count);
+        row_starts.push(next);
+    }
+    TimelineLayout {
+        rows,
+        review_logical_start,
+        item_starts,
+        row_starts,
+        copy_targets,
+    }
+}
+
+pub(super) fn timeline_viewport(
+    state: &TuiState,
+    timeline: TimelineLayout,
+    region: Rect,
+) -> TimelineViewport {
+    let mut scroll = timeline_scroll_start(state, &timeline, region);
+    let mut rows = timeline.rows;
+    let row_starts = timeline.row_starts;
+    let max_scroll = usize::from(u16::MAX);
+    if scroll > max_scroll {
+        // Paragraph scroll is u16; remove complete prefix lines in one linear pass.
+        let rows_to_drop = scroll - max_scroll;
+        let mut dropped_lines = 0;
+        let mut dropped_rows = 0;
+        for (index, _) in rows.iter().enumerate() {
+            if dropped_rows >= rows_to_drop {
+                break;
+            }
+            dropped_rows += row_starts[index + 1].saturating_sub(row_starts[index]);
+            dropped_lines += 1;
+        }
+        if dropped_lines > 0 {
+            rows.drain(..dropped_lines);
+            scroll = scroll.saturating_sub(dropped_rows);
+        }
+    }
+
+    TimelineViewport {
+        lines: rows.into_iter().map(|row| row.display).collect(),
+        scroll: u16::try_from(scroll).unwrap_or(u16::MAX),
+    }
+}
+
+pub(super) fn timeline_scroll_start(
+    state: &TuiState,
+    timeline: &TimelineLayout,
+    region: Rect,
+) -> usize {
+    if let Some(anchor) = state.timeline_anchor()
+        && let Some(&start) = timeline.item_starts.get(anchor.item_index)
+    {
+        let end = timeline
+            .item_starts
+            .get(anchor.item_index + 1)
+            .copied()
+            .unwrap_or(timeline.rows.len());
+        let item_rows = timeline.row_starts[end].saturating_sub(timeline.row_starts[start]);
+        timeline.row_starts[start].saturating_add(anchor.row.min(item_rows.saturating_sub(1)))
+    } else if let Some(logical_start) = timeline.review_logical_start {
+        timeline.row_starts[logical_start]
+    } else {
+        let total = timeline.total_rows();
+        let visible = usize::from(region.height);
+        total
+            .saturating_sub(visible)
+            .saturating_sub(state.timeline_scroll_offset())
+    }
+}
+
+pub(super) fn prepare_timeline_viewport(state: &mut TuiState, region: Rect) {
+    let content = timeline_content_region(region);
+    if !state.is_timeline_detached() || content.is_empty() {
+        return;
+    }
+    let timeline = timeline_layout(state, content);
+    let scroll = timeline_scroll_start(state, &timeline, content);
+    let total = timeline.total_rows();
+    for (index, &start) in timeline.item_starts.iter().enumerate() {
+        let end = timeline
+            .item_starts
+            .get(index + 1)
+            .copied()
+            .unwrap_or(timeline.rows.len());
+        let start_row = timeline.row_starts[start];
+        let rows = timeline.row_starts[end].saturating_sub(start_row);
+        if scroll < start_row.saturating_add(rows) {
+            state.record_timeline_viewport(
+                TimelineAnchor::new(index, scroll.saturating_sub(start_row)),
+                total
+                    .saturating_sub(usize::from(content.height))
+                    .saturating_sub(scroll),
+            );
+            break;
+        }
+    }
+}
+
+pub(crate) fn timeline_content_region(region: Rect) -> Rect {
+    Block::default()
+        .borders(Borders::BOTTOM)
+        .padding(Padding::left(1))
+        .inner(region)
+}
+
+pub(super) fn wrapped_line_count(lines: &[Line<'static>], width: u16) -> usize {
+    Paragraph::new(lines.to_vec())
+        .wrap(Wrap { trim: false })
+        .line_count(width)
+}
+
+pub(super) fn split_oversized_timeline_line(line: Line<'static>) -> Vec<Line<'static>> {
+    let byte_len = line.spans.iter().fold(0_usize, |total, span| {
+        total.saturating_add(span.content.len())
+    });
+    if byte_len <= MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES {
+        return vec![line];
+    }
+
+    let Line {
+        style,
+        alignment,
+        spans,
+    } = line;
+    let mut lines = Vec::new();
+    let mut current_spans = Vec::new();
+    let mut current_graphemes = 0;
+
+    for span in spans {
+        let mut chunk = String::new();
+        for grapheme in span.styled_graphemes(Style::default()) {
+            if current_graphemes == MAX_TIMELINE_LOGICAL_LINE_GRAPHEMES {
+                if !chunk.is_empty() {
+                    current_spans.push(Span::styled(std::mem::take(&mut chunk), span.style));
+                }
+                lines.push(Line {
+                    style,
+                    alignment,
+                    spans: std::mem::take(&mut current_spans),
+                });
+                current_graphemes = 0;
+            }
+            chunk.push_str(grapheme.symbol);
+            current_graphemes += 1;
+        }
+        if !chunk.is_empty() {
+            current_spans.push(Span::styled(chunk, span.style));
+        }
+    }
+
+    if !current_spans.is_empty() || lines.is_empty() {
+        lines.push(Line {
+            style,
+            alignment,
+            spans: current_spans,
+        });
+    }
+    lines
+}
+
+pub(super) fn spaced_timeline_item(
+    mut rows: Vec<TranscriptRow>,
+    has_next_item: bool,
+) -> Vec<TranscriptRow> {
+    if has_next_item && !rows.is_empty() {
+        rows.push(TranscriptRow::new(Line::from(""), SelectionPolicy::Keep));
+    }
+    rows
+}

--- a/crates/merry-cli/src/tui/session_picker.rs
+++ b/crates/merry-cli/src/tui/session_picker.rs
@@ -116,7 +116,7 @@ pub(crate) async fn pick_session(
                     .draw(|frame| render_session_picker(frame, &state, workspace_root))
                     .map_err(unexpected)?;
             }
-            TerminalEvent::Paste(_) => {}
+            TerminalEvent::Paste(_) | TerminalEvent::Mouse(_) => {}
         }
     }
 }

--- a/crates/merry-cli/src/tui/slash_stop_tests.rs
+++ b/crates/merry-cli/src/tui/slash_stop_tests.rs
@@ -413,5 +413,6 @@ fn single_wrapped_line_beyond_u16_scroll_limit_keeps_its_tail_visible() {
     });
 
     let rendered = render::render_to_text(&state, 20, 12);
-    assert!(rendered.contains("TAIL_SENTINEL"), "{rendered}");
+    let visible_characters = rendered.lines().map(str::trim).collect::<String>();
+    assert!(visible_characters.contains("TAIL_SENTINEL"), "{rendered}");
 }

--- a/crates/merry-cli/src/tui/state.rs
+++ b/crates/merry-cli/src/tui/state.rs
@@ -5,8 +5,10 @@ use crate::tui::{
     plan::PlanUiState,
     preferences::{TuiPreferences, TuiSettingsDefaults},
     status::{format_header_status_parts, format_session_usage_full},
+    text_interaction::TextSelection,
     theme::TuiTheme,
 };
+use clipboard::ClipboardFeedback;
 use merry_core::{InteractiveRunState, QueuedInputLane, SessionUsage};
 use merry_runtime::SkillMetadata;
 use overlays::OverlayState;
@@ -14,9 +16,10 @@ use std::{
     path::PathBuf,
     time::{Duration, Instant},
 };
+pub(crate) use timeline::TimelineAnchor;
 pub(crate) use views::{
-    PatchChangeView, PatchLineKind, PatchLineView, QueuePreview, QueuePreviewItem,
-    QueuePreviewState, TimelineItem,
+    CommandFailure, CommandView, PatchChangeView, PatchLineKind, PatchLineView,
+    ProcessOutputPreview, QueuePreview, QueuePreviewItem, QueuePreviewState, TimelineItem,
 };
 
 mod overlays;
@@ -24,6 +27,10 @@ mod overlays;
 mod views;
 
 mod settings;
+
+mod clipboard;
+mod text_interaction;
+mod timeline;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TuiState {
@@ -38,8 +45,14 @@ pub(crate) struct TuiState {
     input_history: InputHistory,
     queue_preview: QueuePreviewState,
     timeline: Vec<TimelineItem>,
+    show_successful_command_output: bool,
+    command_details_generation: u64,
     timeline_scroll_offset: usize,
     timeline_review_user_index: Option<usize>,
+    timeline_anchor: Option<TimelineAnchor>,
+    timeline_has_updates: bool,
+    text_selection: Option<TextSelection>,
+    clipboard_feedback: Option<ClipboardFeedback>,
     pending_local_echoes: Vec<PendingLocalEcho>,
     pending_local_run_start: bool,
     stop_feedback: StopFeedbackState,
@@ -90,8 +103,14 @@ impl TuiState {
             input_history: InputHistory::default(),
             queue_preview: QueuePreviewState::from_preview(QueuePreview::empty()),
             timeline: Vec::new(),
+            show_successful_command_output: false,
+            command_details_generation: 0,
             timeline_scroll_offset: 0,
             timeline_review_user_index: None,
+            timeline_anchor: None,
+            timeline_has_updates: false,
+            text_selection: None,
+            clipboard_feedback: None,
             pending_local_echoes: Vec::new(),
             pending_local_run_start: false,
             stop_feedback: StopFeedbackState::Idle,
@@ -105,6 +124,17 @@ impl TuiState {
             settings_defaults: TuiSettingsDefaults::default(),
             plan: PlanUiState::default(),
         }
+    }
+
+    /// Sets the display-only success-output policy without changing runtime artifacts.
+    pub(crate) fn with_successful_command_output(mut self, show_output: bool) -> Self {
+        self.show_successful_command_output = show_output;
+        self
+    }
+
+    /// Whether completed successful commands show their bounded output preview.
+    pub(crate) fn show_successful_command_output(&self) -> bool {
+        self.show_successful_command_output
     }
 
     pub(crate) fn plan(&self) -> &PlanUiState {
@@ -320,13 +350,13 @@ impl TuiState {
     }
 
     pub(crate) fn push_timeline_item(&mut self, item: TimelineItem) {
+        self.note_timeline_update();
         self.timeline.push(item);
-        self.timeline_scroll_offset = 0;
-        self.timeline_review_user_index = None;
     }
 
     pub(crate) fn append_assistant_delta(&mut self, index: Option<usize>, delta: &str) -> usize {
-        let index = if let Some(index) = index
+        self.note_timeline_update();
+        if let Some(index) = index
             && let Some(TimelineItem::Assistant { text }) = self.timeline.get_mut(index)
         {
             text.push_str(delta);
@@ -336,10 +366,7 @@ impl TuiState {
                 text: delta.to_owned(),
             });
             self.timeline.len().saturating_sub(1)
-        };
-        self.timeline_scroll_offset = 0;
-        self.timeline_review_user_index = None;
-        index
+        }
     }
 
     pub(crate) fn push_user_timeline_item(&mut self, text: String, lane: QueuedInputLane) {
@@ -383,10 +410,9 @@ impl TuiState {
     }
 
     pub(crate) fn replace_timeline_item(&mut self, index: usize, item: TimelineItem) {
+        self.note_timeline_update();
         if let Some(slot) = self.timeline.get_mut(index) {
             *slot = item;
-            self.timeline_scroll_offset = 0;
-            self.timeline_review_user_index = None;
         }
     }
 
@@ -472,13 +498,14 @@ impl TuiState {
     }
 
     pub(crate) fn exit_timeline_review(&mut self) {
-        self.timeline_review_user_index = None;
-        self.timeline_scroll_offset = 0;
+        self.follow_latest();
     }
 
     pub(crate) fn follow_latest(&mut self) {
         self.timeline_scroll_offset = 0;
         self.timeline_review_user_index = None;
+        self.timeline_anchor = None;
+        self.timeline_has_updates = false;
         self.pending_empty_input_quit = false;
     }
 
@@ -490,13 +517,18 @@ impl TuiState {
     pub(crate) fn scroll_timeline_up_by(&mut self, lines: usize) {
         self.pending_empty_input_quit = false;
         self.timeline_review_user_index = None;
+        self.timeline_anchor = None;
         self.timeline_scroll_offset = self.timeline_scroll_offset.saturating_add(lines);
     }
 
     pub(crate) fn scroll_timeline_down_by(&mut self, lines: usize) {
         self.pending_empty_input_quit = false;
         self.timeline_review_user_index = None;
+        self.timeline_anchor = None;
         self.timeline_scroll_offset = self.timeline_scroll_offset.saturating_sub(lines);
+        if self.timeline_scroll_offset == 0 {
+            self.follow_latest();
+        }
     }
 
     pub(crate) fn jump_to_previous_user_input(&mut self) {
@@ -509,6 +541,7 @@ impl TuiState {
         {
             self.pending_empty_input_quit = false;
             self.timeline_review_user_index = Some(index);
+            self.timeline_anchor = None;
         }
     }
 

--- a/crates/merry-cli/src/tui/state/clipboard.rs
+++ b/crates/merry-cli/src/tui/state/clipboard.rs
@@ -1,0 +1,43 @@
+use crate::tui::state::TuiState;
+
+/// A short-lived request/error notice; a terminal write is not a clipboard acknowledgement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClipboardFeedback {
+    pub(crate) message: String,
+    pub(crate) failed: bool,
+    expires_at: tokio::time::Instant,
+}
+
+impl ClipboardFeedback {
+    fn new(message: String, failed: bool) -> Self {
+        Self {
+            message,
+            failed,
+            expires_at: tokio::time::Instant::now() + std::time::Duration::from_secs(4),
+        }
+    }
+
+    fn has_expired(&self) -> bool {
+        tokio::time::Instant::now() >= self.expires_at
+    }
+}
+
+impl TuiState {
+    pub(crate) fn clipboard_feedback(&self) -> Option<&ClipboardFeedback> {
+        self.clipboard_feedback.as_ref()
+    }
+
+    pub(crate) fn show_clipboard_feedback(&mut self, message: String, failed: bool) {
+        self.clipboard_feedback = Some(ClipboardFeedback::new(message, failed));
+    }
+
+    pub(crate) fn expire_clipboard_feedback(&mut self) {
+        if self
+            .clipboard_feedback
+            .as_ref()
+            .is_some_and(ClipboardFeedback::has_expired)
+        {
+            self.clipboard_feedback = None;
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/state/overlays.rs
+++ b/crates/merry-cli/src/tui/state/overlays.rs
@@ -58,6 +58,20 @@ impl TuiState {
         self.overlays.overlay = Some(Overlay::settings());
     }
 
+    pub(crate) fn open_command_details(
+        &mut self,
+        details: crate::tui::command_details::CommandDetails,
+    ) {
+        self.command_details_generation = self.command_details_generation.saturating_add(1);
+        self.completion_menu = None;
+        self.overlays = OverlayState::default();
+        self.overlays.overlay = Some(Overlay::CommandDetails(details));
+    }
+
+    pub(crate) fn command_details_generation(&self) -> u64 {
+        self.command_details_generation
+    }
+
     pub(crate) fn open_provider_manager(&mut self, items: Vec<ProviderListItem>) {
         self.overlays.provider_form_back = None;
         self.overlays.reasoning_picker_back = None;
@@ -78,6 +92,7 @@ impl TuiState {
                 Overlay::PlanApproval(_)
                 | Overlay::PermissionReview(_)
                 | Overlay::Dialog(_)
+                | Overlay::CommandDetails(_)
                 | Overlay::Shortcuts(_),
             )
             | None => {

--- a/crates/merry-cli/src/tui/state/text_interaction.rs
+++ b/crates/merry-cli/src/tui/state/text_interaction.rs
@@ -1,0 +1,65 @@
+use crate::tui::{
+    copy_controls::CopyTextError,
+    state::TuiState,
+    text_interaction::{SelectionViewport, TextSelection},
+};
+use ratatui::layout::{Position, Rect};
+
+impl TuiState {
+    pub(crate) fn text_selection(&self) -> Option<&TextSelection> {
+        self.text_selection.as_ref()
+    }
+
+    pub(crate) fn begin_text_selection(&mut self, selection: TextSelection) {
+        self.clipboard_feedback = None;
+        self.text_selection = Some(selection);
+    }
+
+    pub(crate) fn drag_text_selection(&mut self, position: Position) {
+        if let Some(selection) = &mut self.text_selection {
+            selection.drag_to(position);
+        }
+    }
+
+    pub(crate) fn finish_text_selection(
+        &mut self,
+        position: Position,
+    ) -> Result<Option<String>, CopyTextError> {
+        self.text_selection
+            .take()
+            .map_or(Ok(None), |selection| selection.release(position))
+    }
+
+    pub(crate) fn text_selection_is_autoscrolling(&self) -> bool {
+        self.text_selection
+            .as_ref()
+            .is_some_and(TextSelection::is_autoscrolling)
+    }
+
+    pub(crate) fn autoscroll_text_selection(&mut self) {
+        if let Some(SelectionViewport { anchor, offset }) = self
+            .text_selection
+            .as_mut()
+            .and_then(TextSelection::autoscroll)
+        {
+            self.timeline_review_user_index = None;
+            self.pending_empty_input_quit = false;
+            self.record_timeline_viewport(anchor, offset);
+        }
+    }
+
+    pub(crate) fn clear_text_selection(&mut self) -> bool {
+        self.text_selection.take().is_some()
+    }
+
+    pub(crate) fn validate_text_selection_area(&mut self, area: Rect) {
+        if self.overlay().is_some()
+            || self
+                .text_selection
+                .as_ref()
+                .is_some_and(|selection| selection.area() != area)
+        {
+            self.clear_text_selection();
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/state/timeline.rs
+++ b/crates/merry-cli/src/tui/state/timeline.rs
@@ -1,0 +1,42 @@
+use super::TuiState;
+
+/// Identifies the displayed item and wrapped row, independently of later timeline growth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TimelineAnchor {
+    pub(crate) item_index: usize,
+    pub(crate) row: usize,
+}
+
+impl TimelineAnchor {
+    pub(crate) fn new(item_index: usize, row: usize) -> Self {
+        Self { item_index, row }
+    }
+}
+
+impl TuiState {
+    pub(crate) fn timeline_anchor(&self) -> Option<TimelineAnchor> {
+        self.timeline_anchor
+    }
+
+    pub(crate) fn timeline_has_updates(&self) -> bool {
+        self.timeline_has_updates
+    }
+
+    pub(crate) fn is_timeline_detached(&self) -> bool {
+        self.timeline_anchor.is_some()
+            || self.timeline_scroll_offset > 0
+            || self.is_timeline_reviewing()
+    }
+
+    /// Records the actual viewport after layout, keeping subsequent updates anchored.
+    pub(crate) fn record_timeline_viewport(&mut self, anchor: TimelineAnchor, offset: usize) {
+        self.timeline_anchor = Some(anchor);
+        self.timeline_scroll_offset = offset;
+    }
+
+    pub(super) fn note_timeline_update(&mut self) {
+        if self.is_timeline_detached() {
+            self.timeline_has_updates = true;
+        }
+    }
+}

--- a/crates/merry-cli/src/tui/state/views.rs
+++ b/crates/merry-cli/src/tui/state/views.rs
@@ -1,4 +1,60 @@
-use merry_core::{QueuedInputLane, QueuedInputView};
+use merry_core::{ArtifactRef, QueuedInputLane, QueuedInputView};
+use std::time::Duration;
+use tokio::time::Instant;
+
+const PROCESS_PREVIEW_MAX_LINES: usize = 5;
+
+/// A bounded display preview; complete process output remains in runtime artifacts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProcessOutputPreview {
+    pub(crate) lines: Vec<String>,
+    pub(crate) truncated: bool,
+}
+
+impl ProcessOutputPreview {
+    /// Keeps five nonempty stdout/stderr lines and records local or upstream truncation.
+    pub(crate) fn new(stdout: &str, stderr: &str, source_truncated: bool) -> Self {
+        let mut output_lines = stdout
+            .lines()
+            .chain(stderr.lines())
+            .filter(|line| !line.trim().is_empty());
+        let lines = output_lines
+            .by_ref()
+            .take(PROCESS_PREVIEW_MAX_LINES)
+            .map(str::to_owned)
+            .collect();
+        Self {
+            lines,
+            truncated: source_truncated || output_lines.next().is_some(),
+        }
+    }
+}
+
+/// Distinguishes cancellation from failures without a nonzero exit code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandFailure {
+    Cancelled,
+    Failed,
+}
+
+/// Projects command lifecycle events without owning process execution or runtime state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CommandView {
+    Running {
+        detail: String,
+        started_at: Instant,
+    },
+    Finished {
+        detail: String,
+        exit_code: Option<i64>,
+        failure: Option<CommandFailure>,
+        preview: ProcessOutputPreview,
+        command: String,
+        cwd: String,
+        artifact: ArtifactRef,
+        elapsed: Option<Duration>,
+    },
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
@@ -133,6 +189,7 @@ pub(crate) enum TimelineItem {
     User { text: String, lane: QueuedInputLane },
     Assistant { text: String },
     Muted { title: String, detail: String },
+    Command { view: CommandView },
     LocalCommand { title: String, body: String },
     Expanded { title: String, body: String },
     Diagnostic { title: String, body: String },

--- a/crates/merry-cli/src/tui/terminal.rs
+++ b/crates/merry-cli/src/tui/terminal.rs
@@ -1,8 +1,9 @@
+use crate::tui::{copy_controls::MAX_CLIPBOARD_BYTES, text_interaction::MouseInput};
 use crossterm::{
     cursor::{Hide, Show},
     event::{
         DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, EventStream, KeyEvent, MouseEvent, MouseEventKind,
+        Event, EventStream, KeyEvent, MouseButton, MouseEvent, MouseEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -15,6 +16,7 @@ use std::io::{self, Stdout, stdout};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TerminalEvent {
     Key(KeyEvent),
+    Mouse(MouseInput),
     MouseScrollUp(Position),
     MouseScrollDown(Position),
     Paste(String),
@@ -66,7 +68,7 @@ impl TerminalSession {
             match event {
                 Event::Key(key) => return Ok(Some(TerminalEvent::Key(key))),
                 Event::Mouse(mouse) => {
-                    if let Some(event) = mouse_scroll_event(mouse) {
+                    if let Some(event) = mouse_event(mouse) {
                         return Ok(Some(event));
                     }
                 }
@@ -84,6 +86,24 @@ impl TerminalSession {
     pub(crate) fn size(&self) -> io::Result<Size> {
         self.terminal.size()
     }
+
+    /// Requests a clipboard write through the terminal; OSC 52 support is terminal-owned.
+    pub(crate) fn copy_text(&mut self, text: &str) -> io::Result<()> {
+        write_clipboard_request(self.terminal.backend_mut(), text)
+    }
+}
+
+pub(crate) fn write_clipboard_request(writer: &mut impl io::Write, text: &str) -> io::Result<()> {
+    if text.len() > MAX_CLIPBOARD_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Clipboard payload exceeds 1 MiB; inspect the artifact in the trajectory instead",
+        ));
+    }
+    execute!(
+        writer,
+        crossterm::clipboard::CopyToClipboard::to_clipboard_from(text)
+    )
 }
 
 impl Drop for TerminalSession {
@@ -114,18 +134,28 @@ fn mouse_capture_enabled() -> bool {
     true
 }
 
-fn mouse_scroll_event(mouse: MouseEvent) -> Option<TerminalEvent> {
+fn mouse_event(mouse: MouseEvent) -> Option<TerminalEvent> {
     let position = Position::new(mouse.column, mouse.row);
     match mouse.kind {
         MouseEventKind::ScrollUp => Some(TerminalEvent::MouseScrollUp(position)),
         MouseEventKind::ScrollDown => Some(TerminalEvent::MouseScrollDown(position)),
+        MouseEventKind::Down(MouseButton::Left) if mouse.modifiers.is_empty() => {
+            Some(TerminalEvent::Mouse(MouseInput::Down(position)))
+        }
+        MouseEventKind::Drag(MouseButton::Left) if mouse.modifiers.is_empty() => {
+            Some(TerminalEvent::Mouse(MouseInput::Drag(position)))
+        }
+        MouseEventKind::Up(MouseButton::Left) if mouse.modifiers.is_empty() => {
+            Some(TerminalEvent::Mouse(MouseInput::Up(position)))
+        }
         _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{TerminalEvent, mouse_capture_enabled, mouse_scroll_event};
+    use super::{TerminalEvent, mouse_capture_enabled, mouse_event};
+    use crate::tui::text_interaction::MouseInput;
     use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
     use ratatui::layout::Position;
 
@@ -141,32 +171,70 @@ mod tests {
     #[test]
     fn maps_mouse_wheel_to_timeline_scroll_events() {
         assert_eq!(
-            mouse_scroll_event(mouse(MouseEventKind::ScrollUp)),
+            mouse_event(mouse(MouseEventKind::ScrollUp)),
             Some(TerminalEvent::MouseScrollUp(Position::new(7, 9)))
         );
         assert_eq!(
-            mouse_scroll_event(mouse(MouseEventKind::ScrollDown)),
+            mouse_event(mouse(MouseEventKind::ScrollDown)),
             Some(TerminalEvent::MouseScrollDown(Position::new(7, 9)))
         );
+        assert_eq!(mouse_event(mouse(MouseEventKind::ScrollLeft)), None);
+        assert_eq!(mouse_event(mouse(MouseEventKind::ScrollRight)), None);
+    }
+
+    #[test]
+    fn maps_left_button_presses_to_click_actions() {
         assert_eq!(
-            mouse_scroll_event(mouse(MouseEventKind::Down(MouseButton::Left))),
-            None
+            mouse_event(mouse(MouseEventKind::Down(MouseButton::Left))),
+            Some(TerminalEvent::Mouse(MouseInput::Down(Position::new(7, 9))))
         );
         assert_eq!(
-            mouse_scroll_event(mouse(MouseEventKind::Drag(MouseButton::Left))),
-            None
+            mouse_event(mouse(MouseEventKind::Drag(MouseButton::Left))),
+            Some(TerminalEvent::Mouse(MouseInput::Drag(Position::new(7, 9))))
         );
-        assert_eq!(mouse_scroll_event(mouse(MouseEventKind::Moved)), None);
         assert_eq!(
-            mouse_scroll_event(mouse(MouseEventKind::Up(MouseButton::Left))),
-            None
+            mouse_event(mouse(MouseEventKind::Up(MouseButton::Left))),
+            Some(TerminalEvent::Mouse(MouseInput::Up(Position::new(7, 9))))
         );
-        assert_eq!(mouse_scroll_event(mouse(MouseEventKind::ScrollLeft)), None);
-        assert_eq!(mouse_scroll_event(mouse(MouseEventKind::ScrollRight)), None);
+    }
+
+    #[test]
+    fn ignores_drag_release_and_motion_events() {
+        for kind in [
+            MouseEventKind::Drag(MouseButton::Right),
+            MouseEventKind::Moved,
+        ] {
+            assert_eq!(mouse_event(mouse(kind)), None);
+        }
     }
 
     #[test]
     fn enables_mouse_capture_for_app_owned_timeline_scroll() {
         assert!(mouse_capture_enabled());
+    }
+
+    #[test]
+    fn modified_and_non_left_mouse_events_do_not_start_application_actions() {
+        for modifiers in [
+            KeyModifiers::SHIFT,
+            KeyModifiers::ALT,
+            KeyModifiers::CONTROL,
+        ] {
+            for kind in [
+                MouseEventKind::Down(MouseButton::Left),
+                MouseEventKind::Drag(MouseButton::Left),
+                MouseEventKind::Up(MouseButton::Left),
+            ] {
+                let mut event = mouse(kind);
+                event.modifiers = modifiers;
+                assert_eq!(mouse_event(event), None);
+            }
+        }
+        for kind in [
+            MouseEventKind::Down(MouseButton::Right),
+            MouseEventKind::Down(MouseButton::Middle),
+        ] {
+            assert_eq!(mouse_event(mouse(kind)), None);
+        }
     }
 }

--- a/crates/merry-cli/src/tui/tests.rs
+++ b/crates/merry-cli/src/tui/tests.rs
@@ -98,6 +98,12 @@ fn find_cell_style(buffer: &ratatui::buffer::Buffer, text: &str) -> Option<ratat
 
 mod command_palette;
 
+mod command_details;
+mod command_display;
+
+mod command_runtime;
+mod copy_interactions;
+
 mod composer;
 
 mod event_projection;
@@ -120,6 +126,7 @@ mod submission;
 
 mod text_rendering;
 
+mod reading_position;
 mod timeline_navigation;
 
 mod tool_projection;

--- a/crates/merry-cli/src/tui/tests/command_details.rs
+++ b/crates/merry-cli/src/tui/tests/command_details.rs
@@ -1,0 +1,450 @@
+use crate::tui::{
+    command_details::{CapturedOutput, apply_output, load_output},
+    controller::{ControllerEffect, handle_key_event},
+    keymap::Keymap,
+    projector::TuiProjector,
+    render::{prepare_viewport, render_to_text},
+    state::TuiState,
+    terminal::write_clipboard_request,
+    tests::{pending_call_with_args, source, text_artifact},
+    theme::TuiTheme,
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use merry_core::{
+    ArtifactId, ArtifactRef, ErrorInfo, RuntimeEvent, SessionId, ToolCallId, ToolCallResult,
+    ToolOutput,
+};
+use merry_runtime::{ArtifactContent, Runtime};
+use ratatui::layout::Size;
+use serde_json::json;
+
+fn state() -> TuiState {
+    TuiState::new(
+        "/repo".into(),
+        "test".into(),
+        Keymap::default(),
+        TuiTheme::default(),
+    )
+}
+
+fn completed_command(
+    state: &mut TuiState,
+    id: &str,
+    command: &str,
+    status: i64,
+    output: &str,
+) -> ArtifactRef {
+    let artifact = text_artifact(id);
+    let mut projector = TuiProjector::default();
+    projector.apply(
+        RuntimeEvent::ToolCallStarted {
+            call: pending_call_with_args(
+                id,
+                "run_process",
+                json!({"command": command, "cwd": "src"}),
+            ),
+            source: source(),
+        },
+        state,
+    );
+    let call_id = ToolCallId::new(id).unwrap();
+    let result = if status == 0 {
+        ToolCallResult::succeeded(call_id, artifact.clone())
+    } else {
+        ToolCallResult::failed(
+            call_id,
+            artifact.clone(),
+            ErrorInfo::new("process_action_failed", "command failed").unwrap(),
+        )
+    };
+    projector.apply(
+        RuntimeEvent::ToolCallFinished {
+            result,
+            output: Some(ToolOutput::Json {
+                json: json!({
+                    "kind": "process_action", "status": status,
+                    "stdout": {"text": output}, "stderr": {"text": ""},
+                })
+                .to_string(),
+            }),
+            source: source(),
+        },
+        state,
+    );
+    artifact
+}
+
+fn key(state: &mut TuiState, code: KeyCode) -> ControllerEffect {
+    handle_key_event(KeyEvent::new(code, KeyModifiers::NONE), state)
+}
+
+fn open(state: &mut TuiState) -> ArtifactId {
+    let effect = handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT), state);
+    let ControllerEffect::LoadCommandOutput(artifact_id) = effect else {
+        panic!("opening a completed command should request its artifact");
+    };
+    artifact_id
+}
+
+fn draw(state: &mut TuiState, width: u16, height: u16) -> String {
+    prepare_viewport(state, Size::new(width, height));
+    render_to_text(state, width, height)
+}
+
+#[test]
+fn command_details_shortcut_toggles_without_changing_the_draft_or_reading_position() {
+    let mut state = state();
+    let artifact = completed_command(&mut state, "toggle", "pwd", 0, "");
+    state.append_assistant_delta(None, &"context\n".repeat(40));
+    state.insert_input_str("keep my draft");
+    state.scroll_timeline_up_by(10);
+    let before = draw(&mut state, 80, 24);
+
+    for _ in 0..3 {
+        assert_eq!(open(&mut state), *artifact.id());
+        assert!(draw(&mut state, 80, 24).contains("Loading captured output"));
+        assert_eq!(
+            handle_key_event(
+                KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+                &mut state,
+            ),
+            ControllerEffect::None
+        );
+        assert!(state.overlay().is_none());
+        apply_output(
+            &mut state,
+            artifact.id(),
+            Ok(CapturedOutput::Text("late output".into())),
+        );
+        assert_eq!(draw(&mut state, 80, 24), before);
+    }
+}
+
+#[test]
+fn command_output_hint_appears_only_when_completed_output_is_available() {
+    let mut state = state();
+    assert!(!draw(&mut state, 80, 24).contains("Alt+O output"));
+    TuiProjector::default().apply(
+        RuntimeEvent::ToolCallStarted {
+            call: pending_call_with_args("pending", "run_process", json!({"command": "pwd"})),
+            source: source(),
+        },
+        &mut state,
+    );
+    assert!(!draw(&mut state, 80, 24).contains("Alt+O output"));
+    completed_command(&mut state, "ready", "pwd", 0, "");
+    for width in [24, 80] {
+        assert!(draw(&mut state, width, 24).contains("Alt+O output"));
+    }
+}
+
+#[test]
+fn command_output_hint_does_not_overwrite_new_content_navigation() {
+    let mut state = state();
+    completed_command(&mut state, "hint", "pwd", 0, "");
+    state.append_assistant_delta(None, &"context\n".repeat(40));
+    state.scroll_timeline_up_by(10);
+    draw(&mut state, 80, 24);
+    state.append_assistant_delta(None, "new content");
+
+    let wide = draw(&mut state, 80, 24);
+    assert!(wide.contains("New content"));
+    assert!(wide.contains("Ctrl+End latest"));
+    assert!(wide.contains("Alt+O output"));
+    let narrow = draw(&mut state, 40, 24);
+    assert!(narrow.contains("New content"));
+    assert!(narrow.contains("Ctrl+End latest"));
+    assert!(!narrow.contains("Alt+O output"));
+}
+
+#[test]
+fn command_details_close_hint_and_feedback_fit_narrow_terminals() {
+    let mut state = state();
+    completed_command(&mut state, "footer", "pwd", 0, "");
+    open(&mut state);
+    key(&mut state, KeyCode::Char('y'));
+    for width in [24, 40, 80, 120] {
+        let rendered = draw(&mut state, width, 24);
+        assert!(rendered.contains("Alt+O / Esc close"), "{rendered}");
+        assert!(rendered.contains("↑/↓"), "{rendered}");
+        assert!(
+            rendered.contains("C/Y copy") || rendered.contains("C copy command"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("Output is not"), "{rendered}");
+        assert!(rendered.contains("available yet"), "{rendered}");
+    }
+}
+
+#[test]
+fn command_details_shortcut_does_not_dismiss_unrelated_dialogs() {
+    let mut state = state();
+    completed_command(&mut state, "dialog", "pwd", 0, "");
+    state.show_info_dialog("Keep this dialog", "Unrelated message".into());
+    let before = draw(&mut state, 80, 24);
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+            &mut state,
+        ),
+        ControllerEffect::None
+    );
+    assert_eq!(draw(&mut state, 80, 24), before);
+}
+
+#[test]
+fn hidden_success_output_is_inspectable_and_copy_preserves_the_actual_command() {
+    let mut state = state();
+    let command = "printf '%s' 'line one'\nprintf 'line two'";
+    let artifact = completed_command(&mut state, "first", command, 0, "secret preview");
+    state.insert_input_str("unfinished draft");
+    let compact = draw(&mut state, 100, 26);
+    assert!(!compact.contains("secret preview"));
+    assert_eq!(open(&mut state), *artifact.id());
+    assert!(draw(&mut state, 100, 26).contains("Loading captured output"));
+    apply_output(
+        &mut state,
+        artifact.id(),
+        Ok(CapturedOutput::from_artifact(ArtifactContent::json(
+            json!({
+                "kind": "process_action", "stdout": {"text": "first line\n\n  indented\nlast line"},
+                "stderr": {"text": "an error"},
+            })
+            .to_string(),
+        ))
+        .unwrap()),
+    );
+    let expanded = draw(&mut state, 100, 26);
+    assert!(expanded.contains("Directory: src"));
+    assert!(expanded.contains("  indented"));
+    assert!(expanded.contains("last line"));
+    assert!(expanded.contains("an error"));
+    assert_eq!(
+        key(&mut state, KeyCode::Char('c')),
+        ControllerEffect::CopyText(command.into())
+    );
+    assert_eq!(
+        key(&mut state, KeyCode::Char('y')),
+        ControllerEffect::CopyText("first line\n\n  indented\nlast line\nan error".into())
+    );
+    key(&mut state, KeyCode::Esc);
+    assert!(state.overlay().is_none());
+    let collapsed = draw(&mut state, 100, 26);
+    assert!(collapsed.contains("unfinished draft"));
+    assert!(!collapsed.contains("last line"));
+    assert!(!state.show_successful_command_output());
+}
+
+#[test]
+fn command_navigation_ignores_stale_loads_and_keeps_failed_output_accessible() {
+    let mut state = state();
+    let first = completed_command(&mut state, "first", "pwd", 0, "");
+    let second = completed_command(&mut state, "second", "git status", 128, "line one");
+    assert_eq!(open(&mut state), *second.id());
+    assert_eq!(
+        key(&mut state, KeyCode::Left),
+        ControllerEffect::LoadCommandOutput(first.id().clone())
+    );
+    apply_output(
+        &mut state,
+        second.id(),
+        Ok(CapturedOutput::Text("STALE".into())),
+    );
+    let pending = draw(&mut state, 80, 24);
+    assert!(pending.contains("Command 1/2"));
+    assert!(!pending.contains("STALE"));
+    assert_eq!(key(&mut state, KeyCode::Left), ControllerEffect::None);
+    assert_eq!(
+        key(&mut state, KeyCode::Right),
+        ControllerEffect::LoadCommandOutput(second.id().clone())
+    );
+    apply_output(
+        &mut state,
+        second.id(),
+        Ok(CapturedOutput::Text("COMPLETE ERROR".into())),
+    );
+    let failed = draw(&mut state, 80, 24);
+    assert!(failed.contains("Exit: 128"));
+    assert!(failed.contains("COMPLETE ERROR"));
+    key(&mut state, KeyCode::Esc);
+    apply_output(
+        &mut state,
+        second.id(),
+        Ok(CapturedOutput::Text("late completion".into())),
+    );
+    assert!(state.overlay().is_none());
+}
+
+#[test]
+fn full_output_scrolls_beyond_preview_and_u16_limits_without_truncating_text() {
+    let mut state = state();
+    let artifact = completed_command(&mut state, "large", "cargo test", 0, "");
+    open(&mut state);
+    let output = format!("{}TAIL-完整-output", "line\n".repeat(66_000));
+    apply_output(&mut state, artifact.id(), Ok(CapturedOutput::Text(output)));
+    for width in [24, 80] {
+        key(&mut state, KeyCode::End);
+        let bottom = draw(&mut state, width, 24);
+        assert!(
+            bottom
+                .split_whitespace()
+                .collect::<String>()
+                .contains("TAIL-完整-output"),
+            "{bottom}"
+        );
+        assert!(bottom.contains("Esc close"));
+        key(&mut state, KeyCode::Home);
+        let top = draw(&mut state, width, 24);
+        assert!(top.contains("cargo test"));
+        assert!(!top.contains("TAIL-完整-output"));
+    }
+}
+
+#[test]
+fn upstream_truncation_binary_text_and_load_failures_are_explicit() {
+    let mut state = state();
+    let artifact = completed_command(&mut state, "limited", "build", 1, "");
+    open(&mut state);
+    apply_output(&mut state, artifact.id(), Ok(CapturedOutput::from_artifact(ArtifactContent::json(json!({
+        "kind": "process_action", "stdout": {"text": "prefix", "truncated": true, "utf8": false}, "stderr": {},
+    }).to_string())).unwrap()));
+    let rendered = draw(&mut state, 110, 28);
+    assert!(rendered.contains("capture truncated"));
+    assert!(rendered.contains("Non-UTF-8"));
+    apply_output(
+        &mut state,
+        artifact.id(),
+        Err("artifact unavailable".into()),
+    );
+    assert!(draw(&mut state, 80, 24).contains("Could not load output: artifact unavailable"));
+    assert_eq!(key(&mut state, KeyCode::Char('y')), ControllerEffect::None);
+    assert!(CapturedOutput::from_artifact(ArtifactContent::binary(vec![0, 1])).is_err());
+}
+
+#[tokio::test]
+async fn output_loader_reads_runtime_artifacts_and_reports_missing_records() {
+    let runtime = Runtime::builder(SessionId::new("command-inspection").unwrap())
+        .build()
+        .unwrap();
+    let artifact = text_artifact("capture");
+    runtime
+        .record_artifact(
+            artifact.clone(),
+            ArtifactContent::text("exact captured output\n"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        load_output(&runtime, artifact.id())
+            .await
+            .unwrap()
+            .copy_text(),
+        "exact captured output\n"
+    );
+    assert!(
+        load_output(&runtime, &ArtifactId::new("missing").unwrap())
+            .await
+            .is_err()
+    );
+}
+
+#[test]
+fn copy_uses_encoded_terminal_requests_and_rejects_oversized_payloads() {
+    let mut bytes = Vec::new();
+    write_clipboard_request(&mut bytes, "hello").unwrap();
+    let request = String::from_utf8(bytes).unwrap();
+    assert!(request.starts_with("\u{1b}]52;c;"));
+    assert!(request.contains("aGVsbG8="));
+    let mut bytes = Vec::new();
+    write_clipboard_request(&mut bytes, "\u{1b}[31m\n").unwrap();
+    assert!(!String::from_utf8(bytes).unwrap().contains("\u{1b}[31m"));
+    let mut bytes = Vec::new();
+    assert!(write_clipboard_request(&mut bytes, &"x".repeat(1_048_577)).is_err());
+    assert!(bytes.is_empty());
+    let mut buffer = [0_u8; 1];
+    assert!(write_clipboard_request(&mut &mut buffer[..], "hello").is_err());
+}
+
+#[test]
+fn opening_before_any_command_completes_preserves_the_draft() {
+    let mut state = state();
+    state.insert_input_str("keep my draft");
+    let effect = handle_key_event(
+        KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+        &mut state,
+    );
+    assert_eq!(effect, ControllerEffect::None);
+    assert!(draw(&mut state, 100, 24).contains("No completed commands yet"));
+    key(&mut state, KeyCode::Esc);
+    assert!(draw(&mut state, 100, 24).contains("keep my draft"));
+}
+
+#[test]
+fn inspection_toggle_and_follow_shortcuts_respect_configured_bindings() {
+    let config: crate::config::TuiKeymapToml =
+        toml::from_str("open_command_details = 'ctrl+f'\nfollow_latest = 'ctrl+b'").unwrap();
+    let keymap = Keymap::from_config(&config).unwrap();
+    let mut state = TuiState::new("/repo".into(), "test".into(), keymap, TuiTheme::default());
+    let artifact = completed_command(&mut state, "configured", "pwd", 0, "");
+    let collapsed = draw(&mut state, 80, 24);
+    assert!(collapsed.contains("Ctrl+F output"));
+    assert!(!collapsed.contains("Alt+O output"));
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL),
+            &mut state
+        ),
+        ControllerEffect::LoadCommandOutput(artifact.id().clone())
+    );
+    let expanded = draw(&mut state, 80, 24);
+    assert!(expanded.contains("Ctrl+F / Esc close"));
+    handle_key_event(
+        KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+        &mut state,
+    );
+    assert_eq!(draw(&mut state, 80, 24), expanded);
+    assert_eq!(
+        handle_key_event(
+            KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL),
+            &mut state,
+        ),
+        ControllerEffect::None
+    );
+    assert!(state.overlay().is_none());
+    assert_eq!(draw(&mut state, 80, 24), collapsed);
+    state.scroll_timeline_up_by(10);
+    handle_key_event(
+        KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL),
+        &mut state,
+    );
+    assert!(!state.is_timeline_detached());
+}
+
+#[test]
+fn reopening_the_same_command_rejects_older_load_completions() {
+    use crate::tui::controller::CommandOutputCompletion;
+    let mut state = state();
+    let artifact = completed_command(&mut state, "reopen", "pwd", 0, "");
+    open(&mut state);
+    let previous_generation = state.command_details_generation();
+    key(&mut state, KeyCode::Esc);
+    open(&mut state);
+    key(&mut state, KeyCode::Char('y'));
+    let generation = state.command_details_generation();
+    CommandOutputCompletion::new(
+        artifact.id().clone(),
+        generation,
+        Ok(CapturedOutput::Text("latest capture".into())),
+    )
+    .apply(&mut state);
+    CommandOutputCompletion::new(
+        artifact.id().clone(),
+        previous_generation,
+        Err("obsolete timeout".into()),
+    )
+    .apply(&mut state);
+    let rendered = draw(&mut state, 100, 24);
+    assert!(rendered.contains("latest capture"));
+    assert!(!rendered.contains("obsolete timeout"));
+    assert!(!rendered.contains("Output is not available yet"));
+}

--- a/crates/merry-cli/src/tui/tests/command_details.rs
+++ b/crates/merry-cli/src/tui/tests/command_details.rs
@@ -79,7 +79,10 @@ fn key(state: &mut TuiState, code: KeyCode) -> ControllerEffect {
 }
 
 fn open(state: &mut TuiState) -> ArtifactId {
-    let effect = handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT), state);
+    let effect = handle_key_event(
+        KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+        state,
+    );
     let ControllerEffect::LoadCommandOutput(artifact_id) = effect else {
         panic!("opening a completed command should request its artifact");
     };
@@ -105,7 +108,7 @@ fn command_details_shortcut_toggles_without_changing_the_draft_or_reading_positi
         assert!(draw(&mut state, 80, 24).contains("Loading captured output"));
         assert_eq!(
             handle_key_event(
-                KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+                KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
                 &mut state,
             ),
             ControllerEffect::None
@@ -123,7 +126,7 @@ fn command_details_shortcut_toggles_without_changing_the_draft_or_reading_positi
 #[test]
 fn command_output_hint_appears_only_when_completed_output_is_available() {
     let mut state = state();
-    assert!(!draw(&mut state, 80, 24).contains("Alt+O output"));
+    assert!(!draw(&mut state, 80, 24).contains("Ctrl+T output"));
     TuiProjector::default().apply(
         RuntimeEvent::ToolCallStarted {
             call: pending_call_with_args("pending", "run_process", json!({"command": "pwd"})),
@@ -131,10 +134,10 @@ fn command_output_hint_appears_only_when_completed_output_is_available() {
         },
         &mut state,
     );
-    assert!(!draw(&mut state, 80, 24).contains("Alt+O output"));
+    assert!(!draw(&mut state, 80, 24).contains("Ctrl+T output"));
     completed_command(&mut state, "ready", "pwd", 0, "");
     for width in [24, 80] {
-        assert!(draw(&mut state, width, 24).contains("Alt+O output"));
+        assert!(draw(&mut state, width, 24).contains("Ctrl+T output"));
     }
 }
 
@@ -150,11 +153,11 @@ fn command_output_hint_does_not_overwrite_new_content_navigation() {
     let wide = draw(&mut state, 80, 24);
     assert!(wide.contains("New content"));
     assert!(wide.contains("Ctrl+End latest"));
-    assert!(wide.contains("Alt+O output"));
+    assert!(wide.contains("Ctrl+T output"));
     let narrow = draw(&mut state, 40, 24);
     assert!(narrow.contains("New content"));
     assert!(narrow.contains("Ctrl+End latest"));
-    assert!(!narrow.contains("Alt+O output"));
+    assert!(!narrow.contains("Ctrl+T output"));
 }
 
 #[test]
@@ -165,7 +168,7 @@ fn command_details_close_hint_and_feedback_fit_narrow_terminals() {
     key(&mut state, KeyCode::Char('y'));
     for width in [24, 40, 80, 120] {
         let rendered = draw(&mut state, width, 24);
-        assert!(rendered.contains("Alt+O / Esc close"), "{rendered}");
+        assert!(rendered.contains("Ctrl+T / Esc close"), "{rendered}");
         assert!(rendered.contains("↑/↓"), "{rendered}");
         assert!(
             rendered.contains("C/Y copy") || rendered.contains("C copy command"),
@@ -184,7 +187,7 @@ fn command_details_shortcut_does_not_dismiss_unrelated_dialogs() {
     let before = draw(&mut state, 80, 24);
     assert_eq!(
         handle_key_event(
-            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
             &mut state,
         ),
         ControllerEffect::None
@@ -370,7 +373,7 @@ fn opening_before_any_command_completes_preserves_the_draft() {
     let mut state = state();
     state.insert_input_str("keep my draft");
     let effect = handle_key_event(
-        KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+        KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
         &mut state,
     );
     assert_eq!(effect, ControllerEffect::None);
@@ -388,7 +391,7 @@ fn inspection_toggle_and_follow_shortcuts_respect_configured_bindings() {
     let artifact = completed_command(&mut state, "configured", "pwd", 0, "");
     let collapsed = draw(&mut state, 80, 24);
     assert!(collapsed.contains("Ctrl+F output"));
-    assert!(!collapsed.contains("Alt+O output"));
+    assert!(!collapsed.contains("Ctrl+T output"));
     assert_eq!(
         handle_key_event(
             KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL),
@@ -399,7 +402,7 @@ fn inspection_toggle_and_follow_shortcuts_respect_configured_bindings() {
     let expanded = draw(&mut state, 80, 24);
     assert!(expanded.contains("Ctrl+F / Esc close"));
     handle_key_event(
-        KeyEvent::new(KeyCode::Char('o'), KeyModifiers::ALT),
+        KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
         &mut state,
     );
     assert_eq!(draw(&mut state, 80, 24), expanded);

--- a/crates/merry-cli/src/tui/tests/command_display.rs
+++ b/crates/merry-cli/src/tui/tests/command_display.rs
@@ -1,0 +1,530 @@
+use crate::tui::{
+    keymap::Keymap,
+    projector::TuiProjector,
+    render::{render_to_buffer, render_to_text},
+    state::{TimelineItem, TuiState},
+    tests::{find_cell_color, find_text_position, pending_call_with_args, source, text_artifact},
+    theme::TuiTheme,
+};
+use merry_core::{
+    ErrorInfo, RuntimeEvent, TOOL_CANCELLED_BY_USER_CODE, ToolCallId, ToolCallResult, ToolOutput,
+};
+use merry_runtime::SessionTranscriptItem;
+use ratatui::style::Color;
+use serde_json::json;
+use std::time::Duration;
+
+fn state() -> TuiState {
+    TuiState::new(
+        "/repo".into(),
+        "gpt-test".to_owned(),
+        Keymap::default(),
+        TuiTheme::default(),
+    )
+}
+
+fn start_command(projector: &mut TuiProjector, state: &mut TuiState, id: &str, command: &str) {
+    projector.apply(
+        RuntimeEvent::ToolCallStarted {
+            call: pending_call_with_args(
+                id,
+                "run_process",
+                json!({"command": command, "cwd": "."}),
+            ),
+            source: source(),
+        },
+        state,
+    );
+}
+
+fn process_output(
+    exit_code: i64,
+    stdout: &str,
+    stderr: &str,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+) -> ToolOutput {
+    ToolOutput::Json {
+        json: json!({
+            "kind": "process_action",
+            "status": {"kind": "exited", "code": exit_code},
+            "stdout": {"text": stdout, "bytes": stdout.len(), "truncated": stdout_truncated},
+            "stderr": {"text": stderr, "bytes": stderr.len(), "truncated": stderr_truncated},
+        })
+        .to_string(),
+    }
+}
+
+fn process_result(id: &str, exit_code: i64) -> ToolCallResult {
+    let call_id = ToolCallId::new(id).unwrap();
+    let artifact = text_artifact(&format!("{id}-output"));
+    if exit_code == 0 {
+        ToolCallResult::succeeded(call_id, artifact)
+    } else {
+        ToolCallResult::failed(
+            call_id,
+            artifact,
+            ErrorInfo::new(
+                "process_action_failed",
+                &format!("process exited with code {exit_code}"),
+            )
+            .unwrap(),
+        )
+    }
+}
+
+fn finish_command(
+    projector: &mut TuiProjector,
+    state: &mut TuiState,
+    id: &str,
+    exit_code: i64,
+    output: ToolOutput,
+) {
+    projector.apply(
+        RuntimeEvent::ToolCallFinished {
+            result: process_result(id, exit_code),
+            output: Some(output),
+            source: source(),
+        },
+        state,
+    );
+}
+
+fn rendered_preview(state: &TuiState, title: &str) -> Vec<String> {
+    let rendered = render_to_text(state, 120, 24);
+    let rows = rendered.lines().map(str::trim_end).collect::<Vec<_>>();
+    let title_index = rows
+        .iter()
+        .position(|row| row.strip_prefix(' ') == Some(title))
+        .expect("command title should render");
+    rows[title_index + 1..]
+        .iter()
+        .take_while(|row| row.starts_with("   "))
+        .map(|row| row.trim().to_owned())
+        .collect()
+}
+
+#[tokio::test(start_paused = true)]
+async fn slow_command_duration_is_visible_and_stops_after_completion() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    start_command(&mut projector, &mut state, "slow", "cargo test");
+    assert!(!render_to_text(&state, 120, 24).contains("0.0s"));
+    tokio::time::advance(Duration::from_secs(13)).await;
+    let running = render_to_text(&state, 120, 24);
+    assert!(running.contains("Running"));
+    assert!(running.contains("cargo test (.)  13.0s"));
+    tokio::time::advance(Duration::from_secs(2)).await;
+    finish_command(
+        &mut projector,
+        &mut state,
+        "slow",
+        128,
+        process_output(128, "failure", "", false, false),
+    );
+    let finished = render_to_text(&state, 120, 24);
+    assert!(finished.contains("Ran cargo test (.) -> 128  15.0s"));
+    let buffer = render_to_buffer(&state, 120, 24);
+    assert_eq!(find_cell_color(&buffer, "128"), Some(Color::LightRed));
+    assert_eq!(find_cell_color(&buffer, "Ran"), Some(Color::LightCyan));
+    tokio::time::advance(Duration::from_secs(30)).await;
+    assert_eq!(finished, render_to_text(&state, 120, 24));
+}
+
+#[test]
+fn wrapped_command_continuations_align_with_the_command_body() {
+    let command = format!("printf '%s' '{}end'", "long-argument-".repeat(10));
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    start_command(&mut projector, &mut state, "wrapped", &command);
+    for finished in [false, true] {
+        if finished {
+            finish_command(
+                &mut projector,
+                &mut state,
+                "wrapped",
+                0,
+                process_output(0, "", "", false, false),
+            );
+        }
+        let rendered = render_to_text(&state, 36, 32);
+        let rows = rendered.lines().collect::<Vec<_>>();
+        let start = rows.iter().position(|row| row.contains("printf")).unwrap();
+        let byte_column = rows[start].find("printf").unwrap();
+        let column = unicode_width::UnicodeWidthStr::width(&rows[start][..byte_column]);
+        let continuation_prefix = " ".repeat(column);
+        let continuations = rows[start + 1..]
+            .iter()
+            .take_while(|row| !row.trim().is_empty() && row.starts_with(&continuation_prefix))
+            .collect::<Vec<_>>();
+        assert!(!continuations.is_empty(), "{rendered}");
+        let mut joined = rows[start][byte_column..].to_owned();
+        for line in continuations {
+            joined.push_str(&line[column..]);
+        }
+        assert_eq!(
+            joined.split_whitespace().collect::<String>(),
+            format!("{command} (.)")
+                .split_whitespace()
+                .collect::<String>()
+        );
+        assert!(!joined.contains("..."));
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn running_command_animates_and_completion_stops_the_animation() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    start_command(&mut projector, &mut state, "process", "git status");
+
+    let first = render_to_text(&state, 120, 24);
+    assert!(first.contains("Running "));
+    assert!(first.contains("git status (.)"));
+    assert!(!first.contains("Ran "));
+    let buffer = render_to_buffer(&state, 120, 24);
+    assert_eq!(find_cell_color(&buffer, "Running"), Some(Color::LightCyan));
+    assert_eq!(find_cell_color(&buffer, "git"), Some(Color::LightBlue));
+
+    tokio::time::advance(Duration::from_millis(100)).await;
+    let second = render_to_text(&state, 120, 24);
+    assert!(second.contains("Running "));
+    assert_ne!(first, second);
+
+    finish_command(
+        &mut projector,
+        &mut state,
+        "process",
+        0,
+        process_output(0, "clean", "", false, false),
+    );
+    assert_eq!(state.timeline().len(), 1);
+    let completed = render_to_text(&state, 120, 24);
+    assert!(completed.contains("Ran git status (.)"));
+    assert!(!completed.contains("Running "));
+    tokio::time::advance(Duration::from_millis(100)).await;
+    assert_eq!(completed, render_to_text(&state, 120, 24));
+}
+
+#[test]
+fn successful_commands_hide_output_by_default_and_form_a_compact_list() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    for id in ["cmd1", "cmd2"] {
+        start_command(&mut projector, &mut state, id, id);
+        finish_command(
+            &mut projector,
+            &mut state,
+            id,
+            0,
+            process_output(0, "hidden-stdout", "hidden-stderr", true, true),
+        );
+        assert!(rendered_preview(&state, &format!("Ran {id} (.)")).is_empty());
+    }
+    let rendered = render_to_text(&state, 120, 24);
+    let rows = rendered.lines().map(str::trim_end).collect::<Vec<_>>();
+    assert!(
+        rows.windows(2)
+            .any(|rows| rows == [" Ran cmd1 (.)", " Ran cmd2 (.)"])
+    );
+    assert!(!rendered.contains("hidden-stdout"));
+    assert!(!rendered.contains("hidden-stderr"));
+}
+
+#[test]
+fn timeline_gutter_insets_commands_outputs_and_assistant_text() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    start_command(&mut projector, &mut state, "process", "printf value");
+    finish_command(
+        &mut projector,
+        &mut state,
+        "process",
+        128,
+        process_output(128, "first\nsecond", "", false, false),
+    );
+    state.push_timeline_item(TimelineItem::Assistant {
+        text: "assistant message".to_owned(),
+    });
+
+    let buffer = render_to_buffer(&state, 60, 20);
+    let (command_column, command_row) =
+        find_text_position(&buffer, "Ran printf value").expect("command should be visible");
+    let (assistant_column, assistant_row) =
+        find_text_position(&buffer, "assistant message").expect("assistant should be visible");
+    assert_eq!(command_column, 1);
+    assert_eq!(assistant_column, 1);
+    for output in ["first", "second"] {
+        let (column, _) = find_text_position(&buffer, output).expect("output should be visible");
+        assert_eq!(column, 3);
+    }
+    for row in command_row..=assistant_row {
+        assert_eq!(buffer[(0, row)].symbol(), " ");
+    }
+}
+
+#[test]
+fn timeline_gutter_stays_empty_on_wrapped_command_rows() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    let command = format!("printf {} command-tail", "0123456789".repeat(20));
+    start_command(&mut projector, &mut state, "process", &command);
+
+    let buffer = render_to_buffer(&state, 24, 28);
+    let (_, first_row) = find_text_position(&buffer, "Running").expect("command should be visible");
+    let (_, last_row) =
+        find_text_position(&buffer, "command-tail").expect("command tail should be visible");
+    assert!(last_row > first_row);
+    for row in first_row..=last_row {
+        assert_eq!(
+            buffer[(0, row)].symbol(),
+            " ",
+            "wrapped row {row} should keep the gutter"
+        );
+    }
+}
+
+#[test]
+fn padded_timeline_keeps_wrapped_command_tail_visible_after_scrolling() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    let command = format!("echo {} TAIL_SENTINEL", "abcdefghij".repeat(60));
+    start_command(&mut projector, &mut state, "process", &command);
+    finish_command(
+        &mut projector,
+        &mut state,
+        "process",
+        0,
+        process_output(0, "", "", false, false),
+    );
+
+    let bottom = render_to_text(&state, 20, 12);
+    assert!(bottom.contains("TAIL_SENTINEL"));
+    state.scroll_timeline_up_by(3);
+    assert!(!render_to_text(&state, 20, 12).contains("TAIL_SENTINEL"));
+    state.scroll_timeline_down_by(3);
+    assert_eq!(render_to_text(&state, 20, 12), bottom);
+}
+
+#[test]
+fn command_previews_respect_the_output_toggle_and_both_truncation_boundaries() {
+    for exit_code in [0, 128] {
+        for show_output in [false, true] {
+            for (stdout, stderr, stdout_truncated, stderr_truncated, expected) in [
+                ("", "", false, false, &[][..]),
+                (
+                    "one\ntwo\nthree\nfour\nfive\n",
+                    "",
+                    false,
+                    false,
+                    &["one", "two", "three", "four", "five"][..],
+                ),
+                (
+                    "one\ntwo\nthree\nfour\nfive\nsix\n",
+                    "",
+                    false,
+                    false,
+                    &["one", "two", "three", "four", "five", "..."][..],
+                ),
+                (
+                    "one\ntwo\nthree\nfour\nfive\n",
+                    "stderr",
+                    false,
+                    false,
+                    &["one", "two", "three", "four", "five", "..."][..],
+                ),
+                (
+                    "one\ntwo\nthree\n",
+                    "four\nfive\nsix\n",
+                    false,
+                    false,
+                    &["one", "two", "three", "four", "five", "..."][..],
+                ),
+                ("one\ntwo\n", "", true, false, &["one", "two", "..."][..]),
+                ("", "stderr\n", false, true, &["stderr", "..."][..]),
+                (
+                    "one\ntwo\nthree\nfour\nfive\n\n",
+                    "\n",
+                    false,
+                    false,
+                    &["one", "two", "three", "four", "five"][..],
+                ),
+                ("", "", true, false, &["..."][..]),
+            ] {
+                let mut state = state().with_successful_command_output(show_output);
+                let mut projector = TuiProjector::default();
+                start_command(&mut projector, &mut state, "process", "cmd");
+                finish_command(
+                    &mut projector,
+                    &mut state,
+                    "process",
+                    exit_code,
+                    process_output(
+                        exit_code,
+                        stdout,
+                        stderr,
+                        stdout_truncated,
+                        stderr_truncated,
+                    ),
+                );
+
+                let title = if exit_code == 0 {
+                    "Ran cmd (.)"
+                } else {
+                    "Ran cmd (.) -> 128"
+                };
+                let expected = if exit_code == 0 && !show_output {
+                    &[][..]
+                } else {
+                    expected
+                };
+                assert_eq!(
+                    rendered_preview(&state, title),
+                    expected,
+                    "exit={exit_code}, show={show_output}, stdout={stdout:?}, stderr={stderr:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn long_commands_wrap_without_losing_arguments_or_the_working_directory() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    let command = format!(
+        "printf '%s' '{}' && echo command-tail",
+        "中文-long-token-".repeat(20)
+    );
+    let cwd = format!("src/{}directory-tail", "nested/".repeat(20));
+    projector.apply(
+        RuntimeEvent::ToolCallStarted {
+            call: pending_call_with_args(
+                "long-process",
+                "run_process",
+                json!({"command": command, "cwd": cwd}),
+            ),
+            source: source(),
+        },
+        &mut state,
+    );
+
+    let expected = format!("{command} ({cwd})")
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>();
+    for running in [true, false] {
+        if !running {
+            finish_command(
+                &mut projector,
+                &mut state,
+                "long-process",
+                0,
+                process_output(0, "", "", false, false),
+            );
+        }
+        let rendered = render_to_text(&state, 40, 64);
+        let compact = rendered
+            .chars()
+            .filter(|character| !character.is_whitespace())
+            .collect::<String>();
+        assert!(
+            compact.contains(&expected),
+            "complete command should wrap while running={running}"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn cancelled_commands_stop_animating_without_showing_a_successful_result() {
+    let mut state = state();
+    let mut projector = TuiProjector::default();
+    start_command(&mut projector, &mut state, "process", "sleep 30");
+    projector.apply(
+        RuntimeEvent::ToolCallFinished {
+            result: ToolCallResult::failed(
+                ToolCallId::new("process").unwrap(),
+                text_artifact("cancelled-output"),
+                ErrorInfo::new(TOOL_CANCELLED_BY_USER_CODE, "cancelled by user").unwrap(),
+            ),
+            output: None,
+            source: source(),
+        },
+        &mut state,
+    );
+
+    let rendered = render_to_text(&state, 120, 24);
+    assert!(rendered.contains("Ran sleep 30 (.) -> cancelled"));
+    assert!(!rendered.contains("Running "));
+    tokio::time::advance(Duration::from_millis(100)).await;
+    assert_eq!(rendered, render_to_text(&state, 120, 24));
+    assert!(matches!(
+        crate::tui::controller::handle_key_action(
+            crate::tui::keymap::KeyAction::OpenCommandDetails,
+            &mut state
+        ),
+        crate::tui::controller::ControllerEffect::LoadCommandOutput(_)
+    ));
+}
+
+#[test]
+fn terminal_run_events_stop_pending_command_animations() {
+    for (event, status) in [
+        (
+            RuntimeEvent::RunFailed {
+                diagnostic: ErrorInfo::new("run_failed", "runtime failure").unwrap(),
+                source: source(),
+            },
+            "failed",
+        ),
+        (
+            RuntimeEvent::RunCancelled {
+                diagnostic: ErrorInfo::new("run_cancelled", "runtime cancelled").unwrap(),
+                source: source(),
+            },
+            "cancelled",
+        ),
+        (RuntimeEvent::Closed, "interrupted"),
+    ] {
+        let mut state = state();
+        let mut projector = TuiProjector::default();
+        start_command(&mut projector, &mut state, "pending", "sleep 30");
+        projector.apply(event, &mut state);
+        let rendered = render_to_text(&state, 120, 24);
+        assert!(rendered.contains(&format!("Ran sleep 30 (.) -> {status}")));
+        assert!(!rendered.contains("Running "));
+    }
+}
+
+#[test]
+fn resumed_commands_use_the_same_completion_and_output_policy() {
+    for exit_code in [0, 128] {
+        let mut state = state();
+        let mut projector = TuiProjector::default();
+        projector.apply_transcript_item(
+            SessionTranscriptItem::ToolCall {
+                call: pending_call_with_args(
+                    "saved",
+                    "run_process",
+                    json!({"command": "cmd", "cwd": "."}),
+                ),
+            },
+            &mut state,
+        );
+        projector.apply_transcript_item(
+            SessionTranscriptItem::ToolResult {
+                call_id: ToolCallId::new("saved").unwrap(),
+                result: process_result("saved", exit_code),
+                output: Some(process_output(exit_code, "output", "", false, false)),
+            },
+            &mut state,
+        );
+
+        if exit_code == 0 {
+            assert!(rendered_preview(&state, "Ran cmd (.)").is_empty());
+        } else {
+            assert_eq!(rendered_preview(&state, "Ran cmd (.) -> 128"), ["output"]);
+        }
+        assert!(!render_to_text(&state, 120, 24).contains("Running "));
+    }
+}

--- a/crates/merry-cli/src/tui/tests/command_runtime.rs
+++ b/crates/merry-cli/src/tui/tests/command_runtime.rs
@@ -1,0 +1,201 @@
+use crate::{
+    coding::{
+        CodingSubagentsConfig, HeadlessCodingRuntimeInput, build_headless_coding,
+        fixed_process_backend,
+    },
+    testing::{ScriptedProvider, model_name, process_tool_call},
+    tui::{
+        keymap::Keymap, projector::TuiProjector, render::render_to_text, state::TuiState,
+        theme::TuiTheme,
+    },
+};
+use merry_core::{InteractiveRunState, RuntimeEvent};
+use merry_llm::{FinishReason, ModelEvent, ModelOutput, ModelResponse};
+use merry_process::ProcessSession;
+use merry_runtime::{
+    AcceptedLocalWorkspaceProcessAdmission, AgentLoopConfig, AutomaticCompactionConfig,
+    ProcessActionIntent, ProcessExitStatus, ProcessRunner, ProcessRunnerContext,
+    ProcessRunnerError, ProcessRunnerFuture, ProcessRunnerOutput,
+    StaticPermissionedProcessRunnerFactory, StepContext,
+};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Notify;
+
+struct GatedProcessRunner {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl GatedProcessRunner {
+    fn new(started: Arc<Notify>, release: Arc<Notify>) -> Self {
+        Self { started, release }
+    }
+}
+
+impl ProcessRunner for GatedProcessRunner {
+    fn run<'a>(
+        &'a self,
+        intent: ProcessActionIntent,
+        context: ProcessRunnerContext,
+    ) -> ProcessRunnerFuture<'a> {
+        Box::pin(async move {
+            self.started.notify_one();
+            tokio::select! {
+                _ = self.release.notified() => {}
+                _ = context.cancellation_token().cancelled() => {
+                    return Err(ProcessRunnerError::Cancelled);
+                }
+            }
+            ProcessRunnerOutput::new(
+                &intent,
+                ProcessExitStatus::Exited(0),
+                "done",
+                false,
+                "",
+                false,
+            )
+            .map_err(|error| ProcessRunnerError::infrastructure(error.to_string()))
+        })
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn runtime_process_stays_running_and_animates_until_the_backend_completes() {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let workspace = tempfile::tempdir().expect("workspace should exist");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let runner: Arc<dyn ProcessRunner> = Arc::new(GatedProcessRunner::new(
+            Arc::clone(&started),
+            Arc::clone(&release),
+        ));
+        let permissioned_factory = Arc::new(StaticPermissionedProcessRunnerFactory::new(
+            Arc::clone(&runner),
+        ));
+        let provider = ScriptedProvider::new(vec![
+            vec![Ok(process_tool_call(
+                "running-process",
+                &["pwd"],
+                Some("."),
+            )
+            .unwrap())],
+            vec![Ok(ModelEvent::Completed {
+                response: ModelResponse::new(
+                    vec![ModelOutput::text("finished")],
+                    FinishReason::Stop,
+                    None,
+                ),
+            })],
+        ]);
+        let runtime = build_headless_coding(HeadlessCodingRuntimeInput {
+            session_id: "tui-running-process",
+            root: workspace.path(),
+            provider: Arc::new(provider),
+            model: model_name(),
+            process_backend: fixed_process_backend(ProcessSession::from_parts(
+                AcceptedLocalWorkspaceProcessAdmission::accept_local_workspace(),
+                runner,
+                permissioned_factory,
+            )),
+            extra_tools: Vec::new(),
+            allow_hidden_workspace_paths: false,
+            automatic_compaction: AutomaticCompactionConfig::disabled(),
+            retry_policy: None,
+            context_compaction: None,
+            approval_review: None,
+            skill_roots: Vec::new(),
+            subagents: CodingSubagentsConfig::default(),
+            workspace_tool_limits: None,
+        })
+        .expect("coding runtime should build");
+        let run = runtime
+            .start_interactive_agent_run(StepContext::default(), AgentLoopConfig::default())
+            .expect("interactive run should start");
+        let (mut stream, input, control) = run.split();
+        let mut state = TuiState::new(
+            workspace.path().to_owned(),
+            "test-model".to_owned(),
+            Keymap::default(),
+            TuiTheme::default(),
+        );
+        let mut projector = TuiProjector::default();
+        input
+            .submit_next("Print the current directory.")
+            .await
+            .expect("input should be accepted");
+
+        while let Some(event) = stream
+            .next_event()
+            .await
+            .expect("runtime stream should succeed")
+        {
+            let running_tool = matches!(
+                event,
+                RuntimeEvent::InteractiveRunStateChanged {
+                    state: InteractiveRunState::RunningTool,
+                }
+            );
+            projector.apply(event, &mut state);
+            if running_tool {
+                break;
+            }
+        }
+        started.notified().await;
+        let first = render_to_text(&state, 80, 24);
+        tokio::time::advance(Duration::from_millis(100)).await;
+        let second = render_to_text(&state, 80, 24);
+        let active_before_completion = state.is_active_run();
+
+        release.notify_one();
+        while let Some(event) = stream
+            .next_event()
+            .await
+            .expect("runtime stream should succeed")
+        {
+            let completed = matches!(event, RuntimeEvent::ToolCallFinished { .. });
+            projector.apply(event, &mut state);
+            if completed {
+                break;
+            }
+        }
+        let finished = render_to_text(&state, 80, 24);
+        control.close().await.expect("runtime should close");
+        while stream
+            .next_event()
+            .await
+            .expect("runtime should drain")
+            .is_some()
+        {}
+
+        let effect = crate::tui::controller::handle_key_action(
+            crate::tui::keymap::KeyAction::OpenCommandDetails,
+            &mut state,
+        );
+        let crate::tui::controller::ControllerEffect::LoadCommandOutput(artifact_id) = effect
+        else {
+            panic!("completed runtime command should expose its output artifact");
+        };
+        let output = crate::tui::command_details::load_output(&runtime, &artifact_id).await;
+        crate::tui::command_details::apply_output(&mut state, &artifact_id, output);
+        let inspected = render_to_text(&state, 100, 24);
+        assert!(inspected.contains("stdout"), "{inspected}");
+        assert!(inspected.contains("done"), "{inspected}");
+
+        assert!(active_before_completion);
+        assert!(
+            first.lines().any(|line| line.starts_with(" Running ")),
+            "{first}"
+        );
+        assert!(first.contains("pwd (.)"), "{first}");
+        assert!(!first.contains(" Ran pwd"));
+        assert_ne!(first, second);
+        assert!(
+            second.lines().any(|line| line.starts_with(" Running ")),
+            "{second}"
+        );
+        assert!(finished.contains(" Ran pwd (.)"), "{finished}");
+        assert!(!finished.lines().any(|line| line.starts_with(" Running ")));
+    })
+    .await
+    .expect("runtime command lifecycle should finish within the deadline");
+}

--- a/crates/merry-cli/src/tui/tests/copy_interactions.rs
+++ b/crates/merry-cli/src/tui/tests/copy_interactions.rs
@@ -1,0 +1,408 @@
+use crate::tui::{
+    controller::{ControllerEffect, handle_key_event, handle_mouse_input},
+    keymap::Keymap,
+    render::{prepare_viewport, render_to_buffer},
+    state::{TimelineItem, TuiState},
+    tests::{find_text_position, rendered_buffer_text},
+    text_interaction::MouseInput,
+    theme::TuiTheme,
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Position, Size},
+};
+
+fn state(markdown: &str) -> TuiState {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "test".into(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    state.push_timeline_item(TimelineItem::Assistant {
+        text: markdown.into(),
+    });
+    state
+}
+
+fn draw(state: &mut TuiState, size: Size) -> Buffer {
+    prepare_viewport(state, size);
+    render_to_buffer(state, size.width, size.height)
+}
+
+fn point(buffer: &Buffer, text: &str) -> Position {
+    let (column, row) = find_text_position(buffer, text)
+        .unwrap_or_else(|| panic!("missing {text}:\n{}", rendered_buffer_text(buffer)));
+    Position::new(column, row)
+}
+
+fn buttons(buffer: &Buffer, label: &str) -> Vec<Position> {
+    let mut positions = Vec::new();
+    for row in buffer.area.y..buffer.area.bottom() {
+        for column in buffer.area.x..buffer.area.right() {
+            if label.chars().enumerate().all(|(offset, character)| {
+                let column = column.saturating_add(u16::try_from(offset).unwrap());
+                column < buffer.area.right()
+                    && buffer[(column, row)].symbol() == character.to_string()
+            }) {
+                positions.push(Position::new(column, row));
+            }
+        }
+    }
+    positions
+}
+
+fn click(state: &TuiState, size: Size, position: Position) -> ControllerEffect {
+    let mut state = state.clone();
+    let effect = handle_mouse_input(MouseInput::Down(position), size, &mut state);
+    assert_eq!(
+        handle_mouse_input(MouseInput::Up(position), size, &mut state),
+        ControllerEffect::None
+    );
+    effect
+}
+
+fn drag_copy(state: &mut TuiState, size: Size, start: Position, end: Position) -> ControllerEffect {
+    assert_eq!(
+        handle_mouse_input(MouseInput::Down(start), size, state),
+        ControllerEffect::None
+    );
+    assert_eq!(
+        handle_mouse_input(MouseInput::Drag(end), size, state),
+        ControllerEffect::None
+    );
+    handle_mouse_input(MouseInput::Up(end), size, state)
+}
+
+#[test]
+fn copy_buttons_preserve_markdown_and_each_code_blocks_undecorated_text() {
+    let markdown = "# Steps\n\nRun **both**:\n```sh\nprintf 'one'\n  printf 'two'\n\n\tprintf '三🙂e\u{301}'\n```\n\nThen:\n```\n  final  \n```\n";
+    let mut state = state(markdown);
+    state.insert_input_str("unfinished draft");
+    let size = Size::new(90, 36);
+    let buffer = draw(&mut state, size);
+    assert_eq!(
+        click(&state, size, point(&buffer, "[Copy reply]")),
+        ControllerEffect::CopyText(markdown.into())
+    );
+    let targets = buttons(&buffer, "[Copy code]");
+    assert_eq!(targets.len(), 2);
+    assert_eq!(
+        click(&state, size, targets[0]),
+        ControllerEffect::CopyText(
+            "printf 'one'\n  printf 'two'\n\n\tprintf '三🙂e\u{301}'\n".into()
+        )
+    );
+    assert_eq!(
+        click(&state, size, targets[1]),
+        ControllerEffect::CopyText("  final  \n".into())
+    );
+    assert!(rendered_buffer_text(&draw(&mut state, size)).contains("unfinished draft"));
+}
+
+#[test]
+fn copy_targets_follow_wrapping_scrolling_and_local_markdown_indentation() {
+    let code = "  printf '非常长的命令 alpha beta gamma delta epsilon'\nnext\n";
+    let mut state = state(&format!(
+        "{}\n```sh\n{code}```",
+        "earlier context\n".repeat(80)
+    ));
+    for width in [20, 80, 32] {
+        let size = Size::new(width, 24);
+        let buffer = draw(&mut state, size);
+        let button = point(&buffer, "[Copy code]");
+        assert_eq!(
+            click(&state, size, button),
+            ControllerEffect::CopyText(code.into())
+        );
+    }
+    state.push_timeline_item(TimelineItem::LocalCommand {
+        title: "Help".into(),
+        body: "```text\n  local text\n```".into(),
+    });
+    let size = Size::new(80, 24);
+    let buffer = draw(&mut state, size);
+    let target = *buttons(&buffer, "[Copy code]").last().unwrap();
+    assert_eq!(
+        click(&state, size, target),
+        ControllerEffect::CopyText("  local text\n".into())
+    );
+}
+
+#[test]
+fn copy_target_survives_timeline_offsets_beyond_u16() {
+    let mut state = state(&format!("{}\n```\nTAIL\n```", "prefix\n".repeat(66_000)));
+    let size = Size::new(32, 16);
+    let buffer = draw(&mut state, size);
+    assert_eq!(
+        click(&state, size, point(&buffer, "[Copy code]")),
+        ControllerEffect::CopyText("TAIL\n".into())
+    );
+}
+
+#[test]
+fn literal_copy_labels_and_hidden_controls_are_not_click_targets() {
+    let mut state = state("Text contains [Copy code] but this is not a control.\n\n```\nreal\n```");
+    let size = Size::new(80, 24);
+    let buffer = draw(&mut state, size);
+    let labels = buttons(&buffer, "[Copy code]");
+    assert_eq!(labels.len(), 2);
+    assert_eq!(click(&state, size, labels[0]), ControllerEffect::None);
+    state.show_info_dialog("Modal", "Do not copy behind this dialog".into());
+    assert_eq!(click(&state, size, labels[1]), ControllerEffect::None);
+    state.close_overlay();
+    let narrow = draw(&mut state, Size::new(5, 24));
+    assert!(buttons(&narrow, "[Copy]").is_empty());
+}
+
+#[test]
+fn streamed_code_copy_uses_current_source_without_rendered_wrapping() {
+    let mut state = state("```sh\nfirst\n");
+    let size = Size::new(80, 24);
+    let buffer = draw(&mut state, size);
+    assert_eq!(
+        click(&state, size, point(&buffer, "[Copy code]")),
+        ControllerEffect::CopyText("first\n".into())
+    );
+    state.append_assistant_delta(Some(0), "  second\n```\n");
+    let buffer = draw(&mut state, size);
+    assert_eq!(
+        click(&state, size, point(&buffer, "[Copy code]")),
+        ControllerEffect::CopyText("first\n  second\n".into())
+    );
+}
+
+#[test]
+fn dragging_plain_content_copies_on_release_and_clears_selection() {
+    let mut state = state("alpha 界🙂e\u{301}\n```text\n  beta\n```");
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    let start = point(&buffer, "alpha");
+    assert_eq!(
+        handle_mouse_input(MouseInput::Down(start), size, &mut state),
+        ControllerEffect::None
+    );
+    let end = Position::new(start.x + 4, start.y);
+    assert_eq!(
+        handle_mouse_input(MouseInput::Drag(end), size, &mut state),
+        ControllerEffect::None
+    );
+    let selected = draw(&mut state, size);
+    assert!(
+        selected[(start.x, start.y)]
+            .modifier
+            .contains(ratatui::style::Modifier::REVERSED)
+    );
+    assert_eq!(
+        handle_mouse_input(MouseInput::Up(end), size, &mut state),
+        ControllerEffect::CopyText("alpha".into())
+    );
+    assert!(state.text_selection().is_none());
+}
+
+#[test]
+fn dragging_multiline_content_copies_visible_text_without_markdown_controls() {
+    let mut state = state("alpha\n  beta\nomega");
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    let start = point(&buffer, "alpha");
+    let end = point(&buffer, "omega");
+    assert_eq!(
+        drag_copy(&mut state, size, start, Position::new(end.x + 4, end.y),),
+        ControllerEffect::CopyText("alpha\nbeta\nomega".into())
+    );
+    assert!(state.text_selection().is_none());
+}
+
+#[test]
+fn dragging_can_start_from_the_timeline_edge() {
+    let mut state = state("alpha\nbeta");
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    let end = point(&buffer, "alpha");
+    let start = Position::new(0, end.y);
+    assert_eq!(
+        drag_copy(&mut state, size, start, Position::new(end.x + 4, end.y)),
+        ControllerEffect::CopyText("alpha".into())
+    );
+}
+
+#[test]
+fn dragging_strips_timeline_decoration_from_markdown_output() {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "test".into(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    state.push_timeline_item(TimelineItem::User {
+        text: "Request".into(),
+        lane: merry_core::QueuedInputLane::Next,
+    });
+    state.push_timeline_item(TimelineItem::Assistant {
+        text: "# Title\n\n```sh\nprintf 'hello'\n\nnext\n```".into(),
+    });
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    let start = point(&buffer, "Request");
+    let end = point(&buffer, "next");
+    let copied = match drag_copy(
+        &mut state,
+        size,
+        start,
+        Position::new(size.width.saturating_sub(1), end.y),
+    ) {
+        ControllerEffect::CopyText(text) => text,
+        effect => panic!("expected copied text, got {effect:?}"),
+    };
+    assert!(copied.contains("Title"));
+    assert_eq!(copied, "Request\n\nTitle\nprintf 'hello'\n\nnext");
+    assert!(!copied.contains('▌'));
+    assert!(!copied.contains('▎'));
+    assert!(!copied.contains("[Copy"));
+}
+
+#[test]
+fn dragging_preserves_literal_controls_and_rail_glyphs_in_content() {
+    let mut state = state("literal [Copy code]\nleft ▎ content\n▌ body");
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    let start = point(&buffer, "literal");
+    let end = point(&buffer, "▌ body");
+    assert_eq!(
+        drag_copy(
+            &mut state,
+            size,
+            start,
+            Position::new(size.width.saturating_sub(1), end.y),
+        ),
+        ControllerEffect::CopyText("literal [Copy code]\nleft ▎ content\n▌ body".into())
+    );
+}
+
+#[test]
+fn dragging_local_code_strips_both_local_gutter_and_code_rail() {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "test".into(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    state.push_timeline_item(TimelineItem::LocalCommand {
+        title: "Output".into(),
+        body: "```text\n  local text\n\nnext\n```".into(),
+    });
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    let start = point(&buffer, "local text");
+    let end = point(&buffer, "next");
+    assert_eq!(
+        drag_copy(
+            &mut state,
+            size,
+            start,
+            Position::new(size.width.saturating_sub(1), end.y),
+        ),
+        ControllerEffect::CopyText("local text\n\nnext".into())
+    );
+}
+
+#[test]
+fn reply_copy_preserves_source_indentation() {
+    let markdown = "alpha\n  beta\nomega";
+    let mut state = state(markdown);
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    assert_eq!(
+        click(&state, size, point(&buffer, "[Copy reply]")),
+        ControllerEffect::CopyText(markdown.into())
+    );
+}
+
+#[test]
+fn plain_click_does_not_freeze_streaming_or_intercept_copy_buttons() {
+    let mut state = state("alpha\n```\nold code\n```");
+    let size = Size::new(80, 20);
+    let buffer = draw(&mut state, size);
+    assert_eq!(
+        click(&state, size, point(&buffer, "alpha")),
+        ControllerEffect::None
+    );
+    state.replace_timeline_item(
+        0,
+        TimelineItem::Assistant {
+            text: "new text\n```\nnew code\n```".into(),
+        },
+    );
+    let buffer = draw(&mut state, size);
+    let rendered = rendered_buffer_text(&buffer);
+    assert!(rendered.contains("new text"));
+    assert!(!rendered.contains("alpha"));
+    assert_eq!(
+        click(&state, size, point(&buffer, "[Copy code]")),
+        ControllerEffect::CopyText("new code\n".into())
+    );
+}
+
+#[test]
+fn clicking_transcript_does_not_repurpose_control_c_or_tmux_prefix_keys() {
+    for key in [
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
+    ] {
+        let mut state = state("alpha beta");
+        state.insert_input_str("draft");
+        let size = Size::new(80, 20);
+        let buffer = draw(&mut state, size);
+        assert_eq!(
+            click(&state, size, point(&buffer, "alpha")),
+            ControllerEffect::None
+        );
+        assert!(!matches!(
+            handle_key_event(key, &mut state),
+            ControllerEffect::CopyText(_)
+        ));
+    }
+}
+
+#[test]
+fn copy_buttons_do_not_add_keyboard_bindings() {
+    for key in [
+        KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        ),
+        KeyEvent::new(
+            KeyCode::Char('C'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        ),
+        KeyEvent::new(KeyCode::Char('y'), KeyModifiers::ALT),
+    ] {
+        let mut state = state("alpha beta");
+        assert_eq!(state.keymap().action_for(key.into()), None);
+        let size = Size::new(80, 20);
+        let buffer = draw(&mut state, size);
+        assert_eq!(
+            click(&state, size, point(&buffer, "alpha")),
+            ControllerEffect::None
+        );
+        assert_eq!(handle_key_event(key, &mut state), ControllerEffect::None);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn clipboard_feedback_is_visible_without_an_overlay_and_expires() {
+    let mut state = state("body");
+    let size = Size::new(80, 20);
+    state.show_clipboard_feedback("Copy failed: clipboard unavailable".into(), true);
+    assert!(
+        rendered_buffer_text(&draw(&mut state, size))
+            .contains("Copy failed: clipboard unavailable")
+    );
+    tokio::time::advance(std::time::Duration::from_secs(4)).await;
+    state.expire_clipboard_feedback();
+    let rendered = rendered_buffer_text(&draw(&mut state, size));
+    assert!(!rendered.contains("Copy failed"));
+    assert!(rendered.contains("Ready"));
+}

--- a/crates/merry-cli/src/tui/tests/process_projection.rs
+++ b/crates/merry-cli/src/tui/tests/process_projection.rs
@@ -1,7 +1,8 @@
 use crate::tui::{
     keymap::Keymap,
     projector::TuiProjector,
-    state::{TimelineItem, TuiState},
+    render::render_to_text,
+    state::{CommandView, TimelineItem, TuiState},
     tests::{pending_call_with_args, source, text_artifact},
     theme::TuiTheme,
 };
@@ -15,7 +16,8 @@ fn projector_renders_process_calls_as_ran_with_preview() {
         "gpt-test".to_owned(),
         Keymap::default(),
         TuiTheme::default(),
-    );
+    )
+    .with_successful_command_output(true);
     let mut projector = TuiProjector::default();
 
     projector.apply(
@@ -44,11 +46,10 @@ fn projector_renders_process_calls_as_ran_with_preview() {
     );
 
     assert_eq!(state.timeline().len(), 1);
-    let TimelineItem::Expanded { title, body } = &state.timeline()[0] else {
-        panic!("process call should expand with output preview");
-    };
-    assert_eq!(title, "Ran python3 hello_world.py (.)");
-    assert_eq!(body, "  hello world");
+    let rendered = render_to_text(&state, 120, 24);
+    assert!(rendered.contains("Ran python3 hello_world.py (.)"));
+    assert!(rendered.contains("  hello world"));
+    assert!(!rendered.contains("process_action"));
 }
 
 #[test]
@@ -89,12 +90,12 @@ fn projector_renders_nonzero_process_exit_as_command_result() {
     );
 
     assert_eq!(state.timeline().len(), 1);
-    let TimelineItem::Expanded { title, body } = &state.timeline()[0] else {
-        panic!("nonzero process exit should remain a command result");
-    };
-    assert_eq!(title, "Ran cargo test -p merry-cli (.) -> exit 101");
-    assert_eq!(body, "  error: test failed\n  rerun with --exact");
-    assert!(!body.contains("process_action_failed"));
+    let rendered = render_to_text(&state, 120, 24);
+    assert!(rendered.contains("Ran cargo test -p merry-cli (.) -> 101"));
+    assert!(rendered.contains("  error: test failed"));
+    assert!(rendered.contains("  rerun with --exact"));
+    assert!(!rendered.contains("process_action_failed"));
+    assert!(!rendered.contains("! Error"));
 }
 
 #[test]
@@ -133,12 +134,17 @@ fn projector_keeps_process_start_failure_as_diagnostic() {
         &mut state,
     );
 
-    let TimelineItem::Diagnostic { title, body } = &state.timeline()[0] else {
-        panic!("process start failure should remain a diagnostic");
-    };
-    assert_eq!(title, "Ran missing-command (.) -> failed");
-    assert!(body.contains("process_action_failed"));
-    assert!(body.contains("failed to start process"));
+    let rendered = render_to_text(&state, 120, 24);
+    assert!(rendered.contains("Ran missing-command (.) -> failed"));
+    assert!(rendered.contains("process_action_failed"));
+    assert!(rendered.contains("failed to start process"));
+    assert!(matches!(
+        crate::tui::controller::handle_key_action(
+            crate::tui::keymap::KeyAction::OpenCommandDetails,
+            &mut state
+        ),
+        crate::tui::controller::ControllerEffect::LoadCommandOutput(_)
+    ));
 }
 
 #[test]
@@ -224,11 +230,14 @@ fn projector_keeps_process_preview_lines_intact() {
         &mut state,
     );
 
-    let TimelineItem::Expanded { body, .. } = &state.timeline()[0] else {
+    let TimelineItem::Command {
+        view: CommandView::Finished { preview, .. },
+    } = &state.timeline()[0]
+    else {
         panic!("process call should expand with output preview");
     };
-    assert!(!body.contains("stdout:"));
-    assert!(body.contains(&format!("  {}", "x".repeat(150))));
+    assert_eq!(preview.lines, ["x".repeat(150)]);
+    assert!(!preview.truncated);
 }
 
 #[test]
@@ -266,8 +275,12 @@ fn projector_limits_process_preview_to_five_output_lines() {
         &mut state,
     );
 
-    let TimelineItem::Expanded { body, .. } = &state.timeline()[0] else {
+    let TimelineItem::Command {
+        view: CommandView::Finished { preview, .. },
+    } = &state.timeline()[0]
+    else {
         panic!("process call should expand with output preview");
     };
-    assert_eq!(body, "  one\n  two\n  three\n  four\n  five");
+    assert_eq!(preview.lines, ["one", "two", "three", "four", "five"]);
+    assert!(preview.truncated);
 }

--- a/crates/merry-cli/src/tui/tests/reading_position.rs
+++ b/crates/merry-cli/src/tui/tests/reading_position.rs
@@ -1,0 +1,97 @@
+use crate::tui::{
+    controller::{handle_key_action, handle_key_event},
+    keymap::{KeyAction, Keymap},
+    render::{prepare_viewport, render_to_text},
+    state::{TimelineItem, TuiState},
+    theme::TuiTheme,
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::Size;
+
+fn populated_state() -> TuiState {
+    let mut state = TuiState::new(
+        "/repo".into(),
+        "test".into(),
+        Keymap::default(),
+        TuiTheme::default(),
+    );
+    for index in 0..40 {
+        state.push_timeline_item(TimelineItem::Muted {
+            title: format!("entry-{index:02}"),
+            detail: "reading position".into(),
+        });
+    }
+    state
+}
+
+fn draw(state: &mut TuiState, size: Size) -> String {
+    prepare_viewport(state, size);
+    render_to_text(state, size.width, size.height)
+}
+
+fn visible_entries(rendered: &str) -> Vec<&str> {
+    rendered
+        .lines()
+        .filter(|line| line.contains("entry-"))
+        .collect()
+}
+
+#[test]
+fn incoming_text_and_item_replacement_preserve_the_reading_position() {
+    let mut state = populated_state();
+    let size = Size::new(80, 24);
+    handle_key_action(KeyAction::ScrollUp, &mut state);
+    let before = draw(&mut state, size);
+    assert!(!visible_entries(&before).is_empty());
+    let assistant = state.append_assistant_delta(None, "new streaming answer\n");
+    state.append_assistant_delta(Some(assistant), &"more output\n".repeat(30));
+    state.replace_timeline_item(
+        0,
+        TimelineItem::Assistant {
+            text: "earlier output\n".repeat(20),
+        },
+    );
+    let after = draw(&mut state, size);
+    assert_eq!(visible_entries(&before), visible_entries(&after));
+    assert!(after.contains("New content"));
+    handle_key_event(
+        KeyEvent::new(KeyCode::End, KeyModifiers::CONTROL),
+        &mut state,
+    );
+    let latest = draw(&mut state, size);
+    assert!(latest.contains("more output"));
+    assert!(!latest.contains("New content"));
+    assert!(!state.is_timeline_detached());
+}
+
+#[test]
+fn scrolling_down_to_the_tail_resumes_following_new_output() {
+    let mut state = populated_state();
+    let size = Size::new(80, 24);
+    handle_key_action(KeyAction::ScrollUp, &mut state);
+    draw(&mut state, size);
+    state.append_assistant_delta(None, "first update");
+    draw(&mut state, size);
+    state.scroll_timeline_down_by(usize::MAX);
+    state.append_assistant_delta(None, "latest update");
+    let rendered = draw(&mut state, size);
+    assert!(rendered.contains("latest update"));
+    assert!(!rendered.contains("New content"));
+}
+
+#[test]
+fn review_anchor_survives_narrow_resize_and_repeated_scrolls() {
+    let mut state = populated_state();
+    let wide = Size::new(100, 24);
+    handle_key_action(KeyAction::ScrollUp, &mut state);
+    let before = draw(&mut state, wide);
+    let first = visible_entries(&before)[0].trim().to_owned();
+    let narrow = draw(&mut state, Size::new(45, 24));
+    assert_eq!(visible_entries(&narrow)[0].trim(), first);
+    handle_key_action(KeyAction::ScrollUp, &mut state);
+    let earlier = draw(&mut state, wide);
+    assert_ne!(visible_entries(&earlier)[0].trim(), first);
+    handle_key_action(KeyAction::ScrollDown, &mut state);
+    let restored = draw(&mut state, wide);
+    assert_eq!(visible_entries(&restored)[0].trim(), first);
+}

--- a/crates/merry-cli/src/tui/tests/text_rendering.rs
+++ b/crates/merry-cli/src/tui/tests/text_rendering.rs
@@ -181,6 +181,39 @@ fn renderer_highlights_inline_code_spans() {
 }
 
 #[test]
+fn renderer_preserves_historical_emphasis_across_user_and_assistant_text() {
+    for (focus, expected_color) in [(None, Color::LightMagenta), (Some("red"), Color::Red)] {
+        let theme = TuiTheme::from_config(&crate::config::TuiThemeToml {
+            focus: focus.map(str::to_owned),
+            ..crate::config::TuiThemeToml::default()
+        })
+        .expect("theme config should validate");
+        let mut state = TuiState::new(
+            "/repo".into(),
+            "gpt-test".to_owned(),
+            Keymap::default(),
+            theme,
+        );
+        state.push_timeline_item(TimelineItem::User {
+            text: "inspect `user_keyword`".to_owned(),
+            lane: QueuedInputLane::Next,
+        });
+        state.push_timeline_item(TimelineItem::Assistant {
+            text: "**important** and `assistant_keyword`".to_owned(),
+        });
+
+        let buffer = render_to_buffer(&state, 120, 24);
+        for text in ["user_keyword", "important", "assistant_keyword"] {
+            let style = find_cell_style(&buffer, text).expect("emphasized text should render");
+            assert_eq!(style.fg, Some(expected_color), "{text}");
+            assert_eq!(style.bg, Some(Color::Reset), "{text}");
+            assert!(style.add_modifier.contains(Modifier::BOLD), "{text}");
+            assert!(!style.add_modifier.contains(Modifier::DIM), "{text}");
+        }
+    }
+}
+
+#[test]
 fn renderer_renders_assistant_markdown_strong_without_markers() {
     let mut state = TuiState::new(
         "/repo".into(),
@@ -465,7 +498,7 @@ fn renderer_wraps_assistant_text_on_word_boundaries() {
 }
 
 #[test]
-fn renderer_draws_assistant_separator_across_timeline_width() {
+fn renderer_draws_assistant_separator_across_timeline_content_width() {
     let mut state = TuiState::new(
         "/repo".into(),
         "gpt-test".to_owned(),
@@ -477,5 +510,8 @@ fn renderer_draws_assistant_separator_across_timeline_width() {
     });
 
     let text = render_to_text(&state, 40, 12);
-    assert!(text.lines().any(|line| line == "-".repeat(40)));
+    assert!(
+        text.lines()
+            .any(|line| line == format!(" {}", "-".repeat(39)))
+    );
 }

--- a/crates/merry-cli/src/tui/tests/tool_projection.rs
+++ b/crates/merry-cli/src/tui/tests/tool_projection.rs
@@ -317,19 +317,15 @@ fn projector_expands_tool_batches_in_model_order() {
         &mut state,
     );
 
-    assert_eq!(
-        state.timeline(),
-        [
-            TimelineItem::Muted {
-                title: "Read".to_owned(),
-                detail: "read_text path=first.rs".to_owned(),
-            },
-            TimelineItem::Muted {
-                title: "Ran".to_owned(),
-                detail: "rg --files (src)".to_owned(),
-            },
-        ]
-    );
+    assert_eq!(state.timeline().len(), 2);
+    let rendered = render_to_text(&state, 120, 24);
+    let read_position = rendered
+        .find("Read read_text path=first.rs")
+        .expect("read call is visible");
+    let process_position = rendered.find("Running ").expect("process call is running");
+    assert!(read_position < process_position);
+    assert!(rendered.contains("rg --files (src)"));
+    assert!(!rendered.contains("Ran "));
 }
 
 #[test]

--- a/crates/merry-cli/src/tui/text_interaction.rs
+++ b/crates/merry-cli/src/tui/text_interaction.rs
@@ -1,0 +1,353 @@
+use crate::tui::{
+    copy_controls::{CopyTextBuilder, CopyTextError},
+    state::TimelineAnchor,
+    transcript::{SelectionPolicy, TranscriptRow},
+};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Position, Rect},
+    style::Modifier,
+    widgets::{Paragraph, Widget, Wrap},
+};
+use std::ops::Range;
+use unicode_width::UnicodeWidthStr;
+
+const EDGE_SCROLL_ROWS: usize = 3;
+const COPY_CHUNK_ROWS: u16 = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MouseInput {
+    Down(Position),
+    Drag(Position),
+    Up(Position),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct SelectionPoint {
+    row: usize,
+    column: u16,
+}
+
+impl SelectionPoint {
+    fn new(row: usize, column: u16) -> Self {
+        Self { row, column }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollDirection {
+    Up,
+    Down,
+}
+
+/// Freezes styled transcript lines, rendering only the rows needed for display or copying.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectionSnapshot {
+    rows: Vec<TranscriptRow>,
+    row_starts: Vec<usize>,
+    item_rows: Vec<usize>,
+}
+
+impl SelectionSnapshot {
+    fn new(
+        rows: Vec<TranscriptRow>,
+        item_starts: Vec<usize>,
+        row_starts: Vec<usize>,
+    ) -> Option<Self> {
+        if row_starts.len() != rows.len().saturating_add(1) {
+            return None;
+        }
+        let item_rows = item_starts
+            .into_iter()
+            .map(|index| row_starts.get(index).copied())
+            .collect::<Option<Vec<_>>>()?;
+        Some(Self {
+            rows,
+            row_starts,
+            item_rows,
+        })
+    }
+
+    fn total_rows(&self) -> usize {
+        self.row_starts.last().copied().unwrap_or(0)
+    }
+
+    fn render_rows(&self, start: usize, area: Rect) -> Buffer {
+        let mut buffer = Buffer::empty(area);
+        let first_line = self
+            .row_starts
+            .partition_point(|row| *row <= start)
+            .saturating_sub(1);
+        if first_line >= self.rows.len() || area.is_empty() {
+            return buffer;
+        }
+        let end = start.saturating_add(usize::from(area.height));
+        let last_line = self
+            .row_starts
+            .partition_point(|row| *row < end)
+            .min(self.rows.len());
+        let scroll =
+            u16::try_from(start.saturating_sub(self.row_starts[first_line])).unwrap_or(u16::MAX);
+        Paragraph::new(
+            self.rows[first_line..last_line]
+                .iter()
+                .map(|row| row.display.clone())
+                .collect::<Vec<_>>(),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0))
+        .render(area, &mut buffer);
+        buffer
+    }
+
+    fn anchor_at(&self, row: usize) -> Option<TimelineAnchor> {
+        let index = self
+            .item_rows
+            .partition_point(|start| *start <= row)
+            .saturating_sub(1);
+        self.item_rows
+            .get(index)
+            .map(|start| TimelineAnchor::new(index, row.saturating_sub(*start)))
+    }
+
+    fn row_index_at(&self, visual_row: usize) -> Option<usize> {
+        let index = self
+            .row_starts
+            .partition_point(|start| *start <= visual_row)
+            .saturating_sub(1);
+        (index < self.rows.len()).then_some(index)
+    }
+}
+
+/// Tracks a drag in document rows rather than screen coordinates, including off-screen text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TextSelection {
+    snapshot: SelectionSnapshot,
+    area: Rect,
+    scroll: usize,
+    anchor: SelectionPoint,
+    cursor: SelectionPoint,
+    pointer: Position,
+    scroll_direction: Option<ScrollDirection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SelectionViewport {
+    pub(crate) anchor: TimelineAnchor,
+    pub(crate) offset: usize,
+}
+
+impl TextSelection {
+    /// Takes the timeline renderer's bounded logical lines and current wrapped scroll origin.
+    pub(crate) fn new(
+        rows: Vec<TranscriptRow>,
+        item_starts: Vec<usize>,
+        row_starts: Vec<usize>,
+        area: Rect,
+        scroll: usize,
+        pointer: Position,
+    ) -> Option<Self> {
+        if area.is_empty() || !area.contains(pointer) {
+            return None;
+        }
+        let snapshot = SelectionSnapshot::new(rows, item_starts, row_starts)?;
+        let anchor = SelectionPoint::new(
+            scroll.saturating_add(usize::from(pointer.y - area.y)),
+            pointer.x - area.x,
+        );
+        Some(Self {
+            snapshot,
+            area,
+            scroll,
+            anchor,
+            cursor: anchor,
+            pointer,
+            scroll_direction: None,
+        })
+    }
+
+    pub(crate) fn area(&self) -> Rect {
+        self.area
+    }
+
+    pub(crate) fn drag_to(&mut self, position: Position) {
+        self.pointer = position;
+        self.cursor = self.document_position(position);
+        self.scroll_direction = if position.y <= self.area.y {
+            Some(ScrollDirection::Up)
+        } else if position.y >= self.area.bottom().saturating_sub(1) {
+            Some(ScrollDirection::Down)
+        } else {
+            None
+        };
+    }
+
+    pub(crate) fn is_autoscrolling(&self) -> bool {
+        self.next_scroll() != self.scroll
+    }
+
+    /// Advances one refresh tick and reports the corresponding live-timeline reading position.
+    pub(crate) fn autoscroll(&mut self) -> Option<SelectionViewport> {
+        let next = self.next_scroll();
+        if next == self.scroll {
+            return None;
+        }
+        self.scroll = next;
+        self.cursor = self.document_position(self.pointer);
+        self.snapshot
+            .anchor_at(next)
+            .map(|anchor| SelectionViewport {
+                anchor,
+                offset: self.max_scroll().saturating_sub(next),
+            })
+    }
+
+    pub(crate) fn release(mut self, position: Position) -> Result<Option<String>, CopyTextError> {
+        self.cursor = self.document_position(position);
+        self.text()
+    }
+
+    fn text(&self) -> Result<Option<String>, CopyTextError> {
+        if self.anchor == self.cursor {
+            return Ok(None);
+        }
+        let (start, end) = self.ordered_positions();
+        let mut text = CopyTextBuilder::new();
+        let mut copied_row = false;
+        let mut chunk_start = start.row;
+        while chunk_start <= end.row {
+            let height = u16::try_from(end.row.saturating_sub(chunk_start))
+                .unwrap_or(u16::MAX)
+                .saturating_add(1)
+                .min(COPY_CHUNK_ROWS);
+            let buffer = self
+                .snapshot
+                .render_rows(chunk_start, Rect::new(0, 0, self.area.width, height));
+            for row in 0..height {
+                let document_row = chunk_start + usize::from(row);
+                let columns = self.row_columns(document_row, start, end);
+                let Some(source_row) = self.snapshot.row_index_at(document_row) else {
+                    continue;
+                };
+                let selection = self.snapshot.rows[source_row].selection;
+                let columns = match selection {
+                    SelectionPolicy::Keep => columns,
+                    SelectionPolicy::Skip => continue,
+                    SelectionPolicy::StripPrefix(prefix) => columns.start.max(prefix)..columns.end,
+                };
+                if columns.start >= columns.end {
+                    continue;
+                }
+                let mut row_text = String::new();
+                let mut column = 0;
+                while column < self.area.width {
+                    let symbol = buffer[(column, row)].symbol();
+                    let next = next_column(column, symbol, self.area.width);
+                    if !symbol.is_empty() && column < columns.end && next > columns.start {
+                        row_text.push_str(symbol);
+                    }
+                    column = next;
+                }
+                if columns.end == self.area.width {
+                    let trimmed_len = row_text.trim_end_matches(' ').len();
+                    row_text.truncate(trimmed_len);
+                }
+                if copied_row {
+                    text.push_str("\n")?;
+                }
+                text.push_str(&row_text)?;
+                copied_row = true;
+            }
+            chunk_start = chunk_start.saturating_add(usize::from(height));
+        }
+        if copied_row {
+            Ok(Some(text.finish()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) fn render(&self, buffer: &mut Buffer) {
+        let mut visible = self.snapshot.render_rows(self.scroll, self.area);
+        let (start, end) = self.ordered_positions();
+        for row in self.area.y..self.area.bottom() {
+            let document_row = self.scroll + usize::from(row - self.area.y);
+            if self.anchor != self.cursor && (start.row..=end.row).contains(&document_row) {
+                let columns = self.row_columns(document_row, start, end);
+                let mut column = 0;
+                while column < self.area.width {
+                    let symbol = visible[(self.area.x + column, row)].symbol();
+                    let next = next_column(column, symbol, self.area.width);
+                    if column < columns.end && next > columns.start {
+                        for selected_column in column..next {
+                            visible[(self.area.x + selected_column, row)]
+                                .set_style(Modifier::REVERSED);
+                        }
+                    }
+                    column = next;
+                }
+            }
+            for column in self.area.x..self.area.right() {
+                buffer[(column, row)] = visible[(column, row)].clone();
+            }
+        }
+    }
+
+    fn max_scroll(&self) -> usize {
+        self.snapshot
+            .total_rows()
+            .saturating_sub(usize::from(self.area.height))
+    }
+
+    fn next_scroll(&self) -> usize {
+        match self.scroll_direction {
+            Some(ScrollDirection::Up) => self.scroll.saturating_sub(EDGE_SCROLL_ROWS),
+            Some(ScrollDirection::Down) if self.scroll < self.max_scroll() => self
+                .scroll
+                .saturating_add(EDGE_SCROLL_ROWS)
+                .min(self.max_scroll()),
+            _ => self.scroll,
+        }
+    }
+
+    fn document_position(&self, position: Position) -> SelectionPoint {
+        SelectionPoint::new(
+            self.scroll
+                + usize::from(
+                    position
+                        .y
+                        .saturating_sub(self.area.y)
+                        .min(self.area.height - 1),
+                ),
+            position
+                .x
+                .saturating_sub(self.area.x)
+                .min(self.area.width - 1),
+        )
+    }
+
+    fn ordered_positions(&self) -> (SelectionPoint, SelectionPoint) {
+        if self.anchor <= self.cursor {
+            (self.anchor, self.cursor)
+        } else {
+            (self.cursor, self.anchor)
+        }
+    }
+
+    fn row_columns(&self, row: usize, start: SelectionPoint, end: SelectionPoint) -> Range<u16> {
+        let first = if row == start.row { start.column } else { 0 };
+        let last = if row == end.row {
+            end.column.saturating_add(1)
+        } else {
+            self.area.width
+        };
+        first..last.min(self.area.width)
+    }
+}
+
+fn next_column(column: u16, symbol: &str, width: u16) -> u16 {
+    let symbol_width = u16::try_from(UnicodeWidthStr::width(symbol))
+        .unwrap_or(u16::MAX)
+        .max(1);
+    column.saturating_add(symbol_width).min(width)
+}

--- a/crates/merry-cli/src/tui/text_wrap.rs
+++ b/crates/merry-cli/src/tui/text_wrap.rs
@@ -275,7 +275,7 @@ fn push_long_token_by_char(
     }
 }
 
-fn inline_code_style(state: &TuiState, base_style: Style) -> Style {
+pub(super) fn inline_code_style(state: &TuiState, base_style: Style) -> Style {
     let foreground = state.theme().color(SemanticColor::Focus);
     let mut style = base_style.add_modifier(Modifier::BOLD);
     if let Some(foreground) = foreground {

--- a/crates/merry-cli/src/tui/transcript.rs
+++ b/crates/merry-cli/src/tui/transcript.rs
@@ -1,0 +1,33 @@
+use ratatui::text::Line;
+
+/// Describes which part of a rendered row belongs in mouse-selected text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectionPolicy {
+    Keep,
+    Skip,
+    StripPrefix(u16),
+}
+
+impl SelectionPolicy {
+    pub(crate) fn with_prefix(self, prefix_width: u16) -> Self {
+        match self {
+            Self::Keep if prefix_width == 0 => Self::Keep,
+            Self::Keep => Self::StripPrefix(prefix_width),
+            Self::Skip => Self::Skip,
+            Self::StripPrefix(width) => Self::StripPrefix(width.saturating_add(prefix_width)),
+        }
+    }
+}
+
+/// A rendered transcript row plus its source-selection semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TranscriptRow {
+    pub(crate) display: Line<'static>,
+    pub(crate) selection: SelectionPolicy,
+}
+
+impl TranscriptRow {
+    pub(crate) fn new(display: Line<'static>, selection: SelectionPolicy) -> Self {
+        Self { display, selection }
+    }
+}

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -151,7 +151,7 @@ max_model_turns = 2048
 [tui]
 # Show up to five output lines for successful commands. Failed commands always
 # show their output preview; an extra ... line indicates omitted output.
-# Alt+O inspects captured output independently of this default. In the viewer,
+# Ctrl+T inspects captured output independently of this default. In the viewer,
 # Left/Right selects a command, C copies its command, Y copies captured output,
 # and Esc closes. Copy uses OSC 52 and requires terminal clipboard support.
 show_successful_command_output = false
@@ -187,7 +187,7 @@ scroll_down = "pagedown"
 # Manual scrolling pauses following; return explicitly when ready for new output.
 follow_latest = "ctrl+end"
 # Toggle command output details; pressing the same shortcut again or Esc closes them.
-open_command_details = "alt+o"
+open_command_details = "ctrl+t"
 review_previous_user_input = "ctrl+u"
 open_session_in_browser = "ctrl+g"
 history_previous = "up"

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -148,6 +148,14 @@ max_model_turns = 2048
 # headers = { Authorization = "Bearer replace-with-your-token" }
 # tools = ["resolve-library-id", "get-library-docs"]
 
+[tui]
+# Show up to five output lines for successful commands. Failed commands always
+# show their output preview; an extra ... line indicates omitted output.
+# Alt+O inspects captured output independently of this default. In the viewer,
+# Left/Right selects a command, C copies its command, Y copies captured output,
+# and Esc closes. Copy uses OSC 52 and requires terminal clipboard support.
+show_successful_command_output = false
+
 [tui.theme]
 # Semantic color names keep component styling configurable without changing
 # rendering code.
@@ -176,6 +184,10 @@ interrupt = "esc"
 quit = "ctrl+q"
 scroll_up = "pageup"
 scroll_down = "pagedown"
+# Manual scrolling pauses following; return explicitly when ready for new output.
+follow_latest = "ctrl+end"
+# Toggle command output details; pressing the same shortcut again or Esc closes them.
+open_command_details = "alt+o"
 review_previous_user_input = "ctrl+u"
 open_session_in_browser = "ctrl+g"
 history_previous = "up"


### PR DESCRIPTION
## Summary
- Show animated `Running` status until completion, render complete commands, and hide successful command output by default with an opt-in configuration switch. Failed commands retain five-line previews with an omission marker when needed.
- Add a `Ctrl+T` output inspector that toggles open/closed, with command navigation and copying of commands or captured output. Preserve the reading position during manual scrolling and provide explicit follow-latest behavior. Explicit custom key bindings (including `Alt+O`) remain supported; `Ctrl+O` still toggles the plan.
- Add reply/code-block copy controls and mouse selection that copies on release, clears on a new click, and auto-scrolls at viewport edges. Preserve Markdown highlighting.

## Structure and boundaries
- Introduce semantic transcript rows and a shared timeline layout for rendering, hit testing, selection, and scrolling.
- Exclude UI controls, gutters, and code-block rails (including blank-line rails) from selected text without removing identical literal user content.
- Bound clipboard payloads to 1 MiB and share process-output parsing between previews and the inspector.
- Keep changes within the CLI/TUI surface and its configuration, tests, and OSC 52 dependency feature; no runtime/provider/SDK contract changes.

## Validation
- `cargo fmt --all --check`
- `cargo metadata --offline --locked --format-version 1 --no-deps`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`: **2108 passed, 0 failed, 9 ignored**. The existing ignored tests require explicit live-provider/loopback opt-in. Full tests pass outside the outer execution sandbox, including the four sandbox tests previously blocked by that environment.
- `git diff --cached --check`
- Commit signature verified successfully.

Clipboard writes use OSC 52 and remain dependent on terminal/tmux support; the UI reports a copy request rather than claiming a confirmed system clipboard write.