### PR TITLE
fix(openai): retry transient Responses stream errors

### DIFF
--- a/crates/merry-provider-openai/src/error.rs
+++ b/crates/merry-provider-openai/src/error.rs
@@ -19,7 +19,8 @@ pub enum OpenAiProviderError {
     /// Provider response did not match the expected Responses protocol.
     #[error("OpenAI provider protocol error: {reason}")]
     Protocol { reason: String },
-    /// Provider returned a non-successful HTTP status or transport failure.
+    /// Provider returned a provider-level failure, including transient stream
+    /// errors or a non-successful HTTP status.
     #[error("OpenAI provider request failed ({kind:?}): {message}")]
     Provider {
         /// Provider-neutral error category.

--- a/crates/merry-provider-openai/src/parse.rs
+++ b/crates/merry-provider-openai/src/parse.rs
@@ -229,23 +229,22 @@ impl ResponsesStreamParser {
                 self.parse_terminal_response(response, "incomplete")
             }
             ResponsesStreamEvent::Failed { response } => {
+                if let Some(error) = response.error.as_ref() {
+                    let code = error.code.as_deref();
+                    let kind = responses_stream_error_kind(code);
+                    if kind != ProviderErrorKind::Protocol {
+                        return Err(responses_stream_error(code, error.message.as_deref(), kind));
+                    }
+                }
                 self.parse_terminal_response(response, "failed")
             }
             ResponsesStreamEvent::Error { code, message } => {
                 let kind = responses_stream_error_kind(code.as_deref());
-                let code = code
-                    .as_deref()
-                    .and_then(bounded_provider_metadata)
-                    .unwrap_or_else(|| "unknown".to_owned());
-                let message = message
-                    .as_deref()
-                    .and_then(bounded_provider_error_message)
-                    .unwrap_or_else(|| "provider returned stream error".to_owned());
-                let reason = format!("Responses stream error {code}: {message}");
-                Err(match kind {
-                    ProviderErrorKind::Protocol => OpenAiProviderError::protocol(reason),
-                    kind => OpenAiProviderError::provider(kind, reason),
-                })
+                Err(responses_stream_error(
+                    code.as_deref(),
+                    message.as_deref(),
+                    kind,
+                ))
             }
         }
     }
@@ -304,13 +303,34 @@ impl ResponsesStreamParser {
     }
 }
 
+/// Only explicit transient codes opt into the caller's bounded retry policy.
 fn responses_stream_error_kind(code: Option<&str>) -> ProviderErrorKind {
     match code {
         // Responses emits this event when the provider cannot currently serve
         // the request. Normalize it so the runtime's bounded retry policy can
         // recover from transient capacity failures.
         Some("server_error") => ProviderErrorKind::Unavailable,
+        Some("rate_limit_exceeded") => ProviderErrorKind::RateLimited,
         _ => ProviderErrorKind::Protocol,
+    }
+}
+
+/// Sanitize provider diagnostics identically for both Responses failure forms.
+fn responses_stream_error(
+    code: Option<&str>,
+    message: Option<&str>,
+    kind: ProviderErrorKind,
+) -> OpenAiProviderError {
+    let code = code
+        .and_then(bounded_provider_metadata)
+        .unwrap_or_else(|| "unknown".to_owned());
+    let message = message
+        .and_then(bounded_provider_error_message)
+        .unwrap_or_else(|| "provider returned stream error".to_owned());
+    let reason = format!("Responses stream error {code}: {message}");
+    match kind {
+        ProviderErrorKind::Protocol => OpenAiProviderError::protocol(reason),
+        kind => OpenAiProviderError::provider(kind, reason),
     }
 }
 

--- a/crates/merry-provider-openai/src/parse.rs
+++ b/crates/merry-provider-openai/src/parse.rs
@@ -11,7 +11,7 @@ use crate::{
 use merry_core::ToolName;
 use merry_llm::{
     FinishReason, ModelEvent, ModelOutput, ModelResponse, ModelToolCall, ModelToolCallId,
-    ToolArguments, Usage,
+    ProviderErrorKind, ToolArguments, Usage,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -232,6 +232,7 @@ impl ResponsesStreamParser {
                 self.parse_terminal_response(response, "failed")
             }
             ResponsesStreamEvent::Error { code, message } => {
+                let kind = responses_stream_error_kind(code.as_deref());
                 let code = code
                     .as_deref()
                     .and_then(bounded_provider_metadata)
@@ -240,9 +241,11 @@ impl ResponsesStreamParser {
                     .as_deref()
                     .and_then(bounded_provider_error_message)
                     .unwrap_or_else(|| "provider returned stream error".to_owned());
-                Err(OpenAiProviderError::protocol(format!(
-                    "Responses stream error {code}: {message}"
-                )))
+                let reason = format!("Responses stream error {code}: {message}");
+                Err(match kind {
+                    ProviderErrorKind::Protocol => OpenAiProviderError::protocol(reason),
+                    kind => OpenAiProviderError::provider(kind, reason),
+                })
             }
         }
     }
@@ -298,6 +301,16 @@ impl ResponsesStreamParser {
             },
             usage,
         ))
+    }
+}
+
+fn responses_stream_error_kind(code: Option<&str>) -> ProviderErrorKind {
+    match code {
+        // Responses emits this event when the provider cannot currently serve
+        // the request. Normalize it so the runtime's bounded retry policy can
+        // recover from transient capacity failures.
+        Some("server_error") => ProviderErrorKind::Unavailable,
+        _ => ProviderErrorKind::Protocol,
     }
 }
 

--- a/crates/merry-provider-openai/src/provider/tests.rs
+++ b/crates/merry-provider-openai/src/provider/tests.rs
@@ -1,5 +1,6 @@
 mod errors;
 mod request;
+mod retry;
 mod stream;
 
 use merry_llm::{

--- a/crates/merry-provider-openai/src/provider/tests/retry.rs
+++ b/crates/merry-provider-openai/src/provider/tests/retry.rs
@@ -1,0 +1,205 @@
+use super::model_request;
+use crate::{OpenAiProviderConfig, parse::ResponsesStreamParser};
+use futures_util::{StreamExt, stream};
+use merry_core::ProviderName;
+use merry_llm::{
+    FinishReason, ModelCapabilities, ModelError, ModelEvent, ModelEventStream, ModelProvider,
+    ModelProviderFuture, ModelRequest, ModelRetryPolicy, ModelStreamContext, ProviderErrorKind,
+    RetryingModelProvider,
+};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+const SERVER_ERROR: &str =
+    r#"data: {"type":"error","code":"server_error","message":"Please try again later."}"#;
+const FAILED_SERVER_ERROR: &str = r#"data: {"type":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"Please try again later."}}}"#;
+const RATE_LIMIT: &str =
+    r#"data: {"type":"error","code":"rate_limit_exceeded","message":"Too many requests."}"#;
+const FAILED_RATE_LIMIT: &str = r#"data: {"type":"response.failed","response":{"status":"failed","error":{"code":"rate_limit_exceeded","message":"Too many requests."}}}"#;
+const SUCCESS: &str = r#"data: {"type":"response.output_text.delta","delta":"Recovered"}
+data: {"type":"response.completed","response":{"status":"completed"}}"#;
+
+/// Feeds wire fixtures through the real Responses parser and public retry wrapper.
+struct ScriptedResponsesProvider {
+    config: OpenAiProviderConfig,
+    scripts: Mutex<VecDeque<String>>,
+}
+
+impl ScriptedResponsesProvider {
+    fn new(scripts: Vec<String>) -> Self {
+        Self {
+            config: OpenAiProviderConfig::new("sk-test").expect("valid fixture config"),
+            scripts: Mutex::new(scripts.into()),
+        }
+    }
+
+    fn scripts_remaining(&self) -> usize {
+        self.scripts.lock().expect("fixture lock").len()
+    }
+}
+
+impl ModelProvider for ScriptedResponsesProvider {
+    fn name(&self) -> &ProviderName {
+        self.config.provider_name()
+    }
+
+    fn capabilities(&self) -> &ModelCapabilities {
+        self.config.capabilities()
+    }
+
+    fn stream_model<'a>(
+        &'a self,
+        _request: ModelRequest,
+        _context: ModelStreamContext,
+    ) -> ModelProviderFuture<'a, Result<ModelEventStream, ModelError>> {
+        Box::pin(async move {
+            let script = self
+                .scripts
+                .lock()
+                .expect("fixture lock")
+                .pop_front()
+                .expect("retry must stay within scripted attempts");
+            let mut parser = ResponsesStreamParser::new();
+            let mut events = vec![Ok(ModelEvent::Started)];
+            for line in script.lines() {
+                match parser.parse_sse_line(line) {
+                    Ok(parsed) => events.extend(parsed.into_iter().map(Ok)),
+                    Err(error) => {
+                        events.push(Err(error.into()));
+                        break;
+                    }
+                }
+            }
+            if events.last().is_some_and(Result::is_ok)
+                && let Err(error) = parser.finish()
+            {
+                events.push(Err(error.into()));
+            }
+            let events: ModelEventStream = Box::pin(stream::iter(events));
+            Ok(events)
+        })
+    }
+}
+
+async fn run_scripts(
+    scripts: Vec<String>,
+    policy: ModelRetryPolicy,
+) -> (Vec<Result<ModelEvent, ModelError>>, usize) {
+    let attempts = scripts.len();
+    let inner = Arc::new(ScriptedResponsesProvider::new(scripts));
+    let provider = RetryingModelProvider::new(inner.clone(), policy);
+    let events = tokio::time::timeout(Duration::from_secs(5), async {
+        provider
+            .stream_model(model_request(), ModelStreamContext::default())
+            .await
+            .expect("retry stream setup")
+            .collect::<Vec<_>>()
+            .await
+    })
+    .await
+    .expect("scripted retry must finish within timeout");
+    (events, attempts - inner.scripts_remaining())
+}
+
+fn retry_policy() -> ModelRetryPolicy {
+    ModelRetryPolicy::new(
+        true,
+        2,
+        Duration::from_millis(1),
+        Duration::from_millis(1),
+        Duration::from_secs(5),
+        false,
+    )
+    .expect("valid fixture policy")
+}
+
+#[tokio::test]
+async fn responses_transient_errors_retry_before_output() {
+    for failure in [
+        SERVER_ERROR,
+        FAILED_SERVER_ERROR,
+        RATE_LIMIT,
+        FAILED_RATE_LIMIT,
+    ] {
+        let (events, attempts) =
+            run_scripts(vec![failure.to_owned(), SUCCESS.to_owned()], retry_policy()).await;
+        let events = events
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("transient failure should recover");
+        assert_eq!(attempts, 2);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0], ModelEvent::Started);
+        assert_eq!(
+            events[1],
+            ModelEvent::OutputTextDelta {
+                delta: "Recovered".to_owned()
+            }
+        );
+        assert!(
+            matches!(&events[2], ModelEvent::Completed { response } if response.finish_reason() == FinishReason::Stop)
+        );
+    }
+}
+
+#[tokio::test]
+async fn responses_server_errors_respect_disabled_and_exhausted_retry_budgets() {
+    for (policy, expected_attempts) in [(ModelRetryPolicy::disabled(), 1), (retry_policy(), 2)] {
+        let (events, attempts) = run_scripts(vec![FAILED_SERVER_ERROR.to_owned(); 3], policy).await;
+        assert_eq!(attempts, expected_attempts);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[1], Err(error) if error.kind() == ProviderErrorKind::Unavailable));
+    }
+}
+
+#[tokio::test]
+async fn responses_server_error_does_not_retry_after_text_or_tool_output() {
+    for prefix in [
+        r#"data: {"type":"response.output_text.delta","delta":"Partial"}"#,
+        r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{}"}}"#,
+    ] {
+        for failure in [SERVER_ERROR, FAILED_SERVER_ERROR] {
+            let (events, attempts) = run_scripts(
+                vec![format!("{prefix}\n{failure}"), SUCCESS.to_owned()],
+                retry_policy(),
+            )
+            .await;
+            assert_eq!(attempts, 1);
+            assert_eq!(events.len(), 3);
+            assert!(matches!(
+                &events[1],
+                Ok(ModelEvent::OutputTextDelta { .. } | ModelEvent::ToolCallRequested { .. })
+            ));
+            assert!(
+                matches!(&events[2], Err(error) if error.kind() == ProviderErrorKind::Unavailable)
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn responses_unknown_or_missing_error_codes_do_not_retry() {
+    for failure in [
+        r#"data: {"type":"error","code":"invalid_request_error","message":"Please try again later."}"#,
+        r#"data: {"type":"error","code":"unknown","message":"server_error"}"#,
+        r#"data: {"type":"error","message":"server_error"}"#,
+        r#"data: {"type":"response.failed","response":{"status":"failed","error":{"code":"invalid_prompt","message":"Please try again later."}}}"#,
+        r#"data: {"type":"response.failed","response":{"status":"failed","error":{"message":"server_error"}}}"#,
+        r#"data: {"type":"response.failed","response":{"status":"failed","error":null}}"#,
+    ] {
+        let (events, attempts) =
+            run_scripts(vec![failure.to_owned(), SUCCESS.to_owned()], retry_policy()).await;
+        assert_eq!(attempts, 1);
+        assert_eq!(events.len(), 2);
+        match &events[1] {
+            Err(error) => assert_eq!(error.kind(), ProviderErrorKind::Protocol),
+            Ok(ModelEvent::Completed { response }) => {
+                assert_eq!(response.finish_reason(), FinishReason::Error)
+            }
+            other => panic!("expected terminal failure, got {other:?}"),
+        }
+    }
+}

--- a/crates/merry-provider-openai/src/provider/tests/stream.rs
+++ b/crates/merry-provider-openai/src/provider/tests/stream.rs
@@ -110,13 +110,32 @@ fn parser_reports_unexpected_non_sse_stream_lines() {
 fn responses_stream_error_preserves_safe_server_message() {
     let mut parser = ResponsesStreamParser::new();
     let error = parser
-            .parse_sse_line(
-                r#"data: {"type":"error","code":"invalid_request_error","message":"response schema is invalid"}"#,
-            )
-            .expect_err("provider stream error should be surfaced");
+        .parse_sse_line(
+            r#"data: {"type":"error","code":"invalid_request_error","message":"response schema is invalid"}"#,
+        )
+        .expect_err("provider stream error should be surfaced");
 
     assert!(error.to_string().contains("invalid_request_error"));
     assert!(error.to_string().contains("response schema is invalid"));
+    assert_eq!(
+        merry_llm::ModelError::from(error).kind(),
+        merry_llm::ProviderErrorKind::Protocol
+    );
+}
+
+#[test]
+fn responses_server_error_is_normalized_as_transient() {
+    let mut parser = ResponsesStreamParser::new();
+    let error = parser
+        .parse_sse_line(
+            r#"data: {"type":"error","code":"server_error","message":"Our server are currently overload. Please try again later."}"#,
+        )
+        .expect_err("provider stream error should be surfaced");
+    let error: merry_llm::ModelError = error.into();
+
+    assert_eq!(error.kind(), merry_llm::ProviderErrorKind::Unavailable);
+    assert!(error.message().contains("server_error"));
+    assert!(error.message().contains("try again later"));
 }
 
 #[test]

--- a/crates/merry-provider-openai/src/provider/tests/stream.rs
+++ b/crates/merry-provider-openai/src/provider/tests/stream.rs
@@ -139,6 +139,35 @@ fn responses_server_error_is_normalized_as_transient() {
 }
 
 #[test]
+fn responses_failed_server_error_is_normalized_as_transient() {
+    let mut parser = ResponsesStreamParser::new();
+    let error = parser
+        .parse_sse_line(
+            r#"data: {"type":"response.failed","response":{"status":"failed","error":{"code":"server_error","message":"Our server is overloaded. Please try again later."}}}"#,
+        )
+        .expect_err("failed server response should be surfaced");
+    let error: merry_llm::ModelError = error.into();
+
+    assert_eq!(error.kind(), merry_llm::ProviderErrorKind::Unavailable);
+    assert!(error.message().contains("server_error"));
+    assert!(error.message().contains("try again later"));
+}
+
+#[test]
+fn responses_failed_rate_limit_is_normalized_as_retryable() {
+    let mut parser = ResponsesStreamParser::new();
+    let error = parser
+        .parse_sse_line(
+            r#"data: {"type":"response.failed","response":{"status":"failed","error":{"code":"rate_limit_exceeded","message":"Too many requests."}}}"#,
+        )
+        .expect_err("failed rate-limit response should be surfaced");
+    let error: merry_llm::ModelError = error.into();
+
+    assert_eq!(error.kind(), merry_llm::ProviderErrorKind::RateLimited);
+    assert!(error.message().contains("rate_limit_exceeded"));
+}
+
+#[test]
 fn stream_state_emits_completed_from_final_usage_line_without_trailing_newline() {
     let mut events = OpenAiEventStreamEvents::new(OpenAiProtocol::Responses);
 

--- a/crates/merry-provider-openai/src/wire.rs
+++ b/crates/merry-provider-openai/src/wire.rs
@@ -178,6 +178,17 @@ pub(crate) struct ResponsesResponse {
     pub(crate) output: Vec<ResponsesOutputItem>,
     pub(crate) status: Option<String>,
     pub(crate) usage: Option<ResponsesUsage>,
+    #[serde(default)]
+    pub(crate) error: Option<ResponsesResponseError>,
+}
+
+/// Error details from a failed Responses generation; interpreted by the adapter.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResponsesResponseError {
+    #[serde(default)]
+    pub(crate) code: Option<String>,
+    #[serde(default)]
+    pub(crate) message: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Problem

OpenAI Responses streaming can emit an `error` event with `code = server_error` during temporary provider overload. The adapter classified this as `Protocol`, so the existing bounded model retry policy treated it as terminal.

## Change

Normalize `server_error` stream events as `ProviderErrorKind::Unavailable`, allowing the existing retry wrapper to apply bounded backoff and cancellation behavior. Unknown and invalid protocol errors remain classified as `Protocol`.

## Validation

- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 clippy -p merry-llm -p merry-provider-openai -p merry-runtime -p merry --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 test -p merry-llm --lib` (11 passed)
- OpenAI provider tests excluding three local model-catalog listener tests (54 passed)
- `cargo +1.95.0 test -p merry-runtime` (all passed)
- `cargo +1.95.0 test -p merry` (all passed)

The full workspace test command remains blocked by the existing `merry-web` build requirement for `web/dist/index.html`.